### PR TITLE
Use ILog.get() in Activator static log helpers

### DIFF
--- a/bundles/org.eclipse.ltk.core.refactoring/src/org/eclipse/ltk/internal/core/refactoring/RefactoringCorePlugin.java
+++ b/bundles/org.eclipse.ltk.core.refactoring/src/org/eclipse/ltk/internal/core/refactoring/RefactoringCorePlugin.java
@@ -22,6 +22,7 @@ import org.eclipse.core.commands.operations.IUndoContext;
 import org.eclipse.core.commands.operations.ObjectUndoContext;
 import org.eclipse.core.commands.operations.OperationHistoryFactory;
 
+import org.eclipse.core.runtime.ILog;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Plugin;
 import org.eclipse.core.runtime.Status;
@@ -71,7 +72,7 @@ public class RefactoringCorePlugin extends Plugin {
 	}
 
 	public static void log(IStatus status) {
-		getDefault().getLog().log(status);
+		ILog.get().log(status);
 	}
 
 	public static void log(Throwable t) {

--- a/bundles/org.eclipse.ltk.ui.refactoring/src/org/eclipse/ltk/internal/ui/refactoring/RefactoringUIPlugin.java
+++ b/bundles/org.eclipse.ltk.ui.refactoring/src/org/eclipse/ltk/internal/ui/refactoring/RefactoringUIPlugin.java
@@ -18,6 +18,7 @@ import java.util.List;
 
 import org.osgi.framework.BundleContext;
 
+import org.eclipse.core.runtime.ILog;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Status;
 
@@ -65,7 +66,7 @@ public class RefactoringUIPlugin extends AbstractUIPlugin {
 	}
 
 	public static void log(IStatus status) {
-		getDefault().getLog().log(status);
+		ILog.get().log(status);
 	}
 
 	public static void log(Throwable t) {

--- a/bundles/org.eclipse.search.core/search/org/eclipse/search/internal/core/SearchCorePlugin.java
+++ b/bundles/org.eclipse.search.core/search/org/eclipse/search/internal/core/SearchCorePlugin.java
@@ -16,6 +16,7 @@ package org.eclipse.search.internal.core;
 import org.osgi.framework.BundleContext;
 
 import org.eclipse.core.runtime.Assert;
+import org.eclipse.core.runtime.ILog;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Plugin;
 import org.eclipse.core.runtime.Status;
@@ -83,7 +84,7 @@ public class SearchCorePlugin extends Plugin {
 	 *            the status to log
 	 */
 	public static void log(IStatus status) {
-		getDefault().getLog().log(status);
+		ILog.get().log(status);
 	}
 
 	public static void log(Throwable e) {

--- a/bundles/org.eclipse.search/search/org/eclipse/search/internal/ui/SearchPlugin.java
+++ b/bundles/org.eclipse.search/search/org/eclipse/search/internal/ui/SearchPlugin.java
@@ -27,6 +27,7 @@ import org.eclipse.swt.widgets.Shell;
 import org.eclipse.core.runtime.Assert;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IConfigurationElement;
+import org.eclipse.core.runtime.ILog;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Platform;
 import org.eclipse.core.runtime.Status;
@@ -306,7 +307,7 @@ public class SearchPlugin extends AbstractUIPlugin {
 	 * @param status the status to log
 	 */
 	public static void log(IStatus status) {
-		getDefault().getLog().log(status);
+		ILog.get().log(status);
 	}
 
 	public static void log(Throwable e) {

--- a/bundles/org.eclipse.text.quicksearch/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.text.quicksearch/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.text.quicksearch;singleton:=true
-Bundle-Version: 1.3.400.qualifier
+Bundle-Version: 1.3.500.qualifier
 Bundle-Activator: org.eclipse.text.quicksearch.internal.ui.QuickSearchActivator
 Require-Bundle: org.eclipse.ui;bundle-version="[3.113.0,4.0.0)",
  org.eclipse.core.resources;bundle-version="[3.13.0,4.0.0)",

--- a/bundles/org.eclipse.text.quicksearch/src/org/eclipse/text/quicksearch/internal/ui/QuickSearchActivator.java
+++ b/bundles/org.eclipse.text.quicksearch/src/org/eclipse/text/quicksearch/internal/ui/QuickSearchActivator.java
@@ -12,6 +12,7 @@
  *******************************************************************************/
 package org.eclipse.text.quicksearch.internal.ui;
 
+import org.eclipse.core.runtime.ILog;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.jface.resource.ImageDescriptor;
@@ -84,7 +85,7 @@ public class QuickSearchActivator extends AbstractUIPlugin {
 
 	public static void log(IStatus status) {
 //		if (logger == null) {
-			getDefault().getLog().log(status);
+			ILog.get().log(status);
 //		}
 //		else {
 //			logger.logEntry(status);

--- a/bundles/org.eclipse.ui.editors/src/org/eclipse/ui/internal/editors/text/EditorsPlugin.java
+++ b/bundles/org.eclipse.ui.editors/src/org/eclipse/ui/internal/editors/text/EditorsPlugin.java
@@ -18,6 +18,7 @@ import org.osgi.framework.BundleContext;
 import org.osgi.framework.FrameworkUtil;
 
 import org.eclipse.core.runtime.Assert;
+import org.eclipse.core.runtime.ILog;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.MultiStatus;
 import org.eclipse.core.runtime.Status;
@@ -55,7 +56,7 @@ public class EditorsPlugin extends AbstractUIPlugin {
 	}
 
 	public static void log(IStatus status) {
-		getDefault().getLog().log(status);
+		ILog.get().log(status);
 	}
 
 	public static void logErrorMessage(String message) {

--- a/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/ide/IDEWorkbenchPlugin.java
+++ b/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/ide/IDEWorkbenchPlugin.java
@@ -26,6 +26,7 @@ import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IBundleGroup;
 import org.eclipse.core.runtime.IBundleGroupProvider;
 import org.eclipse.core.runtime.IConfigurationElement;
+import org.eclipse.core.runtime.ILog;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Platform;
@@ -180,7 +181,7 @@ public class IDEWorkbenchPlugin extends AbstractUIPlugin {
 	 *            A high level UI message describing when the problem happened.
 	 */
 	public static void log(String message) {
-		getDefault().getLog().log(Status.error(message));
+		ILog.get().log(Status.error(message));
 	}
 
 	/**
@@ -239,10 +240,10 @@ public class IDEWorkbenchPlugin extends AbstractUIPlugin {
 		//1FTUHE0: ITPCORE:ALL - API - Status & logging - loss of semantic info
 
 		if (message != null) {
-			getDefault().getLog().log(Status.error(message));
+			ILog.get().log(Status.error(message));
 		}
 
-		getDefault().getLog().log(status);
+		ILog.get().log(status);
 	}
 
 	@Override

--- a/bundles/org.eclipse.ui.navigator.resources/src/org/eclipse/ui/internal/navigator/resources/plugin/WorkbenchNavigatorPlugin.java
+++ b/bundles/org.eclipse.ui.navigator.resources/src/org/eclipse/ui/internal/navigator/resources/plugin/WorkbenchNavigatorPlugin.java
@@ -13,6 +13,7 @@
  *******************************************************************************/
 package org.eclipse.ui.internal.navigator.resources.plugin;
 
+import org.eclipse.core.runtime.ILog;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.ui.plugin.AbstractUIPlugin;
@@ -51,11 +52,11 @@ public class WorkbenchNavigatorPlugin extends AbstractUIPlugin {
 	 */
 	public static void log(String message, IStatus status) {
 		if (message != null) {
-			getDefault().getLog().log(
+			ILog.get().log(
 					new Status(IStatus.ERROR, PLUGIN_ID, 0, message, null));
 		}
 		if(status != null) {
-			getDefault().getLog().log(status);
+			ILog.get().log(status);
 		}
 	}
 

--- a/bundles/org.eclipse.ui.navigator/src/org/eclipse/ui/internal/navigator/NavigatorPlugin.java
+++ b/bundles/org.eclipse.ui.navigator/src/org/eclipse/ui/internal/navigator/NavigatorPlugin.java
@@ -88,7 +88,7 @@ public class NavigatorPlugin extends AbstractUIPlugin {
 		protected IStatus run(IProgressMonitor monitor) {
 
 			Object[] mesgs = messages.getListeners();
-			ILog pluginLog = getDefault().getLog();
+			ILog pluginLog = ILog.get();
 			for (Object mesg : mesgs) {
 				pluginLog.log((IStatus)mesg);
 			}
@@ -163,7 +163,7 @@ public class NavigatorPlugin extends AbstractUIPlugin {
 	 */
 	public static void logError(int aCode, String aMessage,
 			Throwable anException) {
-		getDefault().getLog().log(
+		ILog.get().log(
 				createErrorStatus(aCode, aMessage, anException));
 	}
 


### PR DESCRIPTION
Replace getDefault().getLog().log(...) with ILog.get().log(...) inside the Activator's own static log helpers. ILog.get() resolves to the same bundle's log via the caller's classloader, so the log channel does not change. Avoids the Activator singleton round-trip and works even before the singleton is initialized.

Covers: IDEWorkbenchPlugin, NavigatorPlugin, WorkbenchNavigatorPlugin, QuickSearchActivator, RefactoringUIPlugin, RefactoringCorePlugin, SearchPlugin, SearchCorePlugin, EditorsPlugin.