### PR TITLE
Relabel Project Explorer filter dialog OK as Apply, add search icon

### DIFF
--- a/bundles/org.eclipse.ui.navigator/src/org/eclipse/ui/internal/navigator/CommonNavigatorMessages.java
+++ b/bundles/org.eclipse.ui.navigator/src/org/eclipse/ui/internal/navigator/CommonNavigatorMessages.java
@@ -126,6 +126,9 @@ public class CommonNavigatorMessages extends NLS {
 	public static String CommonFilterSelectionDialog_Available_customization_;
 
 	/** */
+	public static String CommonFilterSelectionDialog_Apply;
+
+	/** */
 	public static String CommonSorterDescriptorManager_A_navigatorContent_extension_in_0_;
 
 	/** */

--- a/bundles/org.eclipse.ui.navigator/src/org/eclipse/ui/internal/navigator/filters/CommonFilterSelectionDialog.java
+++ b/bundles/org.eclipse.ui.navigator/src/org/eclipse/ui/internal/navigator/filters/CommonFilterSelectionDialog.java
@@ -17,6 +17,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 
+import org.eclipse.jface.dialogs.IDialogConstants;
 import org.eclipse.jface.dialogs.TrayDialog;
 import org.eclipse.jface.resource.ColorRegistry;
 import org.eclipse.jface.resource.JFaceResources;
@@ -96,6 +97,13 @@ public class CommonFilterSelectionDialog extends TrayDialog {
 	@Override
 	public boolean isHelpAvailable() {
 		return helpContext != null;
+	}
+
+	@Override
+	protected void createButtonsForButtonBar(Composite parent) {
+		createButton(parent, IDialogConstants.OK_ID,
+				CommonNavigatorMessages.CommonFilterSelectionDialog_Apply, true);
+		createButton(parent, IDialogConstants.CANCEL_ID, IDialogConstants.CANCEL_LABEL, false);
 	}
 
 	@Override

--- a/bundles/org.eclipse.ui.navigator/src/org/eclipse/ui/internal/navigator/filters/CommonFiltersTab.java
+++ b/bundles/org.eclipse.ui.navigator/src/org/eclipse/ui/internal/navigator/filters/CommonFiltersTab.java
@@ -95,7 +95,7 @@ public class CommonFiltersTab extends CustomizationTab {
 	}
 
 	private void createPatternFilterText(Composite composite) {
-		filterText = new Text(composite, SWT.SINGLE | SWT.BORDER | SWT.SEARCH | SWT.ICON_CANCEL);
+		filterText = new Text(composite, SWT.SINGLE | SWT.BORDER | SWT.SEARCH | SWT.ICON_SEARCH | SWT.ICON_CANCEL);
 		GridData filterTextGridData = new GridData(GridData.FILL_HORIZONTAL);
 		filterText.setLayoutData(filterTextGridData);
 		filterText.setMessage(CommonNavigatorMessages.CommonFilterSelectionDialog_enter_name_of_filte_);

--- a/bundles/org.eclipse.ui.navigator/src/org/eclipse/ui/internal/navigator/messages.properties
+++ b/bundles/org.eclipse.ui.navigator/src/org/eclipse/ui/internal/navigator/messages.properties
@@ -14,6 +14,7 @@
 #String externalization, key=value
 #Thu Feb 02 14:22:56 EST 2006
 CommonFilterSelectionDialog_Available_customization_=Filters and Customization
+CommonFilterSelectionDialog_Apply=Apply
 CommonSorterDescriptorManager_A_navigatorContent_extension_does_n_=A navigatorContent extension does not exist with id\: {0} in plugin {1}
 
 Delete=Delete


### PR DESCRIPTION
## Summary
- Rename the OK button in the Project Explorer "Filters and Customization" dialog (`CommonFilterSelectionDialog`) to "Apply", which better reflects that the action applies filter and content-extension changes to the view.
- Add `SWT.ICON_SEARCH` to the filter pattern `Text` in `CommonFiltersTab` so the search icon is shown next to the existing cancel icon.

## Test plan
- [ ] Open the Project Explorer, run "Filters and Customization..." and verify the primary button is labeled "Apply"; confirm it still commits filter and content-extension selections and closes the dialog.
- [ ] Verify the filter text field in the "Pre-set filters" tab shows both a search icon (leading) and the cancel icon (trailing), and that typing still filters the list.