### PR TITLE
Dispose leftover shells in WorkbenchContextExtension cleanup

### DIFF
--- a/tests/org.eclipse.e4.ui.tests/src/org/eclipse/e4/ui/tests/rules/WorkbenchContextExtension.java
+++ b/tests/org.eclipse.e4.ui.tests/src/org/eclipse/e4/ui/tests/rules/WorkbenchContextExtension.java
@@ -30,6 +30,7 @@ import org.eclipse.e4.ui.workbench.IWorkbench;
 import org.eclipse.e4.ui.workbench.modeling.EModelService;
 import org.eclipse.e4.ui.workbench.swt.DisplayUISynchronize;
 import org.eclipse.swt.widgets.Display;
+import org.eclipse.swt.widgets.Shell;
 import org.junit.jupiter.api.extension.AfterEachCallback;
 import org.junit.jupiter.api.extension.BeforeEachCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
@@ -88,6 +89,15 @@ public class WorkbenchContextExtension implements BeforeEachCallback, AfterEachC
 	protected void dispose() {
 		if (wb != null) {
 			wb.close();
+		}
+
+		// Dispose any remaining shells that were not cleaned up by wb.close(),
+		// such as PartRenderingEngine's limbo shell
+		Display display = Display.getDefault();
+		for (Shell shell : display.getShells()) {
+			if (!shell.isDisposed()) {
+				shell.dispose();
+			}
 		}
 
 		ContextInjectionFactory.setDefault(null);


### PR DESCRIPTION
## Summary
- Fixes shell accumulation in `WorkbenchContextExtension` test cleanup
- `wb.close()` removes GUI for application windows but does not dispose shells created as side effects (e.g., `PartRenderingEngine`'s limbo shell)
- These leftover shells accumulate across test methods, causing many unexpected windows to open when running tests
- Added explicit disposal of all remaining shells after `wb.close()` to ensure a clean state between test methods

See #3893

## Test plan
- [x] Ran `PartOnTopManagerTest` (6 tests) — all pass
- [x] Ran all 10 test classes using `WorkbenchContextExtension` (182 tests) — no regressions (pre-existing failures in `MWindowTest` and `PartRenderingEngineTests` are unchanged)
- [x] Verified with trace logging that each test leaves behind a `PartRenderingEngine's limbo` shell that the new cleanup correctly disposes