### PR TITLE
Remove outdated legacy migration code in workspace chooser

### DIFF
--- a/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/ide/ChooseWorkspaceData.java
+++ b/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/ide/ChooseWorkspaceData.java
@@ -17,20 +17,12 @@
 package org.eclipse.ui.internal.ide;
 
 import java.io.File;
-import java.io.FileReader;
-import java.io.IOException;
-import java.io.Reader;
 import java.net.URL;
 import java.util.StringTokenizer;
 
 import org.eclipse.core.runtime.IPath;
-import org.eclipse.core.runtime.Platform;
 import org.eclipse.core.runtime.preferences.ConfigurationScope;
 import org.eclipse.jface.preference.IPreferenceStore;
-import org.eclipse.osgi.service.datalocation.Location;
-import org.eclipse.ui.IMemento;
-import org.eclipse.ui.WorkbenchException;
-import org.eclipse.ui.XMLMemento;
 import org.eclipse.ui.ide.IDE;
 import org.eclipse.ui.preferences.ScopedPreferenceStore;
 import org.osgi.service.prefs.BackingStoreException;
@@ -45,25 +37,6 @@ public class ChooseWorkspaceData {
 	 * The default max length of the recent workspace mru list.
 	 */
 	private static final int RECENT_MAX_LENGTH = 10;
-
-	/**
-	 * The directory within the config area that will be used for the
-	 * receiver's persisted data.
-	 */
-	private static final String PERS_FOLDER = "org.eclipse.ui.ide"; //$NON-NLS-1$
-
-	/**
-	 * The name of the file within the config area that will be used for
-	 * the recever's persisted data.
-	 * @see PERS_FOLDER
-	 */
-	private static final String PERS_FILENAME = "recentWorkspaces.xml"; //$NON-NLS-1$
-
-	/**
-	 * In the past a file was used to store persist these values.  This file was written
-	 * with this value as its protocol identifier.
-	 */
-	private static final int PERS_ENCODING_VERSION = 1;
 
 	/**
 	 * This is the first version of the encode/decode protocol that uses the
@@ -91,25 +64,6 @@ public class ChooseWorkspaceData {
 	private String selection;
 
 	private String[] recentWorkspaces;
-
-	// xml tags
-	private static interface XML {
-		public static final String PROTOCOL = "protocol"; //$NON-NLS-1$
-
-		public static final String VERSION = "version"; //$NON-NLS-1$
-
-		public static final String ALWAYS_ASK = "alwaysAsk"; //$NON-NLS-1$
-
-		public static final String SHOW_DIALOG = "showDialog"; //$NON-NLS-1$
-
-		public static final String WORKSPACE = "workspace"; //$NON-NLS-1$
-
-		public static final String RECENT_WORKSPACES = "recentWorkspaces"; //$NON-NLS-1$
-
-		public static final String MAX_LENGTH = "maxLength"; //$NON-NLS-1$
-
-		public static final String PATH = "path"; //$NON-NLS-1$
-	}
 
 	/**
 	 * Creates a new instance, loading persistent data if its found.
@@ -279,104 +233,11 @@ public class ChooseWorkspaceData {
 	}
 
 	/**
-	 * Look for and read data that might have been persisted from some previous
-	 * run. Leave the receiver in a default state if no persistent data is
-	 * found.
-	 *
-	 * @return true if a file was successfully read and false otherwise
-	 */
-	private boolean readPersistedData_file() {
-		URL persUrl = null;
-
-		Location configLoc = Platform.getConfigurationLocation();
-		if (configLoc != null) {
-			persUrl = getPersistenceUrl(configLoc.getURL(), false);
-		}
-
-		try {
-			// inside try to get the safe default creation in the finally
-			// clause
-			if (persUrl == null) {
-				return false;
-			}
-
-			// E.g.,
-			//	<launchWorkspaceData>
-			//		<protocol version="1"/>
-			//      <alwaysAsk showDialog="1"/>
-			// 		<recentWorkspaces maxLength="5">
-			//			<workspace path="C:\eclipse\workspace0"/>
-			//			<workspace path="C:\eclipse\workspace1"/>
-			//		</recentWorkspaces>
-			//	</launchWorkspaceData>
-
-			XMLMemento memento;
-			try (Reader reader = new FileReader(persUrl.getFile())) {
-				memento = XMLMemento.createReadRoot(reader);
-			}
-			if (memento == null || !compatibleFileProtocol(memento)) {
-				return false;
-			}
-
-			IMemento alwaysAskTag = memento.getChild(XML.ALWAYS_ASK);
-			showDialog = alwaysAskTag == null ? true : alwaysAskTag.getInteger(
-					XML.SHOW_DIALOG).intValue() == 1;
-
-			IMemento recent = memento.getChild(XML.RECENT_WORKSPACES);
-			if (recent == null) {
-				return false;
-			}
-
-			Integer maxLength = recent.getInteger(XML.MAX_LENGTH);
-			int max = RECENT_MAX_LENGTH;
-			if (maxLength != null) {
-				max = maxLength.intValue();
-			}
-
-			IMemento indices[] = recent.getChildren(XML.WORKSPACE);
-			if (indices == null || indices.length <= 0) {
-				return false;
-			}
-
-			// if a user has edited maxLength to be shorter than the listed
-			// indices, accept the list (its tougher for them to retype a long
-			// list of paths than to update a max number)
-			max = Math.max(max, indices.length);
-
-			recentWorkspaces = new String[max];
-			for (int i = 0; i < indices.length; ++i) {
-				String path = indices[i].getString(XML.PATH);
-				if (path == null) {
-					break;
-				}
-				recentWorkspaces[i] = path;
-			}
-		} catch (IOException | WorkbenchException e) {
-			// cannot log because instance area has not been set
-			return false;
-		} finally {
-			// create safe default if needed
-			if (recentWorkspaces == null) {
-				recentWorkspaces = new String[RECENT_MAX_LENGTH];
-			}
-		}
-
-		return true;
-	}
-
-	/**
 	 * Return the current (persisted) value of the "showDialog on startup"
 	 * preference. Return the global default if the file cannot be accessed.
 	 */
 	public static boolean getShowDialogValue() {
-		// TODO See the long comment in #readPersistedData -- when the
-		//      transition time is over this method can be changed to
-		//      read the preference directly.
-
 		ChooseWorkspaceData data = new ChooseWorkspaceData(""); //$NON-NLS-1$
-
-		// return either the value in the file or true, which is the global
-		// default
 		return data.readPersistedData() ? data.showDialog : true;
 	}
 
@@ -385,13 +246,7 @@ public class ChooseWorkspaceData {
 	 * preference. Return the global default if the file cannot be accessed.
 	 */
 	public static void setShowDialogValue(boolean showDialog) {
-		// TODO See the long comment in #readPersistedData -- when the
-		//      transition time is over this method can be changed to
-		//      read the preference directly.
-
 		ChooseWorkspaceData data = new ChooseWorkspaceData(""); //$NON-NLS-1$
-
-		// update the value and write the new settings
 		data.showDialog = showDialog;
 		data.writePersistedData();
 	}
@@ -400,9 +255,6 @@ public class ChooseWorkspaceData {
 	 * Look in the config area preference store for the list of recently used
 	 * workspaces.
 	 *
-	 * NOTE: During the transition phase the file will be checked if no config
-	 * preferences are found.
-	 *
 	 * @return true if the values were successfully retrieved and false
 	 *         otherwise
 	 */
@@ -410,23 +262,7 @@ public class ChooseWorkspaceData {
 		IPreferenceStore store = new ScopedPreferenceStore(ConfigurationScope.INSTANCE,
 				IDEWorkbenchPlugin.IDE_WORKBENCH);
 
-		// The old way was to store this information in a file, the new is to
-		// use the configuration area preference store. To help users with the
-		// transition, this code always looks for values in the preference
-		// store; they are used if found. If there aren't any related
-		// preferences, then the file method is used instead. This class always
-		// writes to the preference store, so the fall-back should be needed no
-		// more than once per-user, per-configuration.
-
-		// This code always sets the value of the protocol to a non-zero value
-		// (currently at 2).  If the value comes back as the default (0), then
-		// none of the preferences were set, revert to the file method.
-
 		int protocol = store.getInt(IDE.Preferences.RECENT_WORKSPACES_PROTOCOL);
-		if (protocol == IPreferenceStore.INT_DEFAULT_DEFAULT
-				&& readPersistedData_file()) {
-			return true;
-		}
 
 		// 2. get value for showDialog
 		showDialog = store.getBoolean(IDE.Preferences.SHOW_WORKSPACE_SELECTION_DIALOG);
@@ -504,52 +340,4 @@ public class ChooseWorkspaceData {
 		return paths;
 	}
 
-	/**
-	 * Returns true if the protocol used to encode the argument memento is
-	 * compatible with the receiver's implementation and false otherwise.
-	 */
-	private static boolean compatibleFileProtocol(IMemento memento) {
-		IMemento protocolMemento = memento.getChild(XML.PROTOCOL);
-		if (protocolMemento == null) {
-			return false;
-		}
-
-		Integer version = protocolMemento.getInteger(XML.VERSION);
-		return version != null && version.intValue() == PERS_ENCODING_VERSION;
-	}
-
-	/**
-	 * The workspace data is stored in the well known file pointed to by the result
-	 * of this method.
-	 * @param create If the directory and file does not exist this parameter
-	 *               controls whether it will be created.
-	 * @return An url to the file and null if it does not exist or could not
-	 *         be created.
-	 */
-	private static URL getPersistenceUrl(URL baseUrl, boolean create) {
-		if (baseUrl == null) {
-			return null;
-		}
-
-		try {
-			// make sure the directory exists
-			URL url = new URL(baseUrl, PERS_FOLDER);
-			File dir = new File(url.getFile());
-			if (!dir.exists() && (!create || !dir.mkdir())) {
-				return null;
-			}
-
-			// make sure the file exists
-			url = new URL(dir.toURL(), PERS_FILENAME);
-			File persFile = new File(url.getFile());
-			if (!persFile.exists() && (!create || !persFile.createNewFile())) {
-				return null;
-			}
-
-			return persFile.toURL();
-		} catch (IOException e) {
-			// cannot log because instance area has not been set
-			return null;
-		}
-	}
 }


### PR DESCRIPTION
Remove the XML file-based persistence fallback that was introduced in 2004 to migrate from a custom XML file to the configuration area preference store. After 21 years any user who has launched Eclipse even once has been migrated.

Removed: readPersistedData_file(), compatibleFileProtocol(), getPersistenceUrl(), the XML tag constants interface, and the related PERS_FOLDER, PERS_FILENAME, PERS_ENCODING_VERSION constants.
