### PR TITLE
Use Status.error factory in e4.ui.progress and ide.application

### DIFF
--- a/bundles/org.eclipse.e4.ui.progress/src/org/eclipse/e4/ui/progress/internal/ProgressManagerUtil.java
+++ b/bundles/org.eclipse.e4.ui.progress/src/org/eclipse/e4/ui/progress/internal/ProgressManagerUtil.java
@@ -26,7 +26,6 @@ import org.eclipse.e4.ui.model.application.ui.basic.MPart;
 import org.eclipse.e4.ui.model.application.ui.basic.MWindow;
 import org.eclipse.e4.ui.progress.IProgressConstants;
 import org.eclipse.e4.ui.progress.IProgressService;
-import org.eclipse.e4.ui.progress.internal.legacy.StatusUtil;
 import org.eclipse.e4.ui.workbench.modeling.EPartService;
 import org.eclipse.e4.ui.workbench.modeling.EPartService.PartState;
 import org.eclipse.jface.viewers.Viewer;
@@ -102,9 +101,8 @@ public class ProgressManagerUtil {
 	 * @return IStatus
 	 */
 	static IStatus exceptionStatus(Throwable exception) {
-		return StatusUtil.newStatus(IStatus.ERROR,
-				exception.getMessage() == null ? "" : exception.getMessage(), //$NON-NLS-1$
-				exception);
+		Throwable cause = exception.getCause() != null ? exception.getCause() : exception;
+		return Status.error(exception.getMessage() == null ? "" : exception.getMessage(), cause); //$NON-NLS-1$
 	}
 
 	/**

--- a/bundles/org.eclipse.ui.ide.application/src/org/eclipse/ui/internal/ide/application/IDEWorkbenchAdvisor.java
+++ b/bundles/org.eclipse.ui.ide.application/src/org/eclipse/ui/internal/ide/application/IDEWorkbenchAdvisor.java
@@ -82,7 +82,6 @@ import org.eclipse.ui.internal.ide.IDEWorkbenchActivityHelper;
 import org.eclipse.ui.internal.ide.IDEWorkbenchErrorHandler;
 import org.eclipse.ui.internal.ide.IDEWorkbenchMessages;
 import org.eclipse.ui.internal.ide.IDEWorkbenchPlugin;
-import org.eclipse.ui.internal.ide.StatusUtil;
 import org.eclipse.ui.internal.ide.undo.WorkspaceUndoMonitor;
 import org.eclipse.ui.internal.progress.ProgressMonitorJobsDialog;
 import org.eclipse.ui.progress.IProgressService;
@@ -253,8 +252,7 @@ public class IDEWorkbenchAdvisor extends WorkbenchAdvisor {
 		@Override
 		public void accept(Error allocationStack) {
 			IDEWorkbenchPlugin.log(null,
-					StatusUtil.newStatus(IStatus.ERROR, "Not properly disposed SWT resource", //$NON-NLS-1$
-							allocationStack));
+					Status.error("Not properly disposed SWT resource", allocationStack)); //$NON-NLS-1$
 		}
 
 	}


### PR DESCRIPTION
## Summary

Follow-up to the StatusUtil cleanup started in PR #3906 (org.eclipse.ui.ide). Two small, self-contained sites that do not touch the workbench bundle (still deferred pending the `org.eclipse.ui` vs `org.eclipse.ui.workbench` plug-in id decision):

- **`ProgressManagerUtil#exceptionStatus`** (`org.eclipse.e4.ui.progress`) — replaces the legacy `StatusUtil.newStatus(...)` call with `Status.error(message, throwable)`, inlining the `StatusUtil.getCause()` unwrap so the attached throwable is unchanged. The sibling `logException` already uses `Status.error` and `ILog.of(ProgressManagerUtil.class)` — this aligns `exceptionStatus` with the same factory style. The legacy `StatusUtil` class is kept because other callers still use its `getCause` / `getLocalizedMessage` helpers.

- **`IDENonDisposedReporter` in `IDEWorkbenchAdvisor`** (`org.eclipse.ui.ide.application`) — replaces the cross-bundle `org.eclipse.ui.internal.ide.StatusUtil.newStatus(IStatus.ERROR, ...)` with `Status.error(message, throwable)`. Behavior change noted: previously logged under `"org.eclipse.ui.ide"` (IDE_WORKBENCH constant in the called StatusUtil); with the factory the plug-in id is inferred from the calling class' bundle, so the status now appears under `"org.eclipse.ui.ide.application"` — the bundle that actually emits the SWT-leak report.

## Test plan

- [ ] `mvn clean verify -pl :org.eclipse.e4.ui.progress -Pbuild-individual-bundles`
- [ ] CI runs green for `org.eclipse.ui.ide.application`.