### PR TITLE
Use ILog.of(Class) in org.eclipse.ui.tests

### DIFF
--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/IEditorRegistryTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/IEditorRegistryTest.java
@@ -33,6 +33,7 @@ import org.eclipse.core.internal.content.ContentTypeManager;
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.ILog;
 import org.eclipse.core.runtime.ILogListener;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Platform;
@@ -52,7 +53,6 @@ import org.eclipse.ui.internal.registry.EditorDescriptor;
 import org.eclipse.ui.internal.registry.EditorRegistry;
 import org.eclipse.ui.internal.registry.FileEditorMapping;
 import org.eclipse.ui.internal.util.PrefUtil;
-import org.eclipse.ui.tests.TestPlugin;
 import org.eclipse.ui.tests.harness.util.ArrayUtil;
 import org.eclipse.ui.tests.harness.util.CallHistory;
 import org.eclipse.ui.tests.harness.util.FileUtil;
@@ -93,7 +93,7 @@ public class IEditorRegistryTest {
 			try {
 				FileUtil.deleteProject(proj);
 			} catch (CoreException e) {
-				TestPlugin.getDefault().getLog().log(e.getStatus());
+				ILog.of(IEditorRegistryTest.class).log(e.getStatus());
 				throw e;
 			}
 		}

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/workbenchpart/HeavyResourceView.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/workbenchpart/HeavyResourceView.java
@@ -13,6 +13,7 @@
  *******************************************************************************/
 package org.eclipse.ui.tests.api.workbenchpart;
 
+import org.eclipse.core.runtime.ILog;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.SWTError;
 import org.eclipse.swt.events.SelectionAdapter;
@@ -25,7 +26,6 @@ import org.eclipse.swt.widgets.Label;
 import org.eclipse.swt.widgets.Shell;
 import org.eclipse.ui.internal.WorkbenchPlugin;
 import org.eclipse.ui.part.ViewPart;
-import org.eclipse.ui.tests.TestPlugin;
 
 public class HeavyResourceView extends ViewPart {
 
@@ -81,7 +81,7 @@ public class HeavyResourceView extends ViewPart {
 				new Composite(tempShell, SWT.NONE);
 			}
 		} catch (SWTError e) {
-			TestPlugin.getDefault().getLog().log(WorkbenchPlugin.getStatus(e));
+			ILog.of(HeavyResourceView.class).log(WorkbenchPlugin.getStatus(e));
 		}
 	}
 

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/dialogs/UIWorkingSetWizardsAuto.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/dialogs/UIWorkingSetWizardsAuto.java
@@ -25,6 +25,7 @@ import org.eclipse.core.resources.IResource;
 import org.eclipse.core.resources.IWorkspaceRoot;
 import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.ILog;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.jface.wizard.IWizard;
 import org.eclipse.jface.wizard.IWizardPage;
@@ -44,7 +45,6 @@ import org.eclipse.ui.internal.IWorkbenchHelpContextIds;
 import org.eclipse.ui.internal.WorkbenchPlugin;
 import org.eclipse.ui.internal.registry.WorkingSetDescriptor;
 import org.eclipse.ui.internal.registry.WorkingSetRegistry;
-import org.eclipse.ui.tests.TestPlugin;
 import org.eclipse.ui.tests.harness.util.CloseTestWindowsRule;
 import org.eclipse.ui.tests.harness.util.DialogCheck;
 import org.eclipse.ui.tests.harness.util.FileUtil;
@@ -154,7 +154,7 @@ public abstract class UIWorkingSetWizardsAuto<W extends IWizard> {
 					root.delete(true, null);
 				}
 			} catch (CoreException e1) {
-				TestPlugin.getDefault().getLog().log(e.getStatus());
+				ILog.of(UIWorkingSetWizardsAuto.class).log(e.getStatus());
 				throw createAssertionError(e);
 			}
 		} finally {

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/markers/TestResourceMapping.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/markers/TestResourceMapping.java
@@ -22,8 +22,8 @@ import org.eclipse.core.resources.mapping.ResourceMapping;
 import org.eclipse.core.resources.mapping.ResourceMappingContext;
 import org.eclipse.core.resources.mapping.ResourceTraversal;
 import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.ILog;
 import org.eclipse.core.runtime.IProgressMonitor;
-import org.eclipse.ui.tests.TestPlugin;
 
 public class TestResourceMapping extends ResourceMapping {
 
@@ -78,7 +78,7 @@ public class TestResourceMapping extends ResourceMapping {
 		try {
 			children = ((IContainer) element).members();
 		} catch (CoreException e) {
-			TestPlugin.getDefault().getLog().log(e.getStatus());
+			ILog.of(TestResourceMapping.class).log(e.getStatus());
 			return new TestResourceMapping[0];
 		}
 		TestResourceMapping[] result = new TestResourceMapping[children.length];

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/menus/RemoveMarkersAction.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/menus/RemoveMarkersAction.java
@@ -18,6 +18,7 @@ import org.eclipse.core.resources.IResource;
 import org.eclipse.core.resources.IWorkspaceRoot;
 import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.ILog;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.jface.action.IAction;
@@ -25,7 +26,6 @@ import org.eclipse.jface.dialogs.ErrorDialog;
 import org.eclipse.jface.viewers.ISelection;
 import org.eclipse.ui.IWorkbenchWindow;
 import org.eclipse.ui.IWorkbenchWindowActionDelegate;
-import org.eclipse.ui.tests.TestPlugin;
 import org.osgi.framework.FrameworkUtil;
 
 /**
@@ -77,7 +77,7 @@ public class RemoveMarkersAction implements IWorkbenchWindowActionDelegate {
 
 		IStatus status = new Status(IStatus.ERROR, bundleId, 0, msg, e);
 
-		TestPlugin.getDefault().getLog().log(status);
+		ILog.of(RemoveMarkersAction.class).log(status);
 
 		ErrorDialog.openError(window.getShell(), "Error", msg, status);
 	}

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/progress/ProgressViewTests.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/progress/ProgressViewTests.java
@@ -25,6 +25,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.concurrent.TimeUnit;
 
+import org.eclipse.core.runtime.ILog;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.core.runtime.jobs.Job;
@@ -35,7 +36,6 @@ import org.eclipse.ui.internal.progress.JobTreeElement;
 import org.eclipse.ui.internal.progress.ProgressInfoItem;
 import org.eclipse.ui.internal.progress.TaskInfo;
 import org.eclipse.ui.progress.IProgressConstants;
-import org.eclipse.ui.tests.TestPlugin;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -168,8 +168,8 @@ public class ProgressViewTests extends ProgressTestCase {
 				job.schedule();
 				scheduleOrder.append(job.getName()).append(", ");
 			}
-			TestPlugin.getDefault().getLog()
-					.log(new Status(IStatus.OK, TestPlugin.PLUGIN_ID, scheduleOrder.toString()));
+			ILog.of(ProgressViewTests.class)
+					.log(new Status(IStatus.OK, ProgressViewTests.class, scheduleOrder.toString()));
 
 			// Wait for all jobs to be running
 			for (DummyJob job : allJobs) {


### PR DESCRIPTION
Replace TestPlugin.getDefault().getLog().log(...) with ILog.of(Class).log(...). Drops the Activator round-trip; log channel stays in the same bundle (org.eclipse.ui.tests).