### PR TITLE
Modernize remaining getDefault().getLog() log sites

### DIFF
--- a/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/views/markers/internal/ProjectEncodingMarkerResolutionGenerator.java
+++ b/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/views/markers/internal/ProjectEncodingMarkerResolutionGenerator.java
@@ -25,6 +25,7 @@ import org.eclipse.core.resources.IWorkspace;
 import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.resources.WorkspaceJob;
 import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.ILog;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Status;
@@ -35,7 +36,6 @@ import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.ui.IMarkerResolution;
 import org.eclipse.ui.IMarkerResolutionGenerator2;
-import org.eclipse.ui.internal.UIPlugin;
 import org.eclipse.ui.internal.ide.IDEWorkbenchPlugin;
 import org.eclipse.ui.views.markers.WorkbenchMarkerResolution;
 
@@ -43,7 +43,6 @@ import org.eclipse.ui.views.markers.WorkbenchMarkerResolution;
  * Provides a resolution for warning markers on projects without an explicit
  * encoding setting.
  */
-@SuppressWarnings("restriction")
 public class ProjectEncodingMarkerResolutionGenerator implements IMarkerResolutionGenerator2 {
 
 	@Override
@@ -54,7 +53,7 @@ public class ProjectEncodingMarkerResolutionGenerator implements IMarkerResoluti
 			IMarkerResolution[] resolutions = { new ExplicitEncodingResolution(defaultCharset) };
 			return resolutions;
 		} catch (CoreException e) {
-			UIPlugin.getDefault().getLog().log(e.getStatus());
+			ILog.of(ProjectEncodingMarkerResolutionGenerator.class).log(e.getStatus());
 			return new IMarkerResolution[0];
 		}
 	}
@@ -117,7 +116,7 @@ public class ProjectEncodingMarkerResolutionGenerator implements IMarkerResoluti
 					try {
 						charsetManager.setCharsetFor(project.getFullPath(), charset);
 					} catch (CoreException e) {
-						UIPlugin.getDefault().getLog().log(e.getStatus());
+						ILog.of(ProjectEncodingMarkerResolutionGenerator.class).log(e.getStatus());
 					}
 				}
 			}

--- a/bundles/org.eclipse.ui.navigator/src/org/eclipse/ui/internal/navigator/NavigatorPlugin.java
+++ b/bundles/org.eclipse.ui.navigator/src/org/eclipse/ui/internal/navigator/NavigatorPlugin.java
@@ -181,7 +181,6 @@ public class NavigatorPlugin extends AbstractUIPlugin {
 	 * Record a status against this plugin's log.
 	 */
 	public static void log(IStatus aStatus) {
-		//getDefault().getLog().log(aStatus);
 		logJob.log(aStatus);
 		logJob.schedule(LOG_DELAY);
 	}

--- a/bundles/org.eclipse.ui/src/org/eclipse/ui/internal/UIPreferenceInitializer.java
+++ b/bundles/org.eclipse.ui/src/org/eclipse/ui/internal/UIPreferenceInitializer.java
@@ -18,6 +18,7 @@
  *******************************************************************************/
 package org.eclipse.ui.internal;
 
+import org.eclipse.core.runtime.ILog;
 import org.eclipse.core.runtime.Platform;
 import org.eclipse.core.runtime.preferences.AbstractPreferenceInitializer;
 import org.eclipse.core.runtime.preferences.DefaultScope;
@@ -156,7 +157,7 @@ public class UIPreferenceInitializer extends AbstractPreferenceInitializer {
 								.getSingleton());
 			}
 		} catch (BackingStoreException e) {
-			UIPlugin.getDefault().getLog().error(e.getLocalizedMessage(), e);
+			ILog.of(UIPreferenceInitializer.class).error(e.getLocalizedMessage(), e);
 		}
 
 		rootNode

--- a/examples/org.eclipse.ui.examples.javaeditor/Template Editor Example/org/eclipse/ui/examples/templateeditor/editors/TemplateEditorUI.java
+++ b/examples/org.eclipse.ui.examples.javaeditor/Template Editor Example/org/eclipse/ui/examples/templateeditor/editors/TemplateEditorUI.java
@@ -19,8 +19,7 @@ import java.io.IOException;
 
 import org.osgi.service.prefs.BackingStoreException;
 
-import org.eclipse.core.runtime.IStatus;
-import org.eclipse.core.runtime.Status;
+import org.eclipse.core.runtime.ILog;
 import org.eclipse.core.runtime.preferences.InstanceScope;
 
 import org.eclipse.jface.preference.IPreferenceStore;
@@ -77,7 +76,7 @@ public class TemplateEditorUI  {
 			try {
 				fStore.load();
 			} catch (IOException e) {
-				JavaEditorExamplePlugin.getDefault().getLog().log(new Status(IStatus.ERROR, "org.eclipse.ui.examples.javaeditor", IStatus.OK, "", e)); //$NON-NLS-1$ //$NON-NLS-2$
+				ILog.of(TemplateEditorUI.class).error("", e); //$NON-NLS-1$
 			}
 		}
 		return fStore;

--- a/tests/org.eclipse.core.filebuffers.tests/src/org/eclipse/core/filebuffers/tests/ResourceHelper.java
+++ b/tests/org.eclipse.core.filebuffers.tests/src/org/eclipse/core/filebuffers/tests/ResourceHelper.java
@@ -18,6 +18,7 @@ import java.io.File;
 import java.io.InputStream;
 
 import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.ILog;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.NullProgressMonitor;
@@ -74,7 +75,7 @@ public class ResourceHelper {
 				i= MAX_RETRY;
 			} catch (CoreException x) {
 				if (i == MAX_RETRY - 1) {
-					FileBuffersTestPlugin.getDefault().getLog().log(x.getStatus());
+					ILog.of(ResourceHelper.class).log(x.getStatus());
 //					throw x;
 				}
 				try {

--- a/tests/org.eclipse.ltk.ui.refactoring.tests/src/org/eclipse/ltk/ui/refactoring/tests/RefactoringUITestPlugin.java
+++ b/tests/org.eclipse.ltk.ui.refactoring.tests/src/org/eclipse/ltk/ui/refactoring/tests/RefactoringUITestPlugin.java
@@ -13,6 +13,7 @@
  *******************************************************************************/
 package org.eclipse.ltk.ui.refactoring.tests;
 
+import org.eclipse.core.runtime.ILog;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Status;
 
@@ -35,7 +36,7 @@ public class RefactoringUITestPlugin extends AbstractUIPlugin {
 	}
 
 	public static void log(IStatus status) {
-		getDefault().getLog().log(status);
+		ILog.get().log(status);
 	}
 
 	public static void log(Throwable e) {


### PR DESCRIPTION
## Summary

Follow-up to logging API modernization. Replaces remaining `Plugin.getDefault().getLog().log(new Status(...))` and `Plugin.getDefault().getLog().log(status)` call sites with `ILog.of(Class)` / `ILog.get()`:

- `TemplateEditorUI` (`org.eclipse.ui.examples.javaeditor`) — collapses the `new Status(...)` construction into `ILog.of(...).error(msg, t)`.
- `UIPreferenceInitializer` (`org.eclipse.ui`) — drops the `UIPlugin.getDefault()` round-trip.
- `ProjectEncodingMarkerResolutionGenerator` (`org.eclipse.ui.ide`) — class lives in `org.eclipse.ui.ide` but previously logged via `UIPlugin` (`org.eclipse.ui`); `ILog.of(...)` now routes to the bundle the class lives in.
- `ResourceHelper` (`org.eclipse.core.filebuffers.tests`) — drops the activator lookup.
- `RefactoringUITestPlugin` (`org.eclipse.ltk.ui.refactoring.tests`) — static `log(IStatus)` helper now uses `ILog.get()`, matching the convention from f75764e0f0 / e2f30f7457.

The workbench bundle (`org.eclipse.ui.workbench`) is intentionally deferred until the `org.eclipse.ui` vs `org.eclipse.ui.workbench` plug-in id question is resolved.

## Test plan

- [ ] `mvn clean verify -pl :org.eclipse.core.filebuffers.tests -Pbuild-individual-bundles`
- [ ] `mvn clean verify -pl :org.eclipse.ltk.ui.refactoring.tests -Pbuild-individual-bundles`
- [ ] CI runs green for `org.eclipse.ui`, `org.eclipse.ui.ide`, and the javaeditor example.