### PR TITLE
Use ILog.of(Class) in PositionTracker and SmartImportTests

### DIFF
--- a/bundles/org.eclipse.search/newsearch/org/eclipse/search2/internal/ui/text/PositionTracker.java
+++ b/bundles/org.eclipse.search/newsearch/org/eclipse/search2/internal/ui/text/PositionTracker.java
@@ -18,9 +18,8 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
+import org.eclipse.core.runtime.ILog;
 import org.eclipse.core.runtime.IPath;
-import org.eclipse.core.runtime.IStatus;
-import org.eclipse.core.runtime.Status;
 
 import org.eclipse.core.resources.IFile;
 
@@ -34,7 +33,6 @@ import org.eclipse.jface.text.BadLocationException;
 import org.eclipse.jface.text.IDocument;
 import org.eclipse.jface.text.Position;
 
-import org.eclipse.search.internal.ui.SearchPlugin;
 import org.eclipse.search.ui.IQueryListener;
 import org.eclipse.search.ui.ISearchQuery;
 import org.eclipse.search.ui.ISearchResult;
@@ -338,7 +336,7 @@ public class PositionTracker implements IQueryListener, ISearchResultListener, I
 						try {
 							pos= convertToLinePosition(pos, textBuffer.getDocument());
 						} catch (BadLocationException e) {
-							SearchPlugin.getDefault().getLog().log(new Status(IStatus.ERROR, SearchPlugin.getID(), 0, e.getLocalizedMessage(), e));
+							ILog.of(PositionTracker.class).error(e.getLocalizedMessage(), e);
 						}
 					}
 					if (match.getOffset() != pos.getOffset() || match.getLength() != pos.getLength()) {

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/datatransfer/SmartImportTests.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/datatransfer/SmartImportTests.java
@@ -47,13 +47,13 @@ import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.FileLocator;
 import org.eclipse.core.runtime.IAdaptable;
+import org.eclipse.core.runtime.ILog;
 import org.eclipse.core.runtime.ILogListener;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.core.runtime.OperationCanceledException;
 import org.eclipse.core.runtime.Platform;
-import org.eclipse.core.runtime.Status;
 import org.eclipse.jface.dialogs.IDialogConstants;
 import org.eclipse.jface.resource.JFaceResources;
 import org.eclipse.jface.util.Util;
@@ -75,7 +75,6 @@ import org.eclipse.ui.internal.WorkbenchPlugin;
 import org.eclipse.ui.internal.wizards.datatransfer.SmartImportJob;
 import org.eclipse.ui.internal.wizards.datatransfer.SmartImportRootWizardPage;
 import org.eclipse.ui.internal.wizards.datatransfer.SmartImportWizard;
-import org.eclipse.ui.tests.TestPlugin;
 import org.eclipse.ui.tests.datatransfer.contributions.ImportMeProjectConfigurator;
 import org.eclipse.ui.tests.harness.util.CloseTestWindowsRule;
 import org.junit.After;
@@ -349,8 +348,7 @@ public class SmartImportTests {
 		if (!importRoot.isDirectory()) {
 			importRoot = File.listRoots()[0];
 		}
-		TestPlugin.getDefault().getLog().log(new Status(IStatus.INFO, TestPlugin.PLUGIN_ID,
-				"Testing job cancel with root: " + importRoot.getAbsolutePath()));
+		ILog.of(SmartImportTests.class).info("Testing job cancel with root: " + importRoot.getAbsolutePath());
 
 		SmartImportWizard wizard = new SmartImportWizard();
 		wizard.setInitialImportSource(importRoot);


### PR DESCRIPTION
## Summary

- Replace `Plugin.getDefault().getLog().log(new Status(...))` with `ILog.of(Class).error(...)` / `.info(...)` in two simple sites.
- Drops the Activator round-trip and the `Status` allocation in one go.

## Sites

- `PositionTracker` (org.eclipse.search): error log, same-bundle `SearchPlugin` removed along with unused `IStatus`/`Status` imports.
- `SmartImportTests` (org.eclipse.ui.tests): info log, same-bundle `TestPlugin` removed along with unused `Status` import.

Log channel stays in the same bundle in both cases, so no behavior change.

Context: follow-up to the `ILog.of(Class)` migration suggested at https://github.com/vogellacompany/tasks/issues/1837#issuecomment-4275267304. Kept intentionally small — workbench bundle sites and cross-bundle sites (e.g. `ProjectEncodingMarkerResolutionGenerator` logging through `UIPlugin`) are deferred.

## Test plan

- [x] `mvn clean compile -pl :org.eclipse.search -Pbuild-individual-bundles` succeeds
- [x] `mvn clean compile -pl :org.eclipse.ui.tests,:org.eclipse.jface.tests -Pbuild-individual-bundles -am` succeeds
- [ ] CI green