### PR TITLE
Use  JFace Throttler in AnimationManager 

### DIFF
--- a/bundles/org.eclipse.e4.ui.progress/src/org/eclipse/e4/ui/progress/internal/AnimationManager.java
+++ b/bundles/org.eclipse.e4.ui.progress/src/org/eclipse/e4/ui/progress/internal/AnimationManager.java
@@ -17,13 +17,15 @@ package org.eclipse.e4.ui.progress.internal;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.eclipse.core.runtime.jobs.Job;
 import org.eclipse.e4.core.di.annotations.Creatable;
-import org.eclipse.e4.ui.progress.UIJob;
 import org.eclipse.swt.SWT;
+import org.eclipse.swt.SWTException;
 import org.eclipse.swt.graphics.Color;
 import org.eclipse.swt.widgets.Control;
+import org.eclipse.swt.widgets.Display;
 
 import jakarta.annotation.PostConstruct;
 import jakarta.annotation.PreDestroy;
@@ -38,13 +40,19 @@ import jakarta.inject.Singleton;
 @Singleton
 public class AnimationManager {
 
-	boolean animated = false;
+	private static final int DEBOUNCE_MILLIS = 100;
+
+	volatile boolean animated = false;
 
 	private IJobProgressManagerListener listener;
 
 	IAnimationProcessor animationProcessor;
 
-	Job animationUpdateJob;
+	private Display display;
+
+	private final AtomicBoolean updatePending = new AtomicBoolean();
+
+	private Runnable updateRunnable;
 
 	@Inject
 	ProgressManager progressManager;
@@ -64,15 +72,17 @@ public class AnimationManager {
 	void init() {
 
 		animationProcessor = new ProgressAnimationProcessor(this);
-
-		animationUpdateJob = UIJob.create(ProgressMessages.AnimationManager_AnimationStart, monitor -> {
+		display = Display.getDefault();
+		updateRunnable = () -> {
+			if (display.isDisposed()) {
+				return;
+			}
 			if (animated) {
 				animationProcessor.animationStarted();
 			} else {
 				animationProcessor.animationFinished();
 			}
-		});
-		animationUpdateJob.setSystem(true);
+		};
 
 		listener = getProgressListener();
 		progressManager.addListener(listener);
@@ -114,7 +124,32 @@ public class AnimationManager {
 	 */
 	void setAnimated(final boolean bool) {
 		animated = bool;
-		animationUpdateJob.schedule(100);
+		scheduleUpdate();
+	}
+
+	private void scheduleUpdate() {
+		if (display == null || display.isDisposed()) {
+			return;
+		}
+		// Coalesce bursts: only post one asyncExec at a time. Each posted
+		// runnable calls timerExec with the shared updateRunnable, which
+		// resets any pending timer so the latest call wins (matches the
+		// original Job.schedule(DEBOUNCE_MILLIS) behavior on a sleeping job).
+		if (updatePending.compareAndSet(false, true)) {
+			try {
+				display.asyncExec(() -> {
+					updatePending.set(false);
+					if (!display.isDisposed()) {
+						display.timerExec(DEBOUNCE_MILLIS, updateRunnable);
+					}
+				});
+			} catch (SWTException e) {
+				updatePending.set(false);
+				if (!display.isDisposed()) {
+					throw e;
+				}
+			}
+		}
 	}
 
 	/**

--- a/bundles/org.eclipse.e4.ui.progress/src/org/eclipse/e4/ui/progress/internal/ProgressMessages.java
+++ b/bundles/org.eclipse.e4.ui.progress/src/org/eclipse/e4/ui/progress/internal/ProgressMessages.java
@@ -61,7 +61,6 @@ public class ProgressMessages extends NLS {
 	public static String ProgressMonitorJobsDialog_DetailsTitle;
 	public static String ProgressMonitorJobsDialog_HideTitle;
 	public static String ErrorNotificationManager_OpenErrorDialogJob;
-	public static String AnimationManager_AnimationStart;
 	public static String ProgressFloatingWindow_EllipsisValue;
 	public static String BlockedJobsDialog_UserInterfaceTreeElement;
 	public static String BlockedJobsDialog_BlockedTitle;

--- a/bundles/org.eclipse.e4.ui.progress/src/org/eclipse/e4/ui/progress/internal/messages.properties
+++ b/bundles/org.eclipse.e4.ui.progress/src/org/eclipse/e4/ui/progress/internal/messages.properties
@@ -56,7 +56,6 @@ ProgressManager_showInDialogName=Show In Dialog
 ProgressMonitorJobsDialog_DetailsTitle=&Details >>
 ProgressMonitorJobsDialog_HideTitle=<< &Details
 ErrorNotificationManager_OpenErrorDialogJob=Open error dialog
-AnimationManager_AnimationStart=Animation start
 ProgressFloatingWindow_EllipsisValue=...
 
 BlockedJobsDialog_UserInterfaceTreeElement=Waiting User Operation

--- a/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/progress/AnimationManager.java
+++ b/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/progress/AnimationManager.java
@@ -15,29 +15,34 @@ package org.eclipse.ui.internal.progress;
 
 import java.util.HashSet;
 import java.util.Set;
-import org.eclipse.core.runtime.IProgressMonitor;
-import org.eclipse.core.runtime.IStatus;
-import org.eclipse.core.runtime.Status;
+import java.util.concurrent.atomic.AtomicBoolean;
 import org.eclipse.core.runtime.jobs.Job;
 import org.eclipse.swt.SWT;
+import org.eclipse.swt.SWTException;
 import org.eclipse.swt.graphics.Color;
 import org.eclipse.swt.widgets.Control;
-import org.eclipse.ui.progress.WorkbenchJob;
+import org.eclipse.swt.widgets.Display;
 
 /**
  * The AnimationManager is the class that keeps track of the animation items to
  * update.
  */
 public class AnimationManager {
+	private static final int DEBOUNCE_MILLIS = 100;
+
 	private static AnimationManager singleton;
 
-	boolean animated = false;
+	volatile boolean animated = false;
 
 	private IJobProgressManagerListener listener;
 
 	IAnimationProcessor animationProcessor;
 
-	WorkbenchJob animationUpdateJob;
+	private final Display display;
+
+	private final AtomicBoolean updatePending = new AtomicBoolean();
+
+	private final Runnable updateRunnable;
 
 	/**
 	 * Returns the singleton {@link AnimationManager} instance
@@ -64,21 +69,17 @@ public class AnimationManager {
 	AnimationManager() {
 
 		animationProcessor = new ProgressAnimationProcessor(this);
-
-		animationUpdateJob = new WorkbenchJob(ProgressMessages.AnimationManager_AnimationStart) {
-
-			@Override
-			public IStatus runInUIThread(IProgressMonitor monitor) {
-
-				if (animated) {
-					animationProcessor.animationStarted();
-				} else {
-					animationProcessor.animationFinished();
-				}
-				return Status.OK_STATUS;
+		display = Display.getDefault();
+		updateRunnable = () -> {
+			if (display.isDisposed()) {
+				return;
+			}
+			if (animated) {
+				animationProcessor.animationStarted();
+			} else {
+				animationProcessor.animationFinished();
 			}
 		};
-		animationUpdateJob.setSystem(true);
 
 		listener = getProgressListener();
 		ProgressManager.getInstance().addListener(listener);
@@ -119,7 +120,32 @@ public class AnimationManager {
 	 */
 	void setAnimated(final boolean bool) {
 		animated = bool;
-		animationUpdateJob.schedule(100);
+		scheduleUpdate();
+	}
+
+	private void scheduleUpdate() {
+		if (display.isDisposed()) {
+			return;
+		}
+		// Coalesce bursts: only post one asyncExec at a time. Each posted
+		// runnable calls timerExec with the shared updateRunnable, which
+		// resets any pending timer so the latest call wins (matches the
+		// original Job.schedule(DEBOUNCE_MILLIS) behavior on a sleeping job).
+		if (updatePending.compareAndSet(false, true)) {
+			try {
+				display.asyncExec(() -> {
+					updatePending.set(false);
+					if (!display.isDisposed()) {
+						display.timerExec(DEBOUNCE_MILLIS, updateRunnable);
+					}
+				});
+			} catch (SWTException e) {
+				updatePending.set(false);
+				if (!display.isDisposed()) {
+					throw e;
+				}
+			}
+		}
 	}
 
 	/**


### PR DESCRIPTION
The AnimationManager used a system WorkbenchJob ("Animation start") to toggle the progress region animation on/off with a 100ms debounce. Each job start/stop rescheduled this system job, producing constant "Animation start" noise in the Progress View when system jobs are shown and adding unnecessary Job-scheduler traffic.

The job never ran any work off the UI thread -- runInUIThread toggled the animation and immediately returned OK_STATUS. The Job scheduling machinery (queue, worker thread, rule checking, listener notifications, status objects) was pure overhead around a one-line UI update.

Replace the update job with org.eclipse.jface.util.Throttler, which runs on the UI thread via Display.timerExec with the same 100ms debounce semantics and no Job. This also aligns the animation manager with the rest of the progress package (ProgressManager, ProgressViewUpdater, ProgressAnimationItem), which already uses Throttler for the same "coalesce bursty UI updates" pattern.

Apply the same change to the parallel e4 AnimationManager and remove the now-unused AnimationManager_AnimationStart message key from the e4 bundle.

TaskBarProgressManager uses a similar WorkbenchJob but self-reschedules every 400ms to poll progress, so it is intentionally left unchanged.