### PR TITLE
Fix flaky ensureCleanUpAddonCleansUp by holding CleanupAddon strongly

### DIFF
--- a/tests/org.eclipse.e4.ui.tests/src/org/eclipse/e4/ui/tests/workbench/PartRenderingEngineTests.java
+++ b/tests/org.eclipse.e4.ui.tests/src/org/eclipse/e4/ui/tests/workbench/PartRenderingEngineTests.java
@@ -2435,7 +2435,11 @@ public class PartRenderingEngineTests {
 		partStackForEditor.getChildren().add(editor);
 		partStackForEditor.setSelectedElement(editor);
 
-		ContextInjectionFactory.make(CleanupAddon.class, appContext);
+		// Store the addon in the context so it isn't garbage collected before
+		// its event handlers fire. The DI framework holds injected objects
+		// only via WeakReference, so an addon discarded here can be collected
+		// before its asyncExec runs, silently invalidating the requestor.
+		appContext.set(CleanupAddon.class, ContextInjectionFactory.make(CleanupAddon.class, appContext));
 
 		contextRule.createAndRunWorkbench(window);
 
@@ -2445,8 +2449,6 @@ public class PartRenderingEngineTests {
 
 		assertTrue(partStackForPartBPartC.isToBeRendered(), " PartStack with children should be rendered");
 		partService.hidePart(partB);
-		// Drain pending events between hides so that the event queue is clean
-		// when the second hidePart queues CleanupAddon's asyncExec for visCount==0
 		contextRule.spinEventLoop();
 		partService.hidePart(partC);
 		contextRule.spinEventLoop();
@@ -2494,7 +2496,8 @@ public class PartRenderingEngineTests {
 		partStackB.getChildren().add(partC);
 		partStackB.setSelectedElement(partC);
 
-		ContextInjectionFactory.make(CleanupAddon.class, appContext);
+		// See ensureCleanUpAddonCleansUp for why the addon is stored in the context.
+		appContext.set(CleanupAddon.class, ContextInjectionFactory.make(CleanupAddon.class, appContext));
 
 		contextRule.createAndRunWorkbench(window);
 

--- a/tests/org.eclipse.e4.ui.workbench.addons.swt.test/src/org/eclipse/e4/ui/workbench/addons/cleanupaddon/CleanupAddonTest.java
+++ b/tests/org.eclipse.e4.ui.workbench.addons.swt.test/src/org/eclipse/e4/ui/workbench/addons/cleanupaddon/CleanupAddonTest.java
@@ -164,7 +164,11 @@ public class CleanupAddonTest {
 		appContext.set(MAddon.class, cleanupAddon);
 
 		ContextInjectionFactory.setDefault(appContext);
-		ContextInjectionFactory.make(CleanupAddon.class, appContext);
+		// Store the addon in the context so it isn't garbage collected before
+		// its event handlers fire. The DI framework holds injected objects
+		// only via WeakReference, so an addon discarded here can be collected
+		// before its asyncExec runs, silently invalidating the requestor.
+		appContext.set(CleanupAddon.class, ContextInjectionFactory.make(CleanupAddon.class, appContext));
 
 		appContext.set(IResourceUtilities.class, new ISWTResourceUtilities() {
 


### PR DESCRIPTION
## Summary

`PartRenderingEngineTests.ensureCleanUpAddonCleansUp` has been flaking for a long time (#3581). Prior fixes (synchronous cleanup; extra `spinEventLoop()` between hides) addressed wrong root causes — the synchronous fix had to be reverted because it broke the Welcome screen (#3784), and the event-loop fix did not stop the flake.

## Root cause

The test creates the addon via `ContextInjectionFactory.make(CleanupAddon.class, appContext)` and discards the returned reference. The DI framework holds injected objects only via `WeakReference` (see `InjectorImpl.injectedObjects`). When GC collects the addon between event registration and event firing, the `@UIEventTopic` dispatcher (`UIEventObjectSupplier.UIEventHandler.handleEvent`) observes `requestor.isValid() == false` and silently unsubscribes — the addon method is never invoked, the `asyncExec` that would have unrendered the part stack is never queued, and the assertion fails.

Reproduced locally on Linux with the test trace clearly showing the `TBR partStackBC -> false` event missing on every failure.

## Fix

Store the addon in the application context. The context holds it strongly for the test lifetime; this also matches how addons are referenced in real applications (via the application model). The same pattern is applied to `testBug332463` and `CleanupAddonTest`, which had the same latent issue.

## CI verification

A previous revision of this PR wrapped the test in `@RepeatedTest(500)` to run it 500 times across all CI platforms — all green. Locally (Linux) before the fix: ~1.2% failure rate over 500 iterations; with the fix: 500/500 passed. The `@RepeatedTest(500)` annotation has now been removed and the test is back to a single `@Test`, ready for merge.

Fixes #3581