### PR TITLE
Better button styling in workspace selection dialog

### DIFF
--- a/bundles/org.eclipse.ui.ide.application/src/org/eclipse/ui/internal/ide/application/IDEApplication.java
+++ b/bundles/org.eclipse.ui.ide.application/src/org/eclipse/ui/internal/ide/application/IDEApplication.java
@@ -58,6 +58,7 @@ import org.eclipse.osgi.util.NLS;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.graphics.Color;
 import org.eclipse.swt.layout.FillLayout;
+import org.eclipse.swt.widgets.Button;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.Display;
@@ -945,6 +946,15 @@ public class IDEApplication implements IApplication, IExecutableExtension {
 	}
 
 	private void applyStylesRecursive(Control control, Color bg, Color fg, Color linkColor) {
+		if (control instanceof Button button) {
+			// On Windows, check buttons need an explicit background; otherwise they
+			// appear white because the parent background is not inherited.
+			if (Platform.OS_WIN32.equals(Platform.getOS()) && (button.getStyle() & SWT.CHECK) != 0) {
+				button.setBackground(bg);
+			}
+			// Leave other buttons unstyled so the native dark appearance is used
+			return;
+		}
 		control.setBackground(bg);
 		if (control instanceof Link link) {
 			link.setLinkForeground(linkColor);


### PR DESCRIPTION
The workspace selection dialog at IDE startup mimics dark-theme styling because the ThemeEngine is not yet available. On macOS this produces buttons that look different from the buttons on other dialogs (e.g. `File > Switch Workspace`).

This change skips the hard-coded dark styling for `Button` controls only, so they get the native macOS dark appearance. All other widgets (Shell, Composite, Label, Link) continue to be styled as before.

On Windows the check button needs styling otherwise it appears white.