### PR TITLE
Fix flaky ResourceInitialSelectionTest via pipeline scheduling rule

### DIFF
--- a/bundles/org.eclipse.ui.workbench/.settings/.api_filters
+++ b/bundles/org.eclipse.ui.workbench/.settings/.api_filters
@@ -1,5 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <component id="org.eclipse.ui.workbench" version="2">
+    <resource path="eclipseui/org/eclipse/ui/dialogs/FilteredItemsSelectionDialog.java" type="org.eclipse.ui.dialogs.FilteredItemsSelectionDialog">
+        <filter id="336658481">
+            <message_arguments>
+                <message_argument value="org.eclipse.ui.dialogs.FilteredItemsSelectionDialog"/>
+                <message_argument value="JOB_FAMILY"/>
+            </message_arguments>
+        </filter>
+    </resource>
     <resource path="eclipseui/org/eclipse/ui/dialogs/YesNoCancelListSelectionDialog.java" type="org.eclipse.ui.dialogs.YesNoCancelListSelectionDialog">
         <filter id="576778288">
             <message_arguments>

--- a/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/dialogs/FilteredItemsSelectionDialog.java
+++ b/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/dialogs/FilteredItemsSelectionDialog.java
@@ -50,6 +50,7 @@ import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.core.runtime.ProgressMonitorWrapper;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.core.runtime.SubMonitor;
+import org.eclipse.core.runtime.jobs.ISchedulingRule;
 import org.eclipse.core.runtime.jobs.Job;
 import org.eclipse.jface.action.Action;
 import org.eclipse.jface.action.ActionContributionItem;
@@ -237,6 +238,17 @@ public abstract class FilteredItemsSelectionDialog extends SelectionStatusDialog
 	private boolean isShownForTheFirstTime = true;
 
 	/**
+	 * Job family under which all background filtering and refresh jobs of this
+	 * dialog are grouped. Tests may use this with
+	 * {@link org.eclipse.core.runtime.jobs.IJobManager#join(Object, org.eclipse.core.runtime.IProgressMonitor)}
+	 * to deterministically wait for the filter/refresh pipeline to settle.
+	 *
+	 * @noreference This field is not intended to be referenced by clients.
+	 * @since 3.138
+	 */
+	public static final Object JOB_FAMILY = new Object();
+
+	/**
 	 * Creates a new instance of the class.
 	 *
 	 * @param shell shell to parent the dialog on
@@ -250,8 +262,34 @@ public abstract class FilteredItemsSelectionDialog extends SelectionStatusDialog
 		filterJob = new FilterJob();
 		contentProvider = new ContentProvider();
 		refreshCacheJob = new RefreshCacheJob();
+		// All three jobs mutate / read the same ContentProvider state (items,
+		// duplicates, lastFilteredItems, ...). Without a common scheduling rule
+		// they can run concurrently on different worker threads, racing
+		// FilterHistoryJob.contentProvider.reset() against FilterJob's
+		// fillContentProvider() and silently emptying or corrupting the visible
+		// items. The rule is per-dialog, so separate dialogs still run in
+		// parallel.
+		ISchedulingRule pipelineRule = new ContentProviderSerialRule();
+		filterHistoryJob.setRule(pipelineRule);
+		filterJob.setRule(pipelineRule);
+		refreshCacheJob.setRule(pipelineRule);
 		itemsListSeparator = new ItemsListSeparator(WorkbenchMessages.FilteredItemsSelectionDialog_separatorLabel);
 		selectionMode = NONE;
+	}
+
+	/**
+	 * Per-dialog mutex rule used to serialize the filter/refresh pipeline jobs.
+	 */
+	private static final class ContentProviderSerialRule implements ISchedulingRule {
+		@Override
+		public boolean contains(ISchedulingRule rule) {
+			return rule == this;
+		}
+
+		@Override
+		public boolean isConflicting(ISchedulingRule rule) {
+			return rule == this;
+		}
 	}
 
 	/**
@@ -1315,6 +1353,11 @@ public abstract class FilteredItemsSelectionDialog extends SelectionStatusDialog
 			return new Status(IStatus.OK, PlatformUI.PLUGIN_ID, IStatus.OK, EMPTY_STRING, null);
 		}
 
+		@Override
+		public boolean belongsTo(Object family) {
+			return family == JOB_FAMILY;
+		}
+
 	}
 
 	/**
@@ -1418,6 +1461,11 @@ public abstract class FilteredItemsSelectionDialog extends SelectionStatusDialog
 		protected void canceling() {
 			super.canceling();
 			contentProvider.stopReloadingCache();
+		}
+
+		@Override
+		public boolean belongsTo(Object family) {
+			return family == JOB_FAMILY;
 		}
 
 	}
@@ -1854,6 +1902,11 @@ public abstract class FilteredItemsSelectionDialog extends SelectionStatusDialog
 			return Status.OK_STATUS;
 		}
 
+		@Override
+		public boolean belongsTo(Object family) {
+			return family == JOB_FAMILY;
+		}
+
 	}
 
 	/**
@@ -1975,6 +2028,11 @@ public abstract class FilteredItemsSelectionDialog extends SelectionStatusDialog
 				}
 			}
 
+		}
+
+		@Override
+		public boolean belongsTo(Object family) {
+			return family == JOB_FAMILY;
 		}
 
 	}

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/dialogs/ResourceInitialSelectionTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/dialogs/ResourceInitialSelectionTest.java
@@ -38,6 +38,7 @@ import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Table;
 import org.eclipse.swt.widgets.TableItem;
 import org.eclipse.ui.PlatformUI;
+import org.eclipse.ui.dialogs.FilteredItemsSelectionDialog;
 import org.eclipse.ui.dialogs.FilteredResourcesSelectionDialog;
 import org.eclipse.ui.internal.decorators.DecoratorManager;
 import org.eclipse.ui.tests.harness.util.DisplayHelper;
@@ -125,8 +126,11 @@ public class ResourceInitialSelectionTest {
 		dialog.open();
 		dialog.refresh();
 
-		// Don't wait for full refresh - this test checks that invalid initial
-		// selections don't cause a selection before dialog is fully loaded
+		// Intentionally no waitForDialogRefresh: this asserts that during
+		// initial load, the dialog does not pre-select anything for an
+		// invalid initial element. After the refresh pipeline drains the
+		// dialog falls back to selecting row 0, which is a separate
+		// behavior not under test here.
 
 		List<Object> selected = getSelectedItems(dialog);
 
@@ -167,8 +171,10 @@ public class ResourceInitialSelectionTest {
 		dialog.open();
 		dialog.refresh();
 
-		// Don't wait for full refresh - this test checks that filtered initial
-		// selections don't cause a selection before dialog is fully loaded
+		// Intentionally no waitForDialogRefresh: foofoo is filtered out by
+		// the *.txt pattern, so during initial load nothing is selected.
+		// After the refresh pipeline drains the dialog falls back to row 0,
+		// which is a separate behavior not under test here.
 
 		List<Object> selected = getSelectedItems(dialog);
 
@@ -274,8 +280,11 @@ public class ResourceInitialSelectionTest {
 		dialog.open();
 		dialog.refresh();
 
-		// Don't wait for full refresh - this test checks that invalid initial
-		// selections don't cause a selection before dialog is fully loaded
+		// Intentionally no waitForDialogRefresh: this asserts that during
+		// initial load, the dialog does not pre-select anything for invalid
+		// initial elements. After the refresh pipeline drains the dialog
+		// falls back to selecting row 0, which is a separate behavior not
+		// under test here.
 
 		List<Object> selected = getSelectedItems(dialog);
 
@@ -448,37 +457,21 @@ public class ResourceInitialSelectionTest {
 	}
 
 	/**
-	 * Wait for dialog refresh jobs to complete and process UI events.
-	 * This ensures background jobs finish before assertions are made.
+	 * Wait for the dialog's background filter/refresh jobs to complete.
+	 * <p>
+	 * The dialog schedules a chain of jobs on open/refresh:
+	 * {@code FilterHistoryJob → FilterJob → RefreshCacheJob → RefreshJob}. All
+	 * four are tagged with {@link FilteredItemsSelectionDialog#JOB_FAMILY}, so
+	 * we wait for that family to drain. The 30 s ceiling is a deadlock guard;
+	 * the pipeline usually completes within a few hundred milliseconds.
 	 */
 	private void waitForDialogRefresh() {
 		Display display = PlatformUI.getWorkbench().getDisplay();
-
-		// The dialog performs async operations (FilterHistoryJob → FilterJob →
-		// RefreshCacheJob → RefreshJob) to filter and populate the table after refresh()
-		// We need to wait for the table item count to stabilize before checking
-		// selection state. The count can temporarily be non-zero after the history
-		// refresh, then change again when FilterJob populates actual results.
-		// Selection is applied only in the final refresh, so we must wait for
-		// stability rather than just for any non-zero count.
-		int[] lastCount = { -1 };
-		DisplayHelper.waitForCondition(display, 5000, () -> {
+		DisplayHelper.waitForCondition(display, 30_000L, () -> {
 			processUIEvents();
-			try {
-				Table table = (Table) ((Composite) ((Composite) ((Composite) dialog.getShell().getChildren()[0])
-						.getChildren()[0]).getChildren()[0]).getChildren()[3];
-				int count = table.getItemCount();
-				if (count > 0 && count == lastCount[0]) {
-					return true; // stable non-zero count: all refreshes have completed
-				}
-				lastCount[0] = count;
-				return false;
-			} catch (Exception e) {
-				return false;
-			}
+			return Job.getJobManager().find(FilteredItemsSelectionDialog.JOB_FAMILY).length == 0;
 		});
-
-		// Final event loop processing to pick up any trailing async tasks
+		// Final event loop processing to pick up any trailing asyncExecs.
 		processUIEvents();
 	}
 


### PR DESCRIPTION
## Summary

Fixes #294 — `ResourceInitialSelectionTest` has been intermittently failing (predominantly on macOS) for 4+ years with the same pattern: the table appears empty or shows a wrong subset of items at assertion time.

## Root cause

`FilteredItemsSelectionDialog`'s background pipeline has three jobs that read and write the shared `ContentProvider` state:

- `FilterHistoryJob` calls `contentProvider.reset()` + `addHistoryItems()`
- `FilterJob` populates items via `contentProvider.add()` inside the subclass `fillContentProvider()`
- `RefreshCacheJob` reads items via `contentProvider.reloadCache()`

Without a shared scheduling rule, these can run concurrently on different worker threads. A diagnostic CI run on a fork produced a clean race trace:

```
Worker-22: FilterJob.internalRun          ←  adds items (foo.txt, bar.txt, foofoo)
Worker-5:  FilterHistoryJob.run           ←  calls contentProvider.reset() CONCURRENTLY!
Worker-22: FilterJob -> refresh, items=1  ←  only 1 item survived the race
```

Depending on exactly when `reset()` fires, either 0 items survive (empty-table failure) or a subset survives in the wrong order (wrong-selection failure). Both failure modes reported in #294 have the same underlying cause.

The race is reliably triggered by the `ModifyListener` on the pattern `Text` firing `applyFilter()` twice in quick succession during `createDialogArea` on macOS — scheduling two `FilterHistoryJob` runs that overlap with the `FilterJob`.

## Fix

- Share a per-dialog `ISchedulingRule` across `filterHistoryJob`, `filterJob` and `refreshCacheJob`. They now serialize — the race cannot occur. Separate dialogs still run in parallel (rule is per-instance).
- Expose `JOB_FAMILY` (`@noreference`) and override `belongsTo()` on all four pipeline jobs, so tests can deterministically wait via `Job.getJobManager().find(JOB_FAMILY)`.
- Replace `ResourceInitialSelectionTest.waitForDialogRefresh()` item-count stability probe (unreliable: required count > 0, timed out on empty-pattern tests, and 5 s was too short on slow runners) with a family-based wait.

## Validation

Stress-tested on a fork-internal PR with `@RepeatedTest(100)` on the five previously-flaky tests (500 iterations total):

| Platform | Tests | Failures | Time |
|---|---|---|---|
| Linux | 508 | 0 | 136.7s |
| Windows | 508 | 0 | 138.6s |
| macOS | 508 | **0** | 326.1s |

Before the fix, an equivalent 500-iteration macOS run showed 4 failures / 2500 iterations (~0.16%); earlier 2500-iteration runs showed 10 failures / 2500.

## API impact

Additive `public static final Object JOB_FAMILY`, marked `@noreference`. An `.api_filters` entry is added so tooling does not flag the addition. No manifest version bump needed.

## Test plan

- [x] Verify `ResourceInitialSelectionTest` passes 100 repetitions × 5 flaky tests on Linux/Mac/Windows (done on fork)
- [ ] Upstream CI green on Linux/Mac/Windows