### PR TITLE
Fix sorting when using a TreePathViewerSorter in AbstractTreeViewer

### DIFF
--- a/bundles/org.eclipse.jface/src/org/eclipse/jface/viewers/AbstractTreeViewer.java
+++ b/bundles/org.eclipse.jface/src/org/eclipse/jface/viewers/AbstractTreeViewer.java
@@ -662,12 +662,13 @@ public abstract class AbstractTreeViewer extends ColumnViewer {
 		return comparator.compare(this, e1, e2);
 	}
 
+	@SuppressWarnings("removal")
 	@Override
 	protected Object[] getSortedChildren(Object parentElementOrTreePath) {
 		Object[] result = null;
 		ViewerComparator comparator = getComparator();
 		if (parentElementOrTreePath != null
-				&& comparator instanceof TreePathViewerComparator tpvs) {
+				&& (comparator instanceof TreePathViewerSorter || comparator instanceof TreePathViewerComparator)) {
 			result = getFilteredChildren(parentElementOrTreePath);
 			// be sure we're not modifying the original array from the model
 			result = result.clone();
@@ -682,7 +683,11 @@ public abstract class AbstractTreeViewer extends ColumnViewer {
 					path = internalGetSorterParentPath(w, comparator);
 				}
 			}
-			tpvs.sort(this, path, result);
+			if (comparator instanceof TreePathViewerSorter tpvs) {
+				tpvs.sort(this, path, result);
+			} else if (comparator instanceof TreePathViewerComparator tpvc) {
+				tpvc.sort(this, path, result);
+			}
 			result = applyItemsLimit(parentElementOrTreePath, result);
 		} else {
 			return super.getSortedChildren(parentElementOrTreePath);

--- a/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/viewers/TreeViewerComparatorTest.java
+++ b/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/viewers/TreeViewerComparatorTest.java
@@ -21,6 +21,9 @@ import java.util.List;
 
 import org.eclipse.jface.viewers.ITreeContentProvider;
 import org.eclipse.jface.viewers.StructuredViewer;
+import org.eclipse.jface.viewers.TreePath;
+import org.eclipse.jface.viewers.TreePathViewerComparator;
+import org.eclipse.jface.viewers.TreePathViewerSorter;
 import org.eclipse.jface.viewers.TreeViewer;
 import org.eclipse.jface.viewers.Viewer;
 import org.eclipse.jface.viewers.ViewerComparator;
@@ -112,6 +115,43 @@ public class TreeViewerComparatorTest extends ViewerComparatorTest {
 		team1.addMember("Duong");
 		String[][] expected = { TEAM3_SORTED, TEAM2_SORTED, TEAM1_SORTED_WITH_INSERT };
 		assertSortedResult(expected);
+	}
+
+	@Test
+	@SuppressWarnings({ "deprecation", "removal" })
+	public void test_GH3900_TreePathViewerSorter() {
+		// A TreePathViewerSorter with reversed order.
+		// In GH 3900, the viewer did not call the overridden method and the results
+		// were sorted lexicographically.
+		var sorter = new TreePathViewerSorter() {
+			@Override
+			public int compare(Viewer viewer, TreePath parentPath, Object e1, Object e2) {
+				return -super.compare(viewer, parentPath, e1, e2);
+			}
+		};
+		fViewer.setSorter(sorter);
+		getTreeViewer().expandAll();
+		TreeItem[] items = getTreeViewer().getTree().getItems();
+		assertEquals(UI, items[0].getText());
+		assertEquals(RUNTIME, items[1].getText());
+		assertEquals(CORE, items[2].getText());
+	}
+
+	@Test
+	public void test_GH3900_TreePathViewerComparator() {
+		// A TreePathViewerComparator with reversed order.
+		var comparator = new TreePathViewerComparator() {
+			@Override
+			public int compare(Viewer viewer, TreePath parentPath, Object e1, Object e2) {
+				return -super.compare(viewer, parentPath, e1, e2);
+			}
+		};
+		fViewer.setComparator(comparator);
+		getTreeViewer().expandAll();
+		TreeItem[] items = getTreeViewer().getTree().getItems();
+		assertEquals(UI, items[0].getText());
+		assertEquals(RUNTIME, items[1].getText());
+		assertEquals(CORE, items[2].getText());
 	}
 
 	@Test


### PR DESCRIPTION
Fixes #3900 

I tried to minimize code duplication by making the outer if clause include both cases and then checking for the actual type again
