### PR TITLE
Use ILog.of(Class) in org.eclipse.ui.ide

### DIFF
--- a/bundles/org.eclipse.ui.ide/extensions/org/eclipse/ui/actions/CopyFilesAndFoldersOperation.java
+++ b/bundles/org.eclipse.ui.ide/extensions/org/eclipse/ui/actions/CopyFilesAndFoldersOperation.java
@@ -45,6 +45,7 @@ import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.resources.WorkspaceJob;
 import org.eclipse.core.runtime.Adapters;
 import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.ILog;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
@@ -644,10 +645,9 @@ public class CopyFilesAndFoldersOperation {
 	private void display(InvocationTargetException e) {
 		// CoreExceptions are collected above, but unexpected runtime
 		// exceptions and errors may still occur.
-		IDEWorkbenchPlugin.getDefault().getLog().log(
-				Status.error(MessageFormat.format(
-						"Exception in {0}.performCopy(): {1}", //$NON-NLS-1$
-						getClass().getName(), e.getTargetException())));
+		ILog.of(CopyFilesAndFoldersOperation.class).error(MessageFormat.format(
+				"Exception in {0}.performCopy(): {1}", //$NON-NLS-1$
+				getClass().getName(), e.getTargetException()));
 		displayError(NLS
 				.bind(
 						IDEWorkbenchMessages.CopyFilesAndFoldersOperation_internalError,

--- a/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/ide/EditorAssociationOverrideDescriptor.java
+++ b/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/ide/EditorAssociationOverrideDescriptor.java
@@ -22,6 +22,7 @@ import org.eclipse.core.runtime.Assert;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IConfigurationElement;
 import org.eclipse.core.runtime.IExtensionRegistry;
+import org.eclipse.core.runtime.ILog;
 import org.eclipse.core.runtime.ISafeRunnable;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Platform;
@@ -160,7 +161,7 @@ public final class EditorAssociationOverrideDescriptor {
 			} else {
 				String message= MessageFormat.format(IDEWorkbenchMessages.editorAssociationOverride_error_invalidElementName_message,
 						configElement.getContributor().getName(), configElement.getName());
-				IDEWorkbenchPlugin.getDefault().getLog().log(new Status(IStatus.ERROR, IDEWorkbenchPlugin.IDE_WORKBENCH, IStatus.OK, message, null));
+				ILog.of(EditorAssociationOverrideDescriptor.class).error(message);
 			}
 		}
 		return result.toArray(new EditorAssociationOverrideDescriptor[result.size()]);

--- a/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/ide/dialogs/ProjectNaturesPage.java
+++ b/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/ide/dialogs/ProjectNaturesPage.java
@@ -29,6 +29,7 @@ import org.eclipse.core.resources.IProjectNatureDescriptor;
 import org.eclipse.core.resources.IWorkspace;
 import org.eclipse.core.runtime.Adapters;
 import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.ILog;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.jface.dialogs.ErrorDialog;
@@ -128,10 +129,9 @@ public class ProjectNaturesPage extends PropertyPage {
 			this.naturesIdsWorkingCopy = new ArrayList<>();
 			this.naturesIdsWorkingCopy.addAll(Arrays.asList(project.getDescription().getNatureIds()));
 		} catch (CoreException ex) {
-			IDEWorkbenchPlugin.getDefault().getLog().log(new Status(IStatus.WARNING,
-					IDEWorkbenchPlugin.getDefault().getBundle().getSymbolicName(),
+			ILog.of(ProjectNaturesPage.class).warn(
 					"Error while loading project description for " + this.project.getName(), //$NON-NLS-1$
-					ex));
+					ex);
 		}
 		this.activeNaturesList.setInput(this.naturesIdsWorkingCopy);
 
@@ -313,10 +313,9 @@ public class ProjectNaturesPage extends PropertyPage {
 		try {
 			originalNatureIds = Arrays.asList(this.project.getDescription().getNatureIds());
 		} catch (CoreException ex) {
-			IDEWorkbenchPlugin.getDefault().getLog().log(new Status(IStatus.WARNING,
-					IDEWorkbenchPlugin.getDefault().getBundle().getSymbolicName(),
+			ILog.of(ProjectNaturesPage.class).warn(
 					"Error while loading project description for " + this.project.getName(), //$NON-NLS-1$
-					ex));
+					ex);
 			originalNatureIds = new ArrayList<>();
 		}
 		if (this.naturesIdsWorkingCopy.size() == originalNatureIds.size()

--- a/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/ide/filesystem/FileSystemSupportRegistry.java
+++ b/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/ide/filesystem/FileSystemSupportRegistry.java
@@ -27,6 +27,7 @@ import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IConfigurationElement;
 import org.eclipse.core.runtime.IExtension;
 import org.eclipse.core.runtime.IExtensionPoint;
+import org.eclipse.core.runtime.ILog;
 import org.eclipse.core.runtime.ISafeRunnable;
 import org.eclipse.core.runtime.Platform;
 import org.eclipse.core.runtime.SafeRunner;
@@ -161,7 +162,7 @@ public class FileSystemSupportRegistry implements IExtensionChangeHandler {
 
 				} catch (CoreException exception) {
 					exceptions[0] = exception;
-					IDEWorkbenchPlugin.getDefault().getLog().log(exception.getStatus());
+					ILog.of(FileSystemSupportRegistry.class).log(exception.getStatus());
 				}
 			}
 

--- a/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/views/markers/MarkerContentGenerator.java
+++ b/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/views/markers/MarkerContentGenerator.java
@@ -33,6 +33,7 @@ import org.eclipse.core.resources.IResource;
 import org.eclipse.core.resources.mapping.ResourceMapping;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IConfigurationElement;
+import org.eclipse.core.runtime.ILog;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.jface.preference.IPreferenceStore;
 import org.eclipse.jface.util.IPropertyChangeListener;
@@ -526,7 +527,7 @@ public class MarkerContentGenerator {
 		try {
 			memento.save(writer);
 		} catch (IOException e) {
-			IDEWorkbenchPlugin.getDefault().getLog().log(Util.errorStatus(e));
+			ILog.of(MarkerContentGenerator.class).log(Util.errorStatus(e));
 		}
 		// TODO: We need to migrate this the current class
 		IDEWorkbenchPlugin.getDefault().getPreferenceStore().putValue(

--- a/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/views/markers/internal/MarkerSupportRegistry.java
+++ b/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/views/markers/internal/MarkerSupportRegistry.java
@@ -28,9 +28,8 @@ import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IConfigurationElement;
 import org.eclipse.core.runtime.IExtension;
 import org.eclipse.core.runtime.IExtensionPoint;
-import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.ILog;
 import org.eclipse.core.runtime.Platform;
-import org.eclipse.core.runtime.Status;
 import org.eclipse.core.runtime.dynamichelpers.ExtensionTracker;
 import org.eclipse.core.runtime.dynamichelpers.IExtensionChangeHandler;
 import org.eclipse.core.runtime.dynamichelpers.IExtensionTracker;
@@ -572,11 +571,8 @@ public class MarkerSupportRegistry implements IExtensionChangeHandler {
 			if (markerId != null) {
 				MarkerType markerType = filter.getMarkerType(markerId);
 				if (markerType == null) {
-					IStatus status = new Status(IStatus.WARNING, IDEWorkbenchPlugin.IDE_WORKBENCH, IStatus.WARNING,
-							NLS.bind(MarkerMessages.ProblemFilterRegistry_nullType,
-									new Object[] { markerId, filter.getName() }),
-							null);
-					IDEWorkbenchPlugin.getDefault().getLog().log(status);
+					ILog.of(MarkerSupportRegistry.class).warn(NLS.bind(MarkerMessages.ProblemFilterRegistry_nullType,
+							new Object[] { markerId, filter.getName() }));
 				} else {
 					selectedTypes.add(markerType);
 				}


### PR DESCRIPTION
## Summary

Follow-up to #3906 (Use Status.error/warning factories). Replace Activator-coupled `Plugin.getDefault().getLog().log(...)` call sites in `org.eclipse.ui.ide` with `ILog.of(Class).error/warn/log(...)`. Drops the round-trip through the plug-in singleton and collapses redundant `Status` allocations into the `ILog` convenience methods.

Sites touched:
- `EditorAssociationOverrideDescriptor`, `ProjectNaturesPage` (×2), `MarkerSupportRegistry`: `getDefault().getLog().log(new Status(...))` -> `ILog.of(Class).error/warn(...)`
- `MarkerContentGenerator`, `FileSystemSupportRegistry`: `getDefault().getLog().log(status)` -> `ILog.of(Class).log(status)`
- `CopyFilesAndFoldersOperation`: collapsed the `getDefault().getLog().log(StatusUtil.newStatus(...))` pattern that #3906 partially simplified

Message-fallback behavior is preserved: the `Status.error/warning` factories delegate to the `Status(int, Class<?>, int, String, Throwable)` constructor, which runs the message through `interpolateMessage` (null/empty falls back to `e.getLocalizedMessage()`, then `e.getClass().getSimpleName()`).

## Skipped for follow-ups

- `IDEWorkbenchPlugin` internal log helpers (activator self-reference; separate concern)
- `ProjectEncodingMarkerResolutionGenerator` logs via `UIPlugin` from an IDE-bundle class; bundle-id mismatch needs per-site judgement

## Test plan
- [x] `mvn clean compile -pl bundles/org.eclipse.ui.ide -Pbuild-individual-bundles` succeeds
- [ ] CI green