### PR TITLE
QuickAccessDialog: render filter as native search field

### DIFF
--- a/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/quickaccess/QuickAccessDialog.java
+++ b/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/quickaccess/QuickAccessDialog.java
@@ -229,8 +229,13 @@ public class QuickAccessDialog extends PopupDialog {
 	@Override
 	protected Control createTitleControl(Composite parent) {
 		parent.getShell().setText(QuickAccessMessages.QuickAccessContents_QuickAccess);
-		filterText = new Text(parent, SWT.NONE);
+		filterText = new Text(parent, SWT.SEARCH | SWT.ICON_SEARCH | SWT.ICON_CANCEL);
 		GridDataFactory.fillDefaults().align(SWT.FILL, SWT.CENTER).grab(true, false).applyTo(filterText);
+		filterText.addListener(SWT.DefaultSelection, event -> {
+			if (event.detail == SWT.ICON_CANCEL) {
+				filterText.setText(""); //$NON-NLS-1$
+			}
+		});
 		contents.hookFilterText(filterText);
 		filterText.addKeyListener(getKeyAdapter());
 		return filterText;


### PR DESCRIPTION
Use SWT.SEARCH | SWT.ICON_SEARCH | SWT.ICON_CANCEL for the filter text so the dialog shows the platform magnifier icon and a cancel (X) button to clear the query, matching user expectations for a command palette.