### PR TITLE
Migrate QuickAccessDialogTest to JUnit 5

### DIFF
--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/quickaccess/QuickAccessDialogTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/quickaccess/QuickAccessDialogTest.java
@@ -17,9 +17,9 @@ package org.eclipse.ui.tests.quickaccess;
 
 import static org.eclipse.ui.tests.harness.util.UITestUtil.openTestWindow;
 import static org.eclipse.ui.tests.harness.util.UITestUtil.processEventsUntil;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.util.Arrays;
@@ -47,17 +47,18 @@ import org.eclipse.ui.handlers.IHandlerService;
 import org.eclipse.ui.ide.IDE;
 import org.eclipse.ui.internal.quickaccess.QuickAccessDialog;
 import org.eclipse.ui.internal.quickaccess.QuickAccessMessages;
-import org.eclipse.ui.tests.harness.util.CloseTestWindowsRule;
+import org.eclipse.ui.tests.harness.util.CloseTestWindowsExtension;
 import org.eclipse.ui.tests.harness.util.DisplayHelper;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * Tests the quick access UI
  * @since 3.4
  */
+@ExtendWith(CloseTestWindowsExtension.class)
 public class QuickAccessDialogTest {
 
 	private class TestQuickAccessDialog extends QuickAccessDialog {
@@ -72,9 +73,6 @@ public class QuickAccessDialogTest {
 		}
 	}
 
-	@Rule
-	public CloseTestWindowsRule closeTestWindows = new CloseTestWindowsRule();
-
 	private static final int TIMEOUT = 5000;
 	// As defined in QuickAccessDialog and in SearchField
 	private static final int MAXIMUM_NUMBER_OF_ELEMENTS = 60;
@@ -84,7 +82,7 @@ public class QuickAccessDialogTest {
 	private IWorkbenchWindow activeWorkbenchWindow;
 
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		Arrays.stream(Display.getDefault().getShells()).filter(isQuickAccessShell).forEach(Shell::close);
 		dialogSettings = new DialogSettings("QuickAccessDialogTest" + System.currentTimeMillis());
@@ -99,7 +97,7 @@ public class QuickAccessDialogTest {
 				.map(QuickAccessDialog.class::cast);
 	}
 
-	@After
+	@AfterEach
 	public void tearDown() throws Exception {
 		Arrays.stream(Display.getDefault().getShells()).filter(isQuickAccessShell)
 				.forEach(Shell::close);
@@ -130,23 +128,24 @@ public class QuickAccessDialogTest {
 		dialog.open();
 		Text text = dialog.getQuickAccessContents().getFilterText();
 		Table table = dialog.getQuickAccessContents().getTable();
-		assertTrue("Quick access filter should be empty", text.getText().isEmpty());
-		assertEquals("Quick access table should be empty", 0, table.getItemCount());
+		assertTrue(text.getText().isEmpty(), "Quick access filter should be empty");
+		assertEquals(0, table.getItemCount(), "Quick access table should be empty");
 
 		text.setText("T");
 		processEventsUntil(() -> table.getItemCount() > 1, TIMEOUT);
 		int oldCount = table.getItemCount();
-		assertTrue("Not enough quick access items for simple filter", oldCount > 3);
-		assertTrue("Too many quick access items for size of table", oldCount < MAXIMUM_NUMBER_OF_ELEMENTS);
+		assertTrue(oldCount > 3, "Not enough quick access items for simple filter");
+		assertTrue(oldCount < MAXIMUM_NUMBER_OF_ELEMENTS, "Too many quick access items for size of table");
 		final String oldFirstItemText = table.getItem(0).getText(1);
 
 		text.setText("B"); // The letter mustn't be part of the previous 1st proposal
-		assertTrue("The quick access items should have changed", DisplayHelper.waitForCondition(table.getDisplay(),
+		assertTrue(DisplayHelper.waitForCondition(table.getDisplay(),
 				TIMEOUT,
-				() -> table.getItemCount() > 1 && !table.getItem(0).getText(1).equals(oldFirstItemText)));
+				() -> table.getItemCount() > 1 && !table.getItem(0).getText(1).equals(oldFirstItemText)),
+				"The quick access items should have changed");
 		int newCount = table.getItemCount();
-		assertTrue("Not enough quick access items for simple filter", newCount > 3);
-		assertTrue("Too many quick access items for size of table", newCount < MAXIMUM_NUMBER_OF_ELEMENTS);
+		assertTrue(newCount > 3, "Not enough quick access items for simple filter");
+		assertTrue(newCount < MAXIMUM_NUMBER_OF_ELEMENTS, "Too many quick access items for size of table");
 	}
 
 	@Test
@@ -155,12 +154,13 @@ public class QuickAccessDialogTest {
 		dialog.open();
 		final Table table = dialog.getQuickAccessContents().getTable();
 		Text text = dialog.getQuickAccessContents().getFilterText();
-		assertTrue("Quick access filter should be empty", text.getText().isEmpty());
-		assertEquals("Quick access table should be empty", 0, table.getItemCount());
+		assertTrue(text.getText().isEmpty(), "Quick access filter should be empty");
+		assertEquals(0, table.getItemCount(), "Quick access table should be empty");
 
 		text.setText(TestQuickAccessComputer.TEST_QUICK_ACCESS_PROPOSAL_LABEL);
-		assertTrue("Missing contributed element", DisplayHelper.waitForCondition(dialog.getShell().getDisplay(), TIMEOUT, () ->
-				dialogContains(dialog, TestQuickAccessComputer.TEST_QUICK_ACCESS_PROPOSAL_LABEL))
+		assertTrue(DisplayHelper.waitForCondition(dialog.getShell().getDisplay(), TIMEOUT, () ->
+				dialogContains(dialog, TestQuickAccessComputer.TEST_QUICK_ACCESS_PROPOSAL_LABEL)),
+				"Missing contributed element"
 		);
 	}
 
@@ -172,11 +172,11 @@ public class QuickAccessDialogTest {
 		Text text = dialog.getQuickAccessContents().getFilterText();
 		long duration = System.currentTimeMillis();
 		text.setText(TestLongRunningQuickAccessComputer.THE_ELEMENT.getId());
-		assertTrue("UI Frozen on text change",
-				System.currentTimeMillis() - duration < TestLongRunningQuickAccessComputer.DELAY);
-		assertTrue("Missing contributed element", DisplayHelper.waitForCondition(dialog.getShell().getDisplay(), TestLongRunningQuickAccessComputer.DELAY + TIMEOUT, () ->
+		assertTrue(System.currentTimeMillis() - duration < TestLongRunningQuickAccessComputer.DELAY,
+				"UI Frozen on text change");
+		assertTrue(DisplayHelper.waitForCondition(dialog.getShell().getDisplay(), TestLongRunningQuickAccessComputer.DELAY + TIMEOUT, () ->
 			dialogContains(dialog, TestLongRunningQuickAccessComputer.THE_ELEMENT.getLabel())
-		));
+		), "Missing contributed element");
 		table.select(0);
 		activateCurrentElement(dialog);
 		duration = System.currentTimeMillis();
@@ -185,7 +185,7 @@ public class QuickAccessDialogTest {
 		assertTrue(System.currentTimeMillis() - duration < TestLongRunningQuickAccessComputer.DELAY);
 		AtomicLong tick = new AtomicLong(System.currentTimeMillis());
 		AtomicLong maxBlockedUIThread = new AtomicLong();
-		assertTrue("Missing contributed element as previous pick", DisplayHelper.waitForCondition(
+		assertTrue(DisplayHelper.waitForCondition(
 				secondDialog.getShell().getDisplay(), TestLongRunningQuickAccessComputer.DELAY + TIMEOUT, () -> {
 							long currentTick = System.currentTimeMillis();
 							long previousTick = tick.getAndSet(currentTick);
@@ -193,7 +193,7 @@ public class QuickAccessDialogTest {
 							maxBlockedUIThread.set(Math.max(maxBlockedUIThread.get(), currentDelayInUIThread));
 							return dialogContains(secondDialog,
 									TestLongRunningQuickAccessComputer.THE_ELEMENT.getLabel());
-						}));
+						}), "Missing contributed element as previous pick");
 		assertTrue(maxBlockedUIThread.get() < TestLongRunningQuickAccessComputer.DELAY);
 	}
 
@@ -208,15 +208,15 @@ public class QuickAccessDialogTest {
 		dialog.open();
 		Text text = dialog.getQuickAccessContents().getFilterText();
 		final Table table = dialog.getQuickAccessContents().getTable();
-		assertTrue("Quick access filter should be empty", text.getText().isEmpty());
-		assertEquals("Quick access table should be empty", 0, table.getItemCount());
+		assertTrue(text.getText().isEmpty(), "Quick access filter should be empty");
+		assertEquals(0, table.getItemCount(), "Quick access table should be empty");
 
 		// Set a filter to get some items
 		text.setText("T");
 		processEventsUntil(() -> table.getItemCount() > 1, TIMEOUT);
 		final int defaultCount = table.getItemCount();
-		assertTrue("Not enough quick access items for simple filter", defaultCount > 3);
-		assertTrue("Too many quick access items for size of table", defaultCount < MAXIMUM_NUMBER_OF_ELEMENTS);
+		assertTrue(defaultCount > 3, "Not enough quick access items for simple filter");
+		assertTrue(defaultCount < MAXIMUM_NUMBER_OF_ELEMENTS, "Too many quick access items for size of table");
 		final String oldFirstItemText = table.getItem(0).getText(1);
 
 		IHandlerService handlerService = PlatformUI.getWorkbench().getActiveWorkbenchWindow()
@@ -225,21 +225,21 @@ public class QuickAccessDialogTest {
 		handlerService.executeCommand("org.eclipse.ui.window.quickAccess", null); //$NON-NLS-1$
 		processEventsUntil(() -> table.getItemCount() != defaultCount, TIMEOUT);
 		final int allCount = table.getItemCount();
-		assertTrue("Turning on show all should display more items", allCount > defaultCount);
-		assertEquals("Turning on show all should not change the top item", oldFirstItemText, table.getItem(0).getText(1));
+		assertTrue(allCount > defaultCount, "Turning on show all should display more items");
+		assertEquals(oldFirstItemText, table.getItem(0).getText(1), "Turning on show all should not change the top item");
 
 		// Run the handler to turn off show all
 		handlerService.executeCommand("org.eclipse.ui.window.quickAccess", null); //$NON-NLS-1$
 		processEventsUntil(() -> table.getItemCount() != allCount, TIMEOUT);
 		// Note: The table count may one off from the old count because of shell resizing (scroll bars being added then removed)
-		assertTrue("Turning off show all should limit items shown", table.getItemCount() < allCount);
-		assertEquals("Turning off show all should not change the top item", oldFirstItemText, table.getItem(0).getText(1));
+		assertTrue(table.getItemCount() < allCount, "Turning off show all should limit items shown");
+		assertEquals(oldFirstItemText, table.getItem(0).getText(1), "Turning off show all should not change the top item");
 
 		// Run the handler to turn on show all
 		handlerService.executeCommand("org.eclipse.ui.window.quickAccess", null); //$NON-NLS-1$
 		processEventsUntil(() -> table.getItemCount() == allCount, TIMEOUT);
-		assertEquals("Turning on show all twice shouldn't change the items", allCount, table.getItemCount());
-		assertEquals("Turning on show all twice shouldn't change the top item", oldFirstItemText, table.getItem(0).getText(1));
+		assertEquals(allCount, table.getItemCount(), "Turning on show all twice shouldn't change the items");
+		assertEquals(oldFirstItemText, table.getItem(0).getText(1), "Turning on show all twice shouldn't change the top item");
 
 		// Close and reopen the shell
 		dialog.close();
@@ -250,8 +250,8 @@ public class QuickAccessDialogTest {
 		text.setText("T");
 		processEventsUntil(() -> newTable.getItemCount() > 1, TIMEOUT);
 		// Note: The table count may one off from the old count because of shell resizing (scroll bars being added then removed)
-		assertTrue("Show all should be turned off when the shell is closed and reopened",
-				newTable.getItemCount() < allCount);
+		assertTrue(newTable.getItemCount() < allCount,
+				"Show all should be turned off when the shell is closed and reopened");
 	}
 
 	@Test
@@ -263,9 +263,9 @@ public class QuickAccessDialogTest {
 		Table firstTable = dialog.getQuickAccessContents().getTable();
 		String quickAccessElementText = "Project Explorer";
 		text.setText(quickAccessElementText);
-		assertTrue("Missing entry", DisplayHelper.waitForCondition(firstTable.getDisplay(),
+		assertTrue(DisplayHelper.waitForCondition(firstTable.getDisplay(),
 				TIMEOUT,
-				() -> dialogContains(dialog, quickAccessElementText)));
+				() -> dialogContains(dialog, quickAccessElementText)), "Missing entry");
 		firstTable.select(0);
 		activateCurrentElement(dialog);
 		assertNotEquals(0, dialogSettings.getArray("orderedElements").length);
@@ -278,9 +278,9 @@ public class QuickAccessDialogTest {
 		// then try in a new SearchField
 		QuickAccessDialog secondDialog = new TestQuickAccessDialog(activeWorkbenchWindow, null);
 		secondDialog.open();
-		assertTrue("Missing entry in previous pick",
-				DisplayHelper.waitForCondition(secondDialog.getShell().getDisplay(), TIMEOUT,
-						() -> dialogContains(secondDialog, quickAccessElementText)));
+		assertTrue(DisplayHelper.waitForCondition(secondDialog.getShell().getDisplay(), TIMEOUT,
+						() -> dialogContains(secondDialog, quickAccessElementText)),
+				"Missing entry in previous pick");
 	}
 
 	private void activateCurrentElement(QuickAccessDialog dialog) {
@@ -306,10 +306,10 @@ public class QuickAccessDialogTest {
 		// then try in a new SearchField
 		QuickAccessDialog secondDialog = new TestQuickAccessDialog(activeWorkbenchWindow, null);
 		secondDialog.open();
-		assertTrue("Contributed item not found in previous choices",
-				DisplayHelper.waitForCondition(secondDialog.getShell().getDisplay(), TIMEOUT,
+		assertTrue(DisplayHelper.waitForCondition(secondDialog.getShell().getDisplay(), TIMEOUT,
 						() -> getAllEntries(secondDialog.getQuickAccessContents().getTable()).stream()
-								.anyMatch(TestQuickAccessComputer::isContributedItem)));
+								.anyMatch(TestQuickAccessComputer::isContributedItem)),
+				"Contributed item not found in previous choices");
 	}
 
 	@Test
@@ -330,11 +330,10 @@ public class QuickAccessDialogTest {
 		dialog = new TestQuickAccessDialog(activeWorkbenchWindow, null);
 		dialog.open();
 		final Table secondTable = dialog.getQuickAccessContents().getTable();
-		assertTrue("Contributed item not found in previous choices",
-				DisplayHelper.waitForCondition(secondTable.getDisplay(), TIMEOUT, //
+		assertTrue(DisplayHelper.waitForCondition(secondTable.getDisplay(), TIMEOUT, //
 						() -> getAllEntries(secondTable).stream()
-								.anyMatch(TestIncrementalQuickAccessComputer::isContributedItem)
-				));
+								.anyMatch(TestIncrementalQuickAccessComputer::isContributedItem)),
+				"Contributed item not found in previous choices");
 	}
 
 	@Test
@@ -344,9 +343,9 @@ public class QuickAccessDialogTest {
 		Text text = dialog.getQuickAccessContents().getFilterText();
 		Table table = dialog.getQuickAccessContents().getTable();
 		text.setText("P");
-		assertTrue("Not enough quick access items for simple filter",
-				DisplayHelper.waitForCondition(table.getDisplay(), TIMEOUT, () -> table.getItemCount() > 3));
-		assertTrue("Non-prefix match first", table.getItem(0).getText(1).toLowerCase().startsWith("p"));
+		assertTrue(DisplayHelper.waitForCondition(table.getDisplay(), TIMEOUT, () -> table.getItemCount() > 3),
+				"Not enough quick access items for simple filter");
+		assertTrue(table.getItem(0).getText(1).toLowerCase().startsWith("p"), "Non-prefix match first");
 	}
 
 	@Test
@@ -365,9 +364,9 @@ public class QuickAccessDialogTest {
 		Text text = dialog.getQuickAccessContents().getFilterText();
 		Table table = dialog.getQuickAccessContents().getTable();
 		text.setText("Toggle Split");
-		assertTrue("Not enough quick access items for simple filter",
-				DisplayHelper.waitForCondition(table.getDisplay(), TIMEOUT, () -> table.getItemCount() > 1));
-		assertTrue("Non-prefix match first", table.getItem(0).getText(1).toLowerCase().startsWith("toggle split"));
+		assertTrue(DisplayHelper.waitForCondition(table.getDisplay(), TIMEOUT, () -> table.getItemCount() > 1),
+				"Not enough quick access items for simple filter");
+		assertTrue(table.getItem(0).getText(1).toLowerCase().startsWith("toggle split"), "Non-prefix match first");
 	}
 
 	private List<String> getAllEntries(Table table) {


### PR DESCRIPTION
Replace JUnit 4 annotations and rule with JUnit 5 equivalents:

- \`@Before\` / \`@After\` -> \`@BeforeEach\` / \`@AfterEach\`
- \`@Rule CloseTestWindowsRule\` -> \`@ExtendWith(CloseTestWindowsExtension.class)\`
- \`org.junit.Assert\` -> \`org.junit.jupiter.api.Assertions\` (message
  argument moved from first to last position per JUnit 5 signature)
- \`org.junit.Test\` -> \`org.junit.jupiter.api.Test\`

No behavior change.

## Test plan

- [ ] \`mvn clean verify -pl :org.eclipse.ui.tests -Pbuild-individual-bundles\` runs the class on CI and all existing tests pass.