### PR TITLE
Fix dark styling of Copy Settings checkboxes on macOS (#3897)

### DIFF
--- a/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/ide/ChooseWorkspaceWithSettingsDialog.java
+++ b/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/ide/ChooseWorkspaceWithSettingsDialog.java
@@ -34,6 +34,7 @@ import org.eclipse.jface.dialogs.IDialogSettings;
 import org.eclipse.jface.fieldassist.ControlDecoration;
 import org.eclipse.jface.fieldassist.FieldDecorationRegistry;
 import org.eclipse.jface.resource.JFaceResources;
+import org.eclipse.jface.util.Util;
 import org.eclipse.osgi.util.NLS;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.custom.ScrolledComposite;
@@ -152,6 +153,20 @@ public class ChooseWorkspaceWithSettingsDialog extends ChooseWorkspaceDialog {
 		sectionClient.setVisible(expanded);
 		clientData.exclude = !expanded;
 		toggle.setText(expanded ? "\u25BE" : "\u25B8"); //$NON-NLS-1$ //$NON-NLS-2$
+
+		// On macOS Cocoa, setBackground/setForeground on a hidden widget is dropped
+		// once the widget is realized. Re-apply colors to the check buttons when
+		// the section first becomes visible.
+		if (Util.isMac()) {
+			sectionClient.addListener(SWT.Show, e -> {
+				for (Control child : sectionClient.getChildren()) {
+					if (child instanceof Button button && (button.getStyle() & SWT.CHECK) != 0) {
+						button.setBackground(workArea.getBackground());
+						button.setForeground(workArea.getForeground());
+					}
+				}
+			});
+		}
 
 		Listener toggleListener = e -> {
 			boolean newState = !sectionClient.getVisible();


### PR DESCRIPTION
## Summary

Fixes https://github.com/eclipse-platform/eclipse.platform.ui/issues/3897 — macOS-only rendering regression in the "Copy Settings" section of the workspace selection dialog.

The section's `SWT.CHECK` buttons are created eagerly inside a `sectionClient` composite that is hidden on first launch (`ChooseWorkspaceWithSettingsDialog.java:151-153`). The E4 CSS theme engine styles them at creation time, but on macOS Cocoa, `setBackground` / `setForeground` calls made on an unrealized (hidden) widget are not retained once the widget is realized. When the user expands the section the checkboxes paint with default native light colors — the bright rectangles visible in the screenshot attached to the issue.

GTK and Windows retain widget color state across realize, so they render correctly without any workaround.

## Fix

In `ChooseWorkspaceWithSettingsDialog.createSettingsControls`, attach an `SWT.Show` listener on `sectionClient` that re-applies `workArea.getBackground()` / `workArea.getForeground()` to its `SWT.CHECK` children when it first becomes visible. Guarded by `Util.isMac()`; no-op on GTK and Windows. No public API change.

Placing the workaround in the dialog (rather than in `IDEApplication.applyStylesRecursive`) matches where the styling actually originates at runtime: when the dialog is opened from `OpenWorkspaceAction` inside a running workbench, it is the CSS theme engine — not `IDEApplication` — that supplies the colors.

## Diagnostic process

Standalone SWT snippets isolated the Cocoa hidden-widget `setBackground` quirk against the `setVisible(false)` → expand scenario. Fix was validated against the snippet; @Phillipus confirmed snippet behavior fixes the issue.

## Test plan

- [ ] On macOS dark theme: open workspace selection dialog → expand "Copy Settings" → checkboxes render dark like the rest of the dialog.
- [ ] On Linux GTK dark theme: same scenario, no regression.
- [ ] On Windows dark theme: same scenario, no regression.
- [ ] Light theme unaffected on all platforms (listener only reads parent colors; no theme detection in this path).