### PR TITLE
Use ILog.of(Class) in four text-related bundles

### DIFF
--- a/bundles/org.eclipse.ui.editors/src/org/eclipse/ui/internal/editors/text/codemining/annotation/AnnotationCodeMiningProvider.java
+++ b/bundles/org.eclipse.ui.editors/src/org/eclipse/ui/internal/editors/text/codemining/annotation/AnnotationCodeMiningProvider.java
@@ -28,9 +28,8 @@ import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.swt.events.MouseEvent;
 
 import org.eclipse.core.runtime.Assert;
+import org.eclipse.core.runtime.ILog;
 import org.eclipse.core.runtime.IProgressMonitor;
-import org.eclipse.core.runtime.IStatus;
-import org.eclipse.core.runtime.Status;
 
 import org.eclipse.jface.preference.IPreferenceStore;
 import org.eclipse.jface.util.IPropertyChangeListener;
@@ -55,10 +54,6 @@ import org.eclipse.jface.text.source.IAnnotationModelListenerExtension;
 import org.eclipse.jface.text.source.ISourceViewerExtension2;
 import org.eclipse.jface.text.source.ISourceViewerExtension3;
 import org.eclipse.jface.text.source.ISourceViewerExtension5;
-
-import org.eclipse.ui.internal.editors.text.EditorsPlugin;
-
-import org.eclipse.ui.editors.text.EditorsUI;
 
 /**
  * Shows <i>info</i>, <i>warning</i>, and <i>error</i> Annotations as line header code minings.
@@ -320,7 +315,7 @@ public class AnnotationCodeMiningProvider extends AbstractCodeMiningProvider
 			final String message= quickAssistAssistant.showPossibleQuickAssists();
 
 			if (message != null) {
-				EditorsPlugin.getDefault().getLog().log(new Status(IStatus.ERROR, EditorsUI.PLUGIN_ID, message));
+				ILog.of(AnnotationCodeMiningProvider.class).error(message);
 			}
 
 		});

--- a/bundles/org.eclipse.ui.editors/src/org/eclipse/ui/internal/texteditor/stickyscroll/StickyLinesProviderDescriptor.java
+++ b/bundles/org.eclipse.ui.editors/src/org/eclipse/ui/internal/texteditor/stickyscroll/StickyLinesProviderDescriptor.java
@@ -22,12 +22,11 @@ import org.eclipse.core.expressions.ExpressionConverter;
 import org.eclipse.core.runtime.Assert;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IConfigurationElement;
+import org.eclipse.core.runtime.ILog;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Status;
 
 import org.eclipse.jface.text.source.ISourceViewer;
-
-import org.eclipse.ui.internal.editors.text.EditorsPlugin;
 
 import org.eclipse.ui.texteditor.ITextEditor;
 import org.eclipse.ui.texteditor.stickyscroll.IStickyLinesProvider;
@@ -122,13 +121,11 @@ public class StickyLinesProviderDescriptor {
 			} else {
 				String message= "Invalid extension to stickyLinesProvider. Must extends IStickyLinesProvider: " //$NON-NLS-1$
 						+ getId();
-				EditorsPlugin.getDefault().getLog()
-						.log(new Status(IStatus.ERROR, EditorsUI.PLUGIN_ID, message));
+				ILog.of(StickyLinesProviderDescriptor.class).error(message);
 				return null;
 			}
 		} catch (CoreException e) {
-			EditorsPlugin.getDefault().getLog().log(new Status(IStatus.ERROR, EditorsUI.PLUGIN_ID,
-					"Error while creating stickyLinesProvider: " + getId(), e)); //$NON-NLS-1$
+			ILog.of(StickyLinesProviderDescriptor.class).error("Error while creating stickyLinesProvider: " + getId(), e); //$NON-NLS-1$
 			return null;
 		}
 	}
@@ -154,8 +151,7 @@ public class StickyLinesProviderDescriptor {
 		try {
 			return enabledWhen.evaluate(context) == EvaluationResult.TRUE;
 		} catch (CoreException e) {
-			EditorsPlugin.getDefault().getLog().log(
-					new Status(IStatus.ERROR, EditorsUI.PLUGIN_ID, "Error while 'enabledWhen' evaluation", e)); //$NON-NLS-1$
+			ILog.of(StickyLinesProviderDescriptor.class).error("Error while 'enabledWhen' evaluation", e); //$NON-NLS-1$
 			return false;
 		}
 	}

--- a/bundles/org.eclipse.ui.editors/src/org/eclipse/ui/internal/texteditor/stickyscroll/StickyLinesProviderRegistry.java
+++ b/bundles/org.eclipse.ui.editors/src/org/eclipse/ui/internal/texteditor/stickyscroll/StickyLinesProviderRegistry.java
@@ -21,13 +21,12 @@ import java.util.List;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IConfigurationElement;
 import org.eclipse.core.runtime.IExtensionRegistry;
+import org.eclipse.core.runtime.ILog;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Platform;
 import org.eclipse.core.runtime.Status;
 
 import org.eclipse.jface.text.source.ISourceViewer;
-
-import org.eclipse.ui.internal.editors.text.EditorsPlugin;
 
 import org.eclipse.ui.texteditor.ITextEditor;
 import org.eclipse.ui.texteditor.stickyscroll.IStickyLinesProvider;
@@ -109,7 +108,7 @@ public class StickyLinesProviderRegistry {
 				StickyLinesProviderDescriptor descriptor = descriptorFactory.create(element);
 				descriptors.add(descriptor);
 			} catch (CoreException e) {
-				EditorsPlugin.getDefault().getLog()
+				ILog.of(StickyLinesProviderRegistry.class)
 						.log(new Status(IStatus.ERROR, element.getNamespaceIdentifier(), e.getMessage()));
 			}
 		}

--- a/bundles/org.eclipse.ui.genericeditor/src/org/eclipse/ui/internal/genericeditor/AutoEditStrategyRegistry.java
+++ b/bundles/org.eclipse.ui.genericeditor/src/org/eclipse/ui/internal/genericeditor/AutoEditStrategyRegistry.java
@@ -21,9 +21,8 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.eclipse.core.runtime.IConfigurationElement;
-import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.ILog;
 import org.eclipse.core.runtime.Platform;
-import org.eclipse.core.runtime.Status;
 import org.eclipse.core.runtime.content.IContentType;
 import org.eclipse.jface.text.IAutoEditStrategy;
 import org.eclipse.jface.text.source.ISourceViewer;
@@ -83,8 +82,7 @@ public class AutoEditStrategyRegistry {
 				try {
 					this.extensions.put(extension, new GenericContentTypeRelatedExtension<>(extension));
 				} catch (Exception ex) {
-					GenericEditorPlugin.getDefault().getLog()
-							.log(new Status(IStatus.ERROR, GenericEditorPlugin.BUNDLE_ID, ex.getMessage(), ex));
+					ILog.of(AutoEditStrategyRegistry.class).error(ex.getMessage(), ex);
 				}
 			}
 		}

--- a/bundles/org.eclipse.ui.genericeditor/src/org/eclipse/ui/internal/genericeditor/CharacterPairMatcherRegistry.java
+++ b/bundles/org.eclipse.ui.genericeditor/src/org/eclipse/ui/internal/genericeditor/CharacterPairMatcherRegistry.java
@@ -18,9 +18,8 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.eclipse.core.runtime.IConfigurationElement;
-import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.ILog;
 import org.eclipse.core.runtime.Platform;
-import org.eclipse.core.runtime.Status;
 import org.eclipse.core.runtime.content.IContentType;
 import org.eclipse.jface.text.source.ICharacterPairMatcher;
 import org.eclipse.jface.text.source.ISourceViewer;
@@ -79,8 +78,7 @@ public class CharacterPairMatcherRegistry {
 					this.extensions.put(extension,
 							new GenericContentTypeRelatedExtension<>(extension));
 				} catch (Exception ex) {
-					GenericEditorPlugin.getDefault().getLog()
-							.log(new Status(IStatus.ERROR, GenericEditorPlugin.BUNDLE_ID, ex.getMessage(), ex));
+					ILog.of(CharacterPairMatcherRegistry.class).error(ex.getMessage(), ex);
 				}
 			}
 		}

--- a/bundles/org.eclipse.ui.genericeditor/src/org/eclipse/ui/internal/genericeditor/ContentAssistProcessorRegistry.java
+++ b/bundles/org.eclipse.ui.genericeditor/src/org/eclipse/ui/internal/genericeditor/ContentAssistProcessorRegistry.java
@@ -22,10 +22,9 @@ import java.util.stream.Collectors;
 
 import org.eclipse.core.filebuffers.FileBuffers;
 import org.eclipse.core.runtime.IConfigurationElement;
+import org.eclipse.core.runtime.ILog;
 import org.eclipse.core.runtime.IPath;
-import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Platform;
-import org.eclipse.core.runtime.Status;
 import org.eclipse.core.runtime.content.IContentType;
 import org.eclipse.core.runtime.content.IContentTypeManager;
 import org.eclipse.jface.text.ITextViewer;
@@ -166,7 +165,7 @@ public class ContentAssistProcessorRegistry {
 				try {
 					this.extensions.put(extension, new GenericContentTypeRelatedExtension<>(extension));
 				} catch (Exception ex) {
-					GenericEditorPlugin.getDefault().getLog().log(new Status(IStatus.ERROR, GenericEditorPlugin.BUNDLE_ID, ex.getMessage(), ex));
+					ILog.of(ContentAssistProcessorRegistry.class).error(ex.getMessage(), ex);
 				}
 			}
 		}

--- a/bundles/org.eclipse.ui.genericeditor/src/org/eclipse/ui/internal/genericeditor/ExtensionBasedTextViewerConfiguration.java
+++ b/bundles/org.eclipse.ui.genericeditor/src/org/eclipse/ui/internal/genericeditor/ExtensionBasedTextViewerConfiguration.java
@@ -41,10 +41,9 @@ import org.eclipse.core.resources.IStorage;
 import org.eclipse.core.runtime.Adapters;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IAdaptable;
+import org.eclipse.core.runtime.ILog;
 import org.eclipse.core.runtime.IPath;
-import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Platform;
-import org.eclipse.core.runtime.Status;
 import org.eclipse.core.runtime.content.IContentType;
 import org.eclipse.jface.preference.IPreferenceStore;
 import org.eclipse.jface.text.AbstractReusableInformationControlCreator;
@@ -127,8 +126,7 @@ public final class ExtensionBasedTextViewerConfiguration extends TextSourceViewe
 					this.resolvedContentTypes.add(contentType);
 				}
 			} catch (CoreException ex) {
-				GenericEditorPlugin.getDefault().getLog()
-						.log(new Status(IStatus.ERROR, GenericEditorPlugin.BUNDLE_ID, ex.getMessage(), ex));
+				ILog.of(ExtensionBasedTextViewerConfiguration.class).error(ex.getMessage(), ex);
 			}
 		}
 		String fileName = getCurrentFileName(documentParam);

--- a/bundles/org.eclipse.ui.genericeditor/src/org/eclipse/ui/internal/genericeditor/GenericContentTypeRelatedExtension.java
+++ b/bundles/org.eclipse.ui.genericeditor/src/org/eclipse/ui/internal/genericeditor/GenericContentTypeRelatedExtension.java
@@ -21,6 +21,7 @@ import org.eclipse.core.expressions.ExpressionConverter;
 import org.eclipse.core.expressions.IEvaluationContext;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IConfigurationElement;
+import org.eclipse.core.runtime.ILog;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Platform;
 import org.eclipse.core.runtime.Status;
@@ -63,8 +64,7 @@ public class GenericContentTypeRelatedExtension<T> {
 		try {
 			return (E) extension.createExecutableExtension(CLASS_ATTRIBUTE);
 		} catch (CoreException e) {
-			GenericEditorPlugin.getDefault().getLog()
-					.log(new Status(IStatus.ERROR, GenericEditorPlugin.BUNDLE_ID, e.getMessage(), e));
+			ILog.of(GenericContentTypeRelatedExtension.class).error(e.getMessage(), e);
 		}
 		return null;
 	}
@@ -121,8 +121,7 @@ public class GenericContentTypeRelatedExtension<T> {
 		try {
 			return enabledWhen.evaluate(context) == EvaluationResult.TRUE;
 		} catch (CoreException e) {
-			GenericEditorPlugin.getDefault().getLog().log(new Status(IStatus.ERROR, GenericEditorPlugin.BUNDLE_ID,
-					"Error while 'enabledWhen' evaluation", e)); //$NON-NLS-1$
+			ILog.of(GenericContentTypeRelatedExtension.class).error("Error while 'enabledWhen' evaluation", e); //$NON-NLS-1$
 			return false;
 		}
 	}

--- a/bundles/org.eclipse.ui.genericeditor/src/org/eclipse/ui/internal/genericeditor/GenericEditorWithContentTypeIcon.java
+++ b/bundles/org.eclipse.ui.genericeditor/src/org/eclipse/ui/internal/genericeditor/GenericEditorWithContentTypeIcon.java
@@ -13,9 +13,8 @@
 package org.eclipse.ui.internal.genericeditor;
 
 import org.eclipse.core.runtime.Assert;
-import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.ILog;
 import org.eclipse.core.runtime.Platform;
-import org.eclipse.core.runtime.Status;
 import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.ui.IEditorDescriptor;
 import org.eclipse.ui.IEditorMatchingStrategy;
@@ -49,8 +48,7 @@ public class GenericEditorWithContentTypeIcon implements IEditorDescriptor {
 				return image;
 			}
 		} catch (Exception e) {
-			GenericEditorPlugin.getDefault().getLog()
-					.log(new Status(IStatus.ERROR, GenericEditorPlugin.BUNDLE_ID, e.getMessage(), e));
+			ILog.of(GenericEditorWithContentTypeIcon.class).error(e.getMessage(), e);
 		}
 		return this.editorDescriptor.getImageDescriptor();
 	}

--- a/bundles/org.eclipse.ui.genericeditor/src/org/eclipse/ui/internal/genericeditor/IconsRegistry.java
+++ b/bundles/org.eclipse.ui.genericeditor/src/org/eclipse/ui/internal/genericeditor/IconsRegistry.java
@@ -22,9 +22,8 @@ import java.util.Objects;
 import java.util.Set;
 
 import org.eclipse.core.runtime.IConfigurationElement;
-import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.ILog;
 import org.eclipse.core.runtime.Platform;
-import org.eclipse.core.runtime.Status;
 import org.eclipse.core.runtime.content.IContentType;
 import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.jface.resource.ResourceLocator;
@@ -68,7 +67,7 @@ public class IconsRegistry {
 					ResourceLocator.imageDescriptorFromBundle(extension.getNamespaceIdentifier(), icon).ifPresent(imageDescriptor -> this.extensions.put(contentType, imageDescriptor));
 				}
 			} catch (Exception ex) {
-				GenericEditorPlugin.getDefault().getLog().log(new Status(IStatus.ERROR, GenericEditorPlugin.BUNDLE_ID, ex.getMessage(), ex));
+				ILog.of(IconsRegistry.class).error(ex.getMessage(), ex);
 			}
 		}
 

--- a/bundles/org.eclipse.ui.genericeditor/src/org/eclipse/ui/internal/genericeditor/PresentationReconcilerRegistry.java
+++ b/bundles/org.eclipse.ui.genericeditor/src/org/eclipse/ui/internal/genericeditor/PresentationReconcilerRegistry.java
@@ -21,9 +21,8 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.eclipse.core.runtime.IConfigurationElement;
-import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.ILog;
 import org.eclipse.core.runtime.Platform;
-import org.eclipse.core.runtime.Status;
 import org.eclipse.core.runtime.content.IContentType;
 import org.eclipse.jface.text.presentation.IPresentationReconciler;
 import org.eclipse.jface.text.source.ISourceViewer;
@@ -78,7 +77,7 @@ public class PresentationReconcilerRegistry {
 				try {
 					this.extensions.put(extension, new GenericContentTypeRelatedExtension<>(extension));
 				} catch (Exception ex) {
-					GenericEditorPlugin.getDefault().getLog().log(new Status(IStatus.ERROR, GenericEditorPlugin.BUNDLE_ID, ex.getMessage(), ex));
+					ILog.of(PresentationReconcilerRegistry.class).error(ex.getMessage(), ex);
 				}
 			}
 		}

--- a/bundles/org.eclipse.ui.genericeditor/src/org/eclipse/ui/internal/genericeditor/QuickAssistProcessorRegistry.java
+++ b/bundles/org.eclipse.ui.genericeditor/src/org/eclipse/ui/internal/genericeditor/QuickAssistProcessorRegistry.java
@@ -21,9 +21,8 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.eclipse.core.runtime.IConfigurationElement;
-import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.ILog;
 import org.eclipse.core.runtime.Platform;
-import org.eclipse.core.runtime.Status;
 import org.eclipse.core.runtime.content.IContentType;
 import org.eclipse.jface.text.quickassist.IQuickAssistProcessor;
 import org.eclipse.jface.text.source.ISourceViewer;
@@ -71,8 +70,7 @@ public class QuickAssistProcessorRegistry {
 					this.extensions.put(extension,
 							new GenericContentTypeRelatedExtension<>(extension));
 				} catch (Exception ex) {
-					GenericEditorPlugin.getDefault().getLog()
-							.log(new Status(IStatus.ERROR, GenericEditorPlugin.BUNDLE_ID, ex.getMessage(), ex));
+					ILog.of(QuickAssistProcessorRegistry.class).error(ex.getMessage(), ex);
 				}
 			}
 		}

--- a/bundles/org.eclipse.ui.genericeditor/src/org/eclipse/ui/internal/genericeditor/ReconcilerRegistry.java
+++ b/bundles/org.eclipse.ui.genericeditor/src/org/eclipse/ui/internal/genericeditor/ReconcilerRegistry.java
@@ -22,9 +22,8 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.eclipse.core.runtime.IConfigurationElement;
-import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.ILog;
 import org.eclipse.core.runtime.Platform;
-import org.eclipse.core.runtime.Status;
 import org.eclipse.core.runtime.content.IContentType;
 import org.eclipse.jface.text.reconciler.IReconciler;
 import org.eclipse.jface.text.reconciler.IReconcilingStrategy;
@@ -157,8 +156,7 @@ public class ReconcilerRegistry {
 				try {
 					this.extensions.put(extension, new GenericContentTypeRelatedExtension<>(extension));
 				} catch (Exception ex) {
-					GenericEditorPlugin.getDefault().getLog()
-							.log(new Status(IStatus.ERROR, GenericEditorPlugin.BUNDLE_ID, ex.getMessage(), ex));
+					ILog.of(ReconcilerRegistry.class).error(ex.getMessage(), ex);
 				}
 			}
 		}
@@ -177,8 +175,7 @@ public class ReconcilerRegistry {
 				try {
 					this.highlightExtensions.put(extension, new GenericContentTypeRelatedExtension<>(extension));
 				} catch (Exception ex) {
-					GenericEditorPlugin.getDefault().getLog()
-							.log(new Status(IStatus.ERROR, GenericEditorPlugin.BUNDLE_ID, ex.getMessage(), ex));
+					ILog.of(ReconcilerRegistry.class).error(ex.getMessage(), ex);
 				}
 			}
 		}
@@ -197,8 +194,7 @@ public class ReconcilerRegistry {
 				try {
 					this.foldingExtensions.put(extension, new GenericContentTypeRelatedExtension<>(extension));
 				} catch (Exception ex) {
-					GenericEditorPlugin.getDefault().getLog()
-							.log(new Status(IStatus.ERROR, GenericEditorPlugin.BUNDLE_ID, ex.getMessage(), ex));
+					ILog.of(ReconcilerRegistry.class).error(ex.getMessage(), ex);
 				}
 			}
 		}

--- a/bundles/org.eclipse.ui.genericeditor/src/org/eclipse/ui/internal/genericeditor/TextDoubleClickStrategyRegistry.java
+++ b/bundles/org.eclipse.ui.genericeditor/src/org/eclipse/ui/internal/genericeditor/TextDoubleClickStrategyRegistry.java
@@ -19,9 +19,8 @@ import java.util.Optional;
 import java.util.Set;
 
 import org.eclipse.core.runtime.IConfigurationElement;
-import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.ILog;
 import org.eclipse.core.runtime.Platform;
-import org.eclipse.core.runtime.Status;
 import org.eclipse.core.runtime.content.IContentType;
 import org.eclipse.jface.text.ITextDoubleClickStrategy;
 import org.eclipse.jface.text.source.ISourceViewer;
@@ -72,8 +71,7 @@ public class TextDoubleClickStrategyRegistry {
 					this.extensions.put(extension,
 							new GenericContentTypeRelatedExtension<>(extension));
 				} catch (Exception ex) {
-					GenericEditorPlugin.getDefault().getLog()
-							.log(new Status(IStatus.ERROR, GenericEditorPlugin.BUNDLE_ID, ex.getMessage(), ex));
+					ILog.of(TextDoubleClickStrategyRegistry.class).error(ex.getMessage(), ex);
 				}
 			}
 		}

--- a/bundles/org.eclipse.ui.genericeditor/src/org/eclipse/ui/internal/genericeditor/compare/GenericEditorViewer.java
+++ b/bundles/org.eclipse.ui.genericeditor/src/org/eclipse/ui/internal/genericeditor/compare/GenericEditorViewer.java
@@ -22,10 +22,9 @@ import org.eclipse.compare.contentmergeviewer.TextMergeViewer;
 import org.eclipse.core.resources.IEncodedStorage;
 import org.eclipse.core.resources.IStorage;
 import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.ILog;
 import org.eclipse.core.runtime.IPath;
-import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.PlatformObject;
-import org.eclipse.core.runtime.Status;
 import org.eclipse.jface.preference.IPreferenceStore;
 import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.jface.resource.JFaceResources;
@@ -96,8 +95,7 @@ public class GenericEditorViewer extends Viewer {
 		try {
 			documentProvider.connect(editorInput);
 		} catch (CoreException ex) {
-			GenericEditorPlugin.getDefault().getLog()
-					.log(new Status(IStatus.ERROR, GenericEditorPlugin.BUNDLE_ID, ex.getMessage(), ex));
+			ILog.of(GenericEditorViewer.class).error(ex.getMessage(), ex);
 		}
 
 		sourceViewer.setDocument(documentProvider.getDocument(editorInput));

--- a/bundles/org.eclipse.ui.genericeditor/src/org/eclipse/ui/internal/genericeditor/hover/CompositeInformationControl.java
+++ b/bundles/org.eclipse.ui.genericeditor/src/org/eclipse/ui/internal/genericeditor/hover/CompositeInformationControl.java
@@ -23,8 +23,7 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 
 import org.eclipse.core.runtime.Assert;
-import org.eclipse.core.runtime.IStatus;
-import org.eclipse.core.runtime.Status;
+import org.eclipse.core.runtime.ILog;
 import org.eclipse.jface.text.AbstractInformationControl;
 import org.eclipse.jface.text.IInformationControl;
 import org.eclipse.jface.text.IInformationControlCreator;
@@ -38,7 +37,6 @@ import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.Shell;
 import org.eclipse.ui.editors.text.EditorsUI;
-import org.eclipse.ui.internal.genericeditor.GenericEditorPlugin;
 
 public class CompositeInformationControl extends AbstractInformationControl implements IInformationControlExtension2 {
 
@@ -112,10 +110,9 @@ public class CompositeInformationControl extends AbstractInformationControl impl
 				}
 				controls.put(hoverControlCreator.getKey(), abstractInformationControl);
 			} else {
-				GenericEditorPlugin.getDefault().getLog()
-						.log(new Status(IStatus.WARNING, GenericEditorPlugin.BUNDLE_ID,
-								"Only text hovers producing an AbstractInformationControl can be aggregated; got a " //$NON-NLS-1$
-										+ informationControl.getClass().getSimpleName()));
+				ILog.of(CompositeInformationControl.class).warn(
+						"Only text hovers producing an AbstractInformationControl can be aggregated; got a " //$NON-NLS-1$
+								+ informationControl.getClass().getSimpleName());
 				informationControl.dispose();
 			}
 		}

--- a/bundles/org.eclipse.ui.genericeditor/src/org/eclipse/ui/internal/genericeditor/hover/TextHoverRegistry.java
+++ b/bundles/org.eclipse.ui.genericeditor/src/org/eclipse/ui/internal/genericeditor/hover/TextHoverRegistry.java
@@ -24,9 +24,8 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import org.eclipse.core.runtime.IConfigurationElement;
-import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.ILog;
 import org.eclipse.core.runtime.Platform;
-import org.eclipse.core.runtime.Status;
 import org.eclipse.core.runtime.content.IContentType;
 import org.eclipse.jface.preference.IPreferenceStore;
 import org.eclipse.jface.text.ITextHover;
@@ -114,7 +113,7 @@ public final class TextHoverRegistry {
 				try {
 					ext.put(extension, new TextHoverExtension(extension));
 				} catch (Exception ex) {
-					GenericEditorPlugin.getDefault().getLog().log(new Status(IStatus.ERROR, GenericEditorPlugin.BUNDLE_ID, ex.getMessage(), ex));
+					ILog.of(TextHoverRegistry.class).error(ex.getMessage(), ex);
 				}
 			}
 		}

--- a/bundles/org.eclipse.ui.navigator.resources/src/org/eclipse/ui/internal/navigator/resources/workbench/ResourceExtensionContentProvider.java
+++ b/bundles/org.eclipse.ui.navigator.resources/src/org/eclipse/ui/internal/navigator/resources/workbench/ResourceExtensionContentProvider.java
@@ -25,14 +25,12 @@ import org.eclipse.core.resources.IContainer;
 import org.eclipse.core.resources.IResource;
 import org.eclipse.core.resources.IResourceDelta;
 import org.eclipse.core.runtime.CoreException;
-import org.eclipse.core.runtime.IStatus;
-import org.eclipse.core.runtime.Status;
+import org.eclipse.core.runtime.ILog;
 import org.eclipse.jface.viewers.AbstractTreeViewer;
 import org.eclipse.jface.viewers.StructuredViewer;
 import org.eclipse.jface.viewers.Viewer;
 import org.eclipse.swt.widgets.Control;
 import org.eclipse.ui.internal.navigator.resources.nested.PathComparator;
-import org.eclipse.ui.internal.navigator.resources.plugin.WorkbenchNavigatorPlugin;
 import org.eclipse.ui.model.WorkbenchContentProvider;
 
 /**
@@ -70,8 +68,7 @@ public class ResourceExtensionContentProvider extends WorkbenchContentProvider {
 				return c.members().length > 0;
 			}
 		} catch (CoreException ex) {
-			WorkbenchNavigatorPlugin.getDefault().getLog().log(
-					new Status(IStatus.ERROR, WorkbenchNavigatorPlugin.PLUGIN_ID, 0, ex.getMessage(), ex));
+			ILog.of(ResourceExtensionContentProvider.class).error(ex.getMessage(), ex);
 			return false;
 		}
 

--- a/bundles/org.eclipse.ui.navigator.resources/src/org/eclipse/ui/navigator/resources/ProjectExplorer.java
+++ b/bundles/org.eclipse.ui.navigator.resources/src/org/eclipse/ui/navigator/resources/ProjectExplorer.java
@@ -25,6 +25,7 @@ import org.eclipse.core.commands.common.CommandException;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IResource;
 import org.eclipse.core.runtime.Adapters;
+import org.eclipse.core.runtime.ILog;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.SafeRunner;
@@ -324,7 +325,7 @@ public final class ProjectExplorer extends CommonNavigator implements ISecondary
 					openProjectCommand.executeWithChecks(new ExecutionEvent());
 				} catch (CommandException ex) {
 					IStatus status = WorkbenchNavigatorPlugin.createErrorStatus("'Open Project' failed", ex); //$NON-NLS-1$
-					WorkbenchNavigatorPlugin.getDefault().getLog().log(status);
+					ILog.of(ProjectExplorer.class).log(status);
 				}
 				return;
 			}

--- a/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/overlay/FindReplaceOverlay.java
+++ b/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/overlay/FindReplaceOverlay.java
@@ -46,7 +46,7 @@ import org.eclipse.swt.widgets.Text;
 import org.eclipse.swt.widgets.ToolItem;
 import org.eclipse.swt.widgets.Widget;
 
-import org.eclipse.core.runtime.Status;
+import org.eclipse.core.runtime.ILog;
 
 import org.eclipse.jface.action.IAction;
 import org.eclipse.jface.bindings.keys.KeyStroke;
@@ -72,7 +72,6 @@ import org.eclipse.ui.internal.findandreplace.FindReplaceLogic;
 import org.eclipse.ui.internal.findandreplace.FindReplaceMessages;
 import org.eclipse.ui.internal.findandreplace.HistoryStore;
 import org.eclipse.ui.internal.findandreplace.SearchOptions;
-import org.eclipse.ui.internal.texteditor.TextEditorPlugin;
 import org.eclipse.ui.part.MultiPageEditorSite;
 
 import org.eclipse.ui.texteditor.AbstractTextEditor;
@@ -189,8 +188,7 @@ public class FindReplaceOverlay {
 				method.setAccessible(true);
 				method.invoke(targetPart, Boolean.valueOf(state));
 			} catch (IllegalArgumentException | ReflectiveOperationException ex) {
-				TextEditorPlugin.getDefault().getLog()
-						.log(Status.error("cannot (de-)activate actions for text editor", ex)); //$NON-NLS-1$
+				ILog.of(FindReplaceOverlay.class).error("cannot (de-)activate actions for text editor", ex); //$NON-NLS-1$
 			}
 		}
 

--- a/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/texteditor/CompoundEditExitStrategy.java
+++ b/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/texteditor/CompoundEditExitStrategy.java
@@ -28,9 +28,8 @@ import org.eclipse.core.commands.ExecutionException;
 import org.eclipse.core.commands.IExecutionListener;
 import org.eclipse.core.commands.NotHandledException;
 
-import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.ILog;
 import org.eclipse.core.runtime.ListenerList;
-import org.eclipse.core.runtime.Status;
 
 import org.eclipse.jface.text.ITextViewer;
 
@@ -222,8 +221,7 @@ public final class CompoundEditExitStrategy {
 			try {
 				listener.endCompoundEdit();
 			} catch (Exception e) {
-				IStatus status= new Status(IStatus.ERROR, TextEditorPlugin.PLUGIN_ID, IStatus.OK, "listener notification failed", e); //$NON-NLS-1$
-				TextEditorPlugin.getDefault().getLog().log(status);
+				ILog.of(CompoundEditExitStrategy.class).error("listener notification failed", e); //$NON-NLS-1$
 			}
 		}
 	}

--- a/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/texteditor/HippieCompletionEngine.java
+++ b/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/texteditor/HippieCompletionEngine.java
@@ -23,8 +23,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import org.eclipse.core.runtime.Assert;
-import org.eclipse.core.runtime.IStatus;
-import org.eclipse.core.runtime.Status;
+import org.eclipse.core.runtime.ILog;
 
 import org.eclipse.jface.text.BadLocationException;
 import org.eclipse.jface.text.FindReplaceDocumentAdapter;
@@ -817,7 +816,7 @@ public final class HippieCompletionEngine {
 		if (msg == null) {
 			msg= "unable to access the document"; //$NON-NLS-1$
 		}
-		TextEditorPlugin.getDefault().getLog().log(new Status(IStatus.ERROR, TextEditorPlugin.PLUGIN_ID, IStatus.OK, msg, e));
+		ILog.of(HippieCompletionEngine.class).error(msg, e);
 	}
 
 }

--- a/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/texteditor/codemining/CodeMiningProviderDescriptor.java
+++ b/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/texteditor/codemining/CodeMiningProviderDescriptor.java
@@ -22,6 +22,7 @@ import org.eclipse.core.expressions.ExpressionConverter;
 import org.eclipse.core.runtime.Assert;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IConfigurationElement;
+import org.eclipse.core.runtime.ILog;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Status;
 
@@ -154,13 +155,11 @@ class CodeMiningProviderDescriptor {
 			} else {
 				String message = "Invalid extension to codeMiningProviders. Must extends ICodeMiningProvider: " //$NON-NLS-1$
 						+ getId();
-				TextEditorPlugin.getDefault().getLog()
-						.log(new Status(IStatus.ERROR, TextEditorPlugin.PLUGIN_ID, message));
+				ILog.of(CodeMiningProviderDescriptor.class).error(message);
 				return null;
 			}
 		} catch (CoreException e) {
-			TextEditorPlugin.getDefault().getLog().log(new Status(IStatus.ERROR, TextEditorPlugin.PLUGIN_ID,
-					"Error while creating codeMiningProvider: " + getId(), e)); //$NON-NLS-1$
+			ILog.of(CodeMiningProviderDescriptor.class).error("Error while creating codeMiningProvider: " + getId(), e); //$NON-NLS-1$
 			return null;
 		}
 	}
@@ -188,8 +187,7 @@ class CodeMiningProviderDescriptor {
 		try {
 			return fEnabledWhen.evaluate(context) == EvaluationResult.TRUE;
 		} catch (CoreException e) {
-			TextEditorPlugin.getDefault().getLog().log(
-					new Status(IStatus.ERROR, TextEditorPlugin.PLUGIN_ID, "Error while 'enabledWhen' evaluation", e)); //$NON-NLS-1$
+			ILog.of(CodeMiningProviderDescriptor.class).error("Error while 'enabledWhen' evaluation", e); //$NON-NLS-1$
 			return false;
 		}
 	}

--- a/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/texteditor/codemining/CodeMiningProviderRegistry.java
+++ b/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/texteditor/codemining/CodeMiningProviderRegistry.java
@@ -18,6 +18,7 @@ import java.util.List;
 
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IConfigurationElement;
+import org.eclipse.core.runtime.ILog;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Platform;
 import org.eclipse.core.runtime.Status;
@@ -77,7 +78,7 @@ public class CodeMiningProviderRegistry {
 				CodeMiningProviderDescriptor descriptor = new CodeMiningProviderDescriptor(element);
 				descriptors.add(descriptor);
 			} catch (CoreException e) {
-				TextEditorPlugin.getDefault().getLog()
+				ILog.of(CodeMiningProviderRegistry.class)
 						.log(new Status(IStatus.ERROR, element.getNamespaceIdentifier(), e.getMessage()));
 			}
 		}

--- a/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/views/minimap/MinimapWidget.java
+++ b/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/views/minimap/MinimapWidget.java
@@ -45,8 +45,7 @@ import org.eclipse.swt.graphics.Rectangle;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;
 
-import org.eclipse.core.runtime.IStatus;
-import org.eclipse.core.runtime.Status;
+import org.eclipse.core.runtime.ILog;
 
 import org.eclipse.jface.text.IDocument;
 import org.eclipse.jface.text.IRegion;
@@ -60,8 +59,6 @@ import org.eclipse.jface.text.JFaceTextUtil;
 import org.eclipse.jface.text.Region;
 import org.eclipse.jface.text.TextPresentation;
 import org.eclipse.jface.text.TextViewer;
-
-import org.eclipse.ui.internal.texteditor.TextEditorPlugin;
 
 /**
  * Minimap widget which displays scaled content of the given text editor.
@@ -93,9 +90,7 @@ public class MinimapWidget {
 			try {
 				fMinimapTracker.replaceTextRange(event);
 			} catch (Exception e) {
-				IStatus status = new Status(IStatus.ERROR, TextEditorPlugin.PLUGIN_ID, IStatus.OK,
-						"Minimap text content synchronization failed", e); //$NON-NLS-1$
-				TextEditorPlugin.getDefault().getLog().log(status);
+				ILog.of(MinimapWidget.class).error("Minimap text content synchronization failed", e); //$NON-NLS-1$
 				synchText();
 			}
 		}
@@ -111,9 +106,7 @@ public class MinimapWidget {
 				addPresentation(presentation);
 			} catch (Exception e) {
 				synchTextAndStyles();
-				IStatus status = new Status(IStatus.ERROR, TextEditorPlugin.PLUGIN_ID, IStatus.OK,
-						"Minimap styles synchronization failed", e); //$NON-NLS-1$
-				TextEditorPlugin.getDefault().getLog().log(status);
+				ILog.of(MinimapWidget.class).error("Minimap styles synchronization failed", e); //$NON-NLS-1$
 			}
 		}
 

--- a/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/texteditor/AnnotationPreference.java
+++ b/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/texteditor/AnnotationPreference.java
@@ -22,11 +22,10 @@ import org.eclipse.swt.graphics.RGB;
 
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IConfigurationElement;
+import org.eclipse.core.runtime.ILog;
 import org.eclipse.core.runtime.Platform;
 
 import org.eclipse.jface.resource.ImageDescriptor;
-
-import org.eclipse.ui.internal.texteditor.TextEditorPlugin;
 
 
 /**
@@ -1007,7 +1006,7 @@ public class AnnotationPreference {
 					try {
 						fAnnotationImageProvider= (IAnnotationImageProvider) fConfigurationElement.createExecutableExtension(fAnnotationImageProviderAttribute);
 					} catch (CoreException x) {
-						TextEditorPlugin.getDefault().getLog().log(x.getStatus());
+						ILog.of(AnnotationPreference.class).log(x.getStatus());
 					}
 				}
 			}

--- a/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/texteditor/CaseAction.java
+++ b/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/texteditor/CaseAction.java
@@ -21,8 +21,7 @@ import java.util.ResourceBundle;
 
 import org.eclipse.swt.custom.StyledText;
 
-import org.eclipse.core.runtime.IStatus;
-import org.eclipse.core.runtime.Status;
+import org.eclipse.core.runtime.ILog;
 
 import org.eclipse.jface.text.BadLocationException;
 import org.eclipse.jface.text.IBlockTextSelection;
@@ -35,7 +34,6 @@ import org.eclipse.jface.text.MultiTextSelection;
 import org.eclipse.jface.text.Region;
 import org.eclipse.jface.text.source.ISourceViewer;
 
-import org.eclipse.ui.internal.texteditor.TextEditorPlugin;
 
 /**
  * Action that converts the current selection to lower case or upper case.
@@ -131,8 +129,7 @@ public class CaseAction extends TextEditorAction {
 			// don't use the viewer's reveal feature in order to avoid jumping around
 			st.showSelection();
 		} catch (BadLocationException x) {
-			TextEditorPlugin.getDefault().getLog()
-					.log(new Status(IStatus.ERROR, TextEditorPlugin.PLUGIN_ID, x.getMessage(), x));
+			ILog.of(CaseAction.class).error(x.getMessage(), x);
 		}
 	}
 

--- a/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/texteditor/ConfigurationElementSorter.java
+++ b/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/texteditor/ConfigurationElementSorter.java
@@ -34,11 +34,8 @@ import org.eclipse.osgi.util.ManifestElement;
 import org.eclipse.core.runtime.Assert;
 import org.eclipse.core.runtime.IConfigurationElement;
 import org.eclipse.core.runtime.IExtension;
-import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.ILog;
 import org.eclipse.core.runtime.Platform;
-import org.eclipse.core.runtime.Status;
-
-import org.eclipse.ui.internal.texteditor.TextEditorPlugin;
 
 /**
  * Allows to sort an array based on their elements' configuration elements
@@ -157,8 +154,7 @@ public abstract class ConfigurationElementSorter {
 				} catch (BundleException e) {
 					String uid= getExtensionPointUniqueIdentifier(bundle);
 					String message= "ConfigurationElementSorter for '" + uid + "': getting required plug-ins for '" + bundle.getSymbolicName() + "' failed"; //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
-					Status status= new Status(IStatus.ERROR, TextEditorPlugin.PLUGIN_ID, IStatus.OK, message, e);
-					TextEditorPlugin.getDefault().getLog().log(status);
+					ILog.of(ConfigurationElementSorter.class).error(message, e);
 					continue;
 				}
 

--- a/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/texteditor/GotoLastEditPositionAction.java
+++ b/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/texteditor/GotoLastEditPositionAction.java
@@ -13,8 +13,7 @@
  *******************************************************************************/
 package org.eclipse.ui.texteditor;
 
-import org.eclipse.core.runtime.IStatus;
-import org.eclipse.core.runtime.Status;
+import org.eclipse.core.runtime.ILog;
 
 import org.eclipse.jface.action.Action;
 import org.eclipse.jface.action.IAction;
@@ -96,9 +95,7 @@ public class GotoLastEditPositionAction extends Action implements IWorkbenchWind
 			try {
 				editor = page.openEditor(editPosition.getEditorInput(), editPosition.getEditorId());
 			} catch (PartInitException ex) {
-				IStatus status = new Status(IStatus.ERROR, TextEditorPlugin.PLUGIN_ID, IStatus.OK,
-						"Go to Previous Edit Location failed", ex); //$NON-NLS-1$
-				TextEditorPlugin.getDefault().getLog().log(status);
+				ILog.of(GotoLastEditPositionAction.class).error("Go to Previous Edit Location failed", ex); //$NON-NLS-1$
 				return;
 			}
 

--- a/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/texteditor/GotoLineAction.java
+++ b/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/texteditor/GotoLineAction.java
@@ -23,8 +23,7 @@ import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.Shell;
 
-import org.eclipse.core.runtime.IStatus;
-import org.eclipse.core.runtime.Status;
+import org.eclipse.core.runtime.ILog;
 
 import org.eclipse.jface.dialogs.IDialogSettings;
 import org.eclipse.jface.dialogs.IInputValidator;
@@ -39,7 +38,6 @@ import org.eclipse.jface.text.ITextSelection;
 import org.eclipse.ui.IWorkbenchPage;
 import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.internal.texteditor.NLSUtility;
-import org.eclipse.ui.internal.texteditor.TextEditorPlugin;
 
 
 /**
@@ -215,8 +213,7 @@ public class GotoLineAction extends TextEditorAction {
 		try {
 			fLastLine= document.getLineOfOffset(document.getLength()) + 1;
 		} catch (BadLocationException ex) {
-			IStatus status= new Status(IStatus.ERROR, TextEditorPlugin.PLUGIN_ID, IStatus.OK, "Go to Line failed", ex); //$NON-NLS-1$
-			TextEditorPlugin.getDefault().getLog().log(status);
+			ILog.of(GotoLineAction.class).error("Go to Line failed", ex); //$NON-NLS-1$
 			return;
 		}
 

--- a/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/texteditor/GotoNextEditPositionAction.java
+++ b/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/texteditor/GotoNextEditPositionAction.java
@@ -13,8 +13,7 @@
  *******************************************************************************/
 package org.eclipse.ui.texteditor;
 
-import org.eclipse.core.runtime.IStatus;
-import org.eclipse.core.runtime.Status;
+import org.eclipse.core.runtime.ILog;
 
 import org.eclipse.jface.action.Action;
 import org.eclipse.jface.action.IAction;
@@ -99,9 +98,7 @@ public class GotoNextEditPositionAction extends Action implements IWorkbenchWind
 			try {
 				editor = page.openEditor(editPosition.getEditorInput(), editPosition.getEditorId());
 			} catch (PartInitException ex) {
-				IStatus status = new Status(IStatus.ERROR, TextEditorPlugin.PLUGIN_ID, IStatus.OK,
-						"Go to Next Edit Location failed", ex); //$NON-NLS-1$
-				TextEditorPlugin.getDefault().getLog().log(status);
+				ILog.of(GotoNextEditPositionAction.class).error("Go to Next Edit Location failed", ex); //$NON-NLS-1$
 				return;
 			}
 

--- a/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/texteditor/HippieCompleteAction.java
+++ b/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/texteditor/HippieCompleteAction.java
@@ -21,8 +21,7 @@ import java.util.List;
 import java.util.ResourceBundle;
 
 import org.eclipse.core.runtime.Assert;
-import org.eclipse.core.runtime.IStatus;
-import org.eclipse.core.runtime.Status;
+import org.eclipse.core.runtime.ILog;
 
 import org.eclipse.jface.text.BadLocationException;
 import org.eclipse.jface.text.IDocument;
@@ -32,7 +31,6 @@ import org.eclipse.jface.text.source.ISourceViewer;
 
 import org.eclipse.ui.internal.texteditor.CompoundEditExitStrategy;
 import org.eclipse.ui.internal.texteditor.HippieCompletionEngine;
-import org.eclipse.ui.internal.texteditor.TextEditorPlugin;
 
 
 /**
@@ -408,6 +406,6 @@ final class HippieCompleteAction extends TextEditorAction {
 		if (msg == null) {
 			msg= "unable to access the document"; //$NON-NLS-1$
 		}
-		TextEditorPlugin.getDefault().getLog().log(new Status(IStatus.ERROR, TextEditorPlugin.PLUGIN_ID, IStatus.OK, msg, e));
+		ILog.of(HippieCompleteAction.class).error(msg, e);
 	}
 }

--- a/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/texteditor/HyperlinkDetectorDescriptor.java
+++ b/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/texteditor/HyperlinkDetectorDescriptor.java
@@ -22,6 +22,7 @@ import org.eclipse.core.runtime.Assert;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IConfigurationElement;
 import org.eclipse.core.runtime.IExtensionRegistry;
+import org.eclipse.core.runtime.ILog;
 import org.eclipse.core.runtime.ISafeRunnable;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Platform;
@@ -237,11 +238,11 @@ public final class HyperlinkDetectorDescriptor {
 					result.add(desc);
 				} else {
 					String message= NLSUtility.format(EditorMessages.Editor_error_HyperlinkDetector_invalidExtension_message, new String[] {desc.getId(), element.getContributor().getName()});
-					TextEditorPlugin.getDefault().getLog().log(new Status(IStatus.ERROR, TextEditorPlugin.PLUGIN_ID, IStatus.OK, message, null));
+					ILog.of(HyperlinkDetectorDescriptor.class).error(message);
 				}
 			} else {
 				String message= NLSUtility.format(EditorMessages.Editor_error_HyperlinkDetector_invalidElementName_message, new String[] { element.getContributor().getName(), element.getName() });
-				TextEditorPlugin.getDefault().getLog().log(new Status(IStatus.ERROR, TextEditorPlugin.PLUGIN_ID, IStatus.OK, message, null));
+				ILog.of(HyperlinkDetectorDescriptor.class).error(message);
 			}
 		}
 		return result.toArray(new HyperlinkDetectorDescriptor[result.size()]);

--- a/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/texteditor/HyperlinkDetectorTargetDescriptor.java
+++ b/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/texteditor/HyperlinkDetectorTargetDescriptor.java
@@ -19,12 +19,10 @@ import java.util.List;
 import org.eclipse.core.runtime.Assert;
 import org.eclipse.core.runtime.IConfigurationElement;
 import org.eclipse.core.runtime.IExtensionRegistry;
-import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.ILog;
 import org.eclipse.core.runtime.Platform;
-import org.eclipse.core.runtime.Status;
 
 import org.eclipse.ui.internal.texteditor.NLSUtility;
-import org.eclipse.ui.internal.texteditor.TextEditorPlugin;
 
 
 /**
@@ -136,11 +134,11 @@ public final class HyperlinkDetectorTargetDescriptor {
 					result.add(desc);
 				} else {
 					String message= NLSUtility.format(EditorMessages.Editor_error_HyperlinkDetectorTarget_invalidExtension_message, new String[] {desc.getId(), element.getContributor().getName()});
-					TextEditorPlugin.getDefault().getLog().log(new Status(IStatus.ERROR, TextEditorPlugin.PLUGIN_ID, IStatus.OK, message, null));
+					ILog.of(HyperlinkDetectorTargetDescriptor.class).error(message);
 				}
 			} else {
 				String message= NLSUtility.format(EditorMessages.Editor_error_HyperlinkDetectorTarget_invalidElementName_message, new String[] { element.getContributor().getName(), element.getName() });
-				TextEditorPlugin.getDefault().getLog().log(new Status(IStatus.ERROR, TextEditorPlugin.PLUGIN_ID, IStatus.OK, message, null));
+				ILog.of(HyperlinkDetectorTargetDescriptor.class).error(message);
 			}
 
 		}

--- a/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/texteditor/TextViewerDeleteLineTarget.java
+++ b/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/texteditor/TextViewerDeleteLineTarget.java
@@ -29,6 +29,7 @@ import org.eclipse.swt.events.MouseEvent;
 import org.eclipse.swt.events.MouseListener;
 
 import org.eclipse.core.runtime.Assert;
+import org.eclipse.core.runtime.ILog;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Status;
 
@@ -375,7 +376,7 @@ public class TextViewerDeleteLineTarget implements IDeleteLineTarget {
 
 				// log
 				Status status= new Status(IStatus.ERROR, TextEditorPlugin.PLUGIN_ID, e.code, EditorMessages.Editor_error_clipboard_copy_failed_message, e);
-				TextEditorPlugin.getDefault().getLog().log(status);
+				ILog.of(TextViewerDeleteLineTarget.class).log(status);
 
 				fClipboard.uninstall();
 				return; // don't delete

--- a/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/texteditor/rulers/RulerColumnRegistry.java
+++ b/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/texteditor/rulers/RulerColumnRegistry.java
@@ -28,6 +28,7 @@ import org.eclipse.core.runtime.Assert;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IConfigurationElement;
 import org.eclipse.core.runtime.IExtensionRegistry;
+import org.eclipse.core.runtime.ILog;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.InvalidRegistryObjectException;
 import org.eclipse.core.runtime.Platform;
@@ -291,6 +292,6 @@ public final class RulerColumnRegistry {
 	}
 
 	private void warnUser(IStatus status) {
-		TextEditorPlugin.getDefault().getLog().log(status);
+		ILog.of(RulerColumnRegistry.class).log(status);
 	}
 }

--- a/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/texteditor/spelling/SpellingService.java
+++ b/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/texteditor/spelling/SpellingService.java
@@ -15,6 +15,7 @@
 package org.eclipse.ui.texteditor.spelling;
 
 import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.ILog;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.ISafeRunnable;
 import org.eclipse.core.runtime.SafeRunner;
@@ -114,7 +115,7 @@ public class SpellingService {
 						SafeRunner.run(runnable);
 					}
 				} catch (CoreException x) {
-					TextEditorPlugin.getDefault().getLog().log(x.getStatus());
+					ILog.of(SpellingService.class).log(x.getStatus());
 				}
 			}
 		} finally {

--- a/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/texteditor/templates/AbstractTemplatesPage.java
+++ b/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/texteditor/templates/AbstractTemplatesPage.java
@@ -52,8 +52,7 @@ import org.eclipse.swt.widgets.TreeColumn;
 import org.eclipse.swt.widgets.TreeItem;
 
 import org.eclipse.core.runtime.Assert;
-import org.eclipse.core.runtime.IStatus;
-import org.eclipse.core.runtime.Status;
+import org.eclipse.core.runtime.ILog;
 
 import org.eclipse.jface.action.Action;
 import org.eclipse.jface.action.IAction;
@@ -1381,8 +1380,7 @@ public abstract class AbstractTemplatesPage extends Page implements ITemplatesPa
 		try {
 			getTemplateStore().save();
 		} catch (IOException e) {
-			TextEditorPlugin.getDefault().getLog().log(new Status(IStatus.ERROR, TextEditorPlugin.PLUGIN_ID,
-					TemplatesMessages.TemplatesPage_save_error_message, e));
+			ILog.of(AbstractTemplatesPage.class).error(TemplatesMessages.TemplatesPage_save_error_message, e);
 			MessageDialog.openError(getShell(),
 					TemplatesMessages.TemplatesPage_save_error_message, e.getMessage());
 		}

--- a/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/texteditor/templates/TemplatePreferencePage.java
+++ b/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/texteditor/templates/TemplatePreferencePage.java
@@ -63,8 +63,7 @@ import org.eclipse.swt.widgets.Widget;
 
 import org.eclipse.core.expressions.Expression;
 
-import org.eclipse.core.runtime.IStatus;
-import org.eclipse.core.runtime.Status;
+import org.eclipse.core.runtime.ILog;
 
 import org.eclipse.text.templates.TemplatePersistenceData;
 import org.eclipse.text.templates.TemplateReaderWriter;
@@ -125,7 +124,6 @@ import org.eclipse.ui.handlers.IHandlerActivation;
 import org.eclipse.ui.handlers.IHandlerService;
 import org.eclipse.ui.internal.texteditor.NLSUtility;
 import org.eclipse.ui.internal.texteditor.SWTUtil;
-import org.eclipse.ui.internal.texteditor.TextEditorPlugin;
 import org.eclipse.ui.internal.texteditor.templates.TextViewerAction;
 
 import org.eclipse.ui.texteditor.ITextEditorActionConstants;
@@ -1491,8 +1489,7 @@ public abstract class TemplatePreferencePage extends PreferencePage implements I
 	 * @since 3.2
 	 */
 	private void openReadErrorDialog(IOException ex) {
-		IStatus status= new Status(IStatus.ERROR, TextEditorPlugin.PLUGIN_ID, IStatus.OK, "Failed to read templates.", ex); //$NON-NLS-1$
-		TextEditorPlugin.getDefault().getLog().log(status);
+		ILog.of(TemplatePreferencePage.class).error("Failed to read templates.", ex); //$NON-NLS-1$
 		String title= TemplatesMessages.TemplatePreferencePage_error_read_title;
 		String message= TemplatesMessages.TemplatePreferencePage_error_read_message;
 		MessageDialog.openError(getShell(), title, message);
@@ -1502,8 +1499,7 @@ public abstract class TemplatePreferencePage extends PreferencePage implements I
 	 * @since 3.2
 	 */
 	private void openWriteErrorDialog(IOException ex) {
-		IStatus status= new Status(IStatus.ERROR, TextEditorPlugin.PLUGIN_ID, IStatus.OK, "Failed to write templates.", ex); //$NON-NLS-1$
-		TextEditorPlugin.getDefault().getLog().log(status);
+		ILog.of(TemplatePreferencePage.class).error("Failed to write templates.", ex); //$NON-NLS-1$
 		String title= TemplatesMessages.TemplatePreferencePage_error_write_title;
 		String message= TemplatesMessages.TemplatePreferencePage_error_write_message;
 		MessageDialog.openError(getShell(), title, message);


### PR DESCRIPTION
## Summary

Follow-up to #3907. Replace Activator-coupled `Plugin.getDefault().getLog().log(...)` call sites across four bundles with `ILog.of(Class).error/warn/log(...)`. Drops the round-trip through the plug-in singleton and collapses redundant `Status` allocations into the `ILog` convenience methods.

Bundles in scope (all have a single Activator, matching `Bundle-SymbolicName`, and classes live in the same bundle they log to):

| Bundle | Sites migrated |
|---|---|
| `org.eclipse.ui.workbench.texteditor` | 26 |
| `org.eclipse.ui.genericeditor` | 17 |
| `org.eclipse.ui.editors` | 5 (+1 preserved) |
| `org.eclipse.ui.navigator.resources` | 2 (+2 activator helpers left) |

Message-fallback behavior is preserved: the `ILog.error/warn(msg, t)` path goes through the `Status(int, Class<?>, int, String, Throwable)` constructor, which interpolates a null/empty message from `e.getLocalizedMessage()` / `e.getClass().getSimpleName()` (equinox `org.eclipse.core.runtime.Status.interpolateMessage`).

## Intentionally preserved

Two sites keep the explicit `Status` construction because they attribute the log to the contributor bundle via `element.getNamespaceIdentifier()`, not the current bundle:
- `CodeMiningProviderRegistry` (texteditor)
- `StickyLinesProviderRegistry` (editors)

Only the `ILog` instance is swapped there to avoid changing the logged pluginId.

## Left for follow-ups

- Activator internal log helpers (`IDEWorkbenchPlugin.log`, `WorkbenchNavigatorPlugin.log`, `EditorsPlugin.log`, etc.) still use `getDefault().getLog()`, but inside the Activator that is just a self-reference. Modernizing those helper bodies is a separate concern.
- Two `org.eclipse.ui.editors` sites in `ProjectEncodingMarkerResolutionGenerator` log via `UIPlugin` from an IDE-bundle class; that bundle-id mismatch needs per-site judgement.
- `org.eclipse.ui.workbench` and `org.eclipse.ui` are deferred until the `org.eclipse.ui` vs `org.eclipse.ui.workbench` id question is resolved.

## Test plan
- [x] `mvn clean compile` per bundle succeeds locally
- [ ] CI green