### PR TITLE
Use Status.error/warning factories in org.eclipse.ui.ide

### DIFF
--- a/bundles/org.eclipse.ui.ide/extensions/org/eclipse/ui/actions/CopyFilesAndFoldersOperation.java
+++ b/bundles/org.eclipse.ui.ide/extensions/org/eclipse/ui/actions/CopyFilesAndFoldersOperation.java
@@ -76,7 +76,6 @@ import org.eclipse.ui.ide.undo.WorkspaceUndoUtil;
 import org.eclipse.ui.internal.ide.IDEInternalPreferences;
 import org.eclipse.ui.internal.ide.IDEWorkbenchMessages;
 import org.eclipse.ui.internal.ide.IDEWorkbenchPlugin;
-import org.eclipse.ui.internal.ide.StatusUtil;
 import org.eclipse.ui.internal.ide.dialogs.IDEResourceInfoUtils;
 import org.eclipse.ui.statushandlers.StatusManager;
 import org.eclipse.ui.wizards.datatransfer.FileStoreStructureProvider;
@@ -646,9 +645,9 @@ public class CopyFilesAndFoldersOperation {
 		// CoreExceptions are collected above, but unexpected runtime
 		// exceptions and errors may still occur.
 		IDEWorkbenchPlugin.getDefault().getLog().log(
-				StatusUtil.newStatus(IStatus.ERROR, MessageFormat.format(
+				Status.error(MessageFormat.format(
 						"Exception in {0}.performCopy(): {1}", //$NON-NLS-1$
-						getClass().getName(), e.getTargetException()), null));
+						getClass().getName(), e.getTargetException())));
 		displayError(NLS
 				.bind(
 						IDEWorkbenchMessages.CopyFilesAndFoldersOperation_internalError,

--- a/bundles/org.eclipse.ui.ide/extensions/org/eclipse/ui/actions/RefreshAction.java
+++ b/bundles/org.eclipse.ui.ide/extensions/org/eclipse/ui/actions/RefreshAction.java
@@ -50,7 +50,6 @@ import org.eclipse.swt.widgets.Shell;
 import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.internal.ide.IDEWorkbenchMessages;
 import org.eclipse.ui.internal.ide.IIDEHelpContextIds;
-import org.eclipse.ui.internal.ide.StatusUtil;
 import org.eclipse.ui.internal.ide.dialogs.IDEResourceInfoUtils;
 
 /**
@@ -298,7 +297,7 @@ public class RefreshAction extends WorkspaceAction {
 					String msg = NLS.bind(
 							IDEWorkbenchMessages.WorkspaceAction_logTitle, getClass()
 									.getName(), e.getTargetException());
-					throw new CoreException(StatusUtil.newStatus(IStatus.ERROR, msg, e.getTargetException()));
+					throw new CoreException(Status.error(msg, e.getTargetException()));
 				} catch (InterruptedException e) {
 					return Status.CANCEL_STATUS;
 				}

--- a/bundles/org.eclipse.ui.ide/extensions/org/eclipse/ui/actions/WorkspaceAction.java
+++ b/bundles/org.eclipse.ui.ide/extensions/org/eclipse/ui/actions/WorkspaceAction.java
@@ -40,7 +40,6 @@ import org.eclipse.osgi.util.NLS;
 import org.eclipse.swt.widgets.Shell;
 import org.eclipse.ui.internal.ide.IDEWorkbenchMessages;
 import org.eclipse.ui.internal.ide.IDEWorkbenchPlugin;
-import org.eclipse.ui.internal.ide.StatusUtil;
 import org.eclipse.ui.internal.progress.ProgressMonitorJobsDialog;
 import org.eclipse.ui.progress.IProgressConstants2;
 
@@ -324,7 +323,7 @@ public abstract class WorkspaceAction extends SelectionListenerAction {
 			String msg = NLS.bind(
 					IDEWorkbenchMessages.WorkspaceAction_logTitle, getClass()
 							.getName(), e.getTargetException());
-			IDEWorkbenchPlugin.log(msg, StatusUtil.newStatus(IStatus.ERROR, msg, e.getTargetException()));
+			IDEWorkbenchPlugin.log(msg, Status.error(msg, e.getTargetException()));
 			displayError(e.getTargetException().getMessage());
 		}
 		// If errors occurred, open an Error dialog & build a multi status error

--- a/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/ide/IDEWorkbenchPlugin.java
+++ b/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/ide/IDEWorkbenchPlugin.java
@@ -180,8 +180,7 @@ public class IDEWorkbenchPlugin extends AbstractUIPlugin {
 	 *            A high level UI message describing when the problem happened.
 	 */
 	public static void log(String message) {
-		getDefault().getLog().log(
-				StatusUtil.newStatus(IStatus.ERROR, message, null));
+		getDefault().getLog().log(Status.error(message));
 	}
 
 	/**
@@ -198,7 +197,7 @@ public class IDEWorkbenchPlugin extends AbstractUIPlugin {
 	 *            The throwable from where the problem actually occurred.
 	 */
 	public static void log(String message, Throwable t) {
-		IStatus status = StatusUtil.newStatus(IStatus.ERROR, message, t);
+		IStatus status = Status.error(message, t);
 		log(message, status);
 	}
 
@@ -240,8 +239,7 @@ public class IDEWorkbenchPlugin extends AbstractUIPlugin {
 		//1FTUHE0: ITPCORE:ALL - API - Status & logging - loss of semantic info
 
 		if (message != null) {
-			getDefault().getLog().log(
-					StatusUtil.newStatus(IStatus.ERROR, message, null));
+			getDefault().getLog().log(Status.error(message));
 		}
 
 		getDefault().getLog().log(status);

--- a/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/views/markers/ExtendedMarkersView.java
+++ b/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/views/markers/ExtendedMarkersView.java
@@ -104,7 +104,6 @@ import org.eclipse.ui.ide.ResourceUtil;
 import org.eclipse.ui.internal.WorkbenchPage;
 import org.eclipse.ui.internal.WorkbenchPlugin;
 import org.eclipse.ui.internal.ide.IDEWorkbenchPlugin;
-import org.eclipse.ui.internal.ide.StatusUtil;
 import org.eclipse.ui.menus.IMenuService;
 import org.eclipse.ui.operations.RedoActionHandler;
 import org.eclipse.ui.operations.UndoActionHandler;
@@ -1277,9 +1276,8 @@ public class ExtendedMarkersView extends ViewPart {
 			}
 		}
 		StatusManager.getManager().handle(
-				StatusUtil.newStatus(IStatus.WARNING,
-						"Sorting by non visible field " //$NON-NLS-1$
-								+ field.getName(), null));
+				Status.warning("Sorting by non visible field " //$NON-NLS-1$
+						+ field.getName()));
 	}
 
 	/**

--- a/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/views/markers/MarkCompletedHandler.java
+++ b/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/views/markers/MarkCompletedHandler.java
@@ -20,7 +20,7 @@ import java.util.Map;
 import org.eclipse.core.commands.ExecutionEvent;
 import org.eclipse.core.commands.operations.IUndoableOperation;
 import org.eclipse.core.resources.IMarker;
-import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.Status;
 import org.eclipse.core.runtime.SubMonitor;
 import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.ide.undo.UpdateMarkersOperation;
@@ -61,8 +61,7 @@ public class MarkCompletedHandler extends MarkerViewHandler {
 			StatusManager.getManager().handle(StatusUtil.newError(e), StatusManager.LOG);
 		} catch (InterruptedException e) {
 			StatusManager.getManager().handle(
-					StatusUtil.newStatus(IStatus.WARNING, e
-							.getLocalizedMessage(), e), StatusManager.LOG);
+					Status.warning(e.getLocalizedMessage(), e), StatusManager.LOG);
 		}
 		return this;
 

--- a/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/wizards/newresource/BasicNewProjectResourceWizard.java
+++ b/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/wizards/newresource/BasicNewProjectResourceWizard.java
@@ -72,7 +72,6 @@ import org.eclipse.ui.internal.IPreferenceConstants;
 import org.eclipse.ui.internal.WorkbenchPlugin;
 import org.eclipse.ui.internal.ide.IDEInternalPreferences;
 import org.eclipse.ui.internal.ide.IDEWorkbenchPlugin;
-import org.eclipse.ui.internal.ide.StatusUtil;
 import org.eclipse.ui.internal.registry.PerspectiveDescriptor;
 import org.eclipse.ui.internal.util.PrefUtil;
 import org.eclipse.ui.internal.wizards.newresource.ResourceMessages;
@@ -256,19 +255,13 @@ public class BasicNewProjectResourceWizard extends BasicNewResourceWizard
 				CoreException cause = (CoreException) t.getCause();
 				StatusAdapter status;
 				if (cause.getStatus().getCode() == IResourceStatus.CASE_VARIANT_EXISTS) {
-					status = new StatusAdapter(
-							StatusUtil
-									.newStatus(
-											IStatus.WARNING,
-											NLS
-													.bind(
-															ResourceMessages.NewProject_caseVariantExistsError,
-															newProjectHandle
-																	.getName()),
-											cause));
+					status = new StatusAdapter(Status.warning(
+							NLS.bind(ResourceMessages.NewProject_caseVariantExistsError,
+									newProjectHandle.getName()),
+							cause));
 				} else {
-					status = new StatusAdapter(StatusUtil.newStatus(cause
-							.getStatus().getSeverity(),
+					status = new StatusAdapter(new Status(cause.getStatus().getSeverity(),
+							IDEWorkbenchPlugin.IDE_WORKBENCH,
 							ResourceMessages.NewProject_errorMessage, cause));
 				}
 				status.setProperty(IStatusAdapterConstants.TITLE_PROPERTY,


### PR DESCRIPTION
Replaces 9 call sites of the internal StatusUtil.newStatus(...) wrapper in org.eclipse.ui.ide with the Status.error(...) / Status.warning(...) static factories. The factories infer the plug-in id from the calling class' bundle, which equals IDEWorkbenchPlugin.IDE_WORKBENCH for all callers in this bundle, so the produced status objects keep the same plug-in id.

The (severity, message, throwable) overload of StatusUtil also passed 'severity' as the unused 'code' field; the factories use IStatus.OK which is the conventional value for that field.

One BasicNewProjectResourceWizard call uses a dynamic severity derived from a wrapped CoreException. It is rewritten to a direct Status constructor so the severity remains preserved.

StatusUtil itself is still used by ~11 callers of newError(Throwable) (which provides a getLocalizedMessage / getMessage / toString fallback chain that has no direct factory equivalent) and the multi-status overload, so the class is intentionally kept.