### PR TITLE
Style workspace version dialog with dark theme

### DIFF
--- a/bundles/org.eclipse.ui.ide.application/src/org/eclipse/ui/internal/ide/application/IDEApplication.java
+++ b/bundles/org.eclipse.ui.ide.application/src/org/eclipse/ui/internal/ide/application/IDEApplication.java
@@ -691,6 +691,15 @@ public class IDEApplication implements IApplication, IExecutableExtension {
 					// in the task manager of the OS
 					return null;
 				}
+
+				@Override
+				protected Control createContents(Composite parent) {
+					Control contents = super.createContents(parent);
+					if (isDark) {
+						applyDarkStyles(getShell());
+					}
+					return contents;
+				}
 			};
 			// hide splash if any
 			hideSplash(shell);


### PR DESCRIPTION
Apply the same dark theme styling used for the workspace selection dialog to the "Older/Newer Workspace Version" dialog. This ensures the version warning dialog is rendered consistently when the user's preferred theme is dark.