### PR TITLE
Remove unused ExpandableComposite styling in IDEApplication

### DIFF
--- a/bundles/org.eclipse.ui.ide.application/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.ui.ide.application/META-INF/MANIFEST.MF
@@ -18,7 +18,6 @@ Require-Bundle: org.eclipse.ui.ide;bundle-version="[3.21.0,4.0.0)",
  org.eclipse.e4.core.di.extensions,
  org.eclipse.e4.core.services;bundle-version="2.4.0",
  org.eclipse.e4.core.contexts;bundle-version="[1.12.0,2.0.0)",
- org.eclipse.ui.forms,
  org.eclipse.urischeme;bundle-version="[1.3.0,2.0.0)",
  org.eclipse.e4.ui.di
 Export-Package: org.eclipse.ui.internal.ide.application;x-internal:=true,

--- a/bundles/org.eclipse.ui.ide.application/src/org/eclipse/ui/internal/ide/application/IDEApplication.java
+++ b/bundles/org.eclipse.ui.ide.application/src/org/eclipse/ui/internal/ide/application/IDEApplication.java
@@ -66,7 +66,6 @@ import org.eclipse.swt.widgets.Listener;
 import org.eclipse.swt.widgets.Shell;
 import org.eclipse.ui.IWorkbench;
 import org.eclipse.ui.PlatformUI;
-import org.eclipse.ui.forms.widgets.ExpandableComposite;
 import org.eclipse.ui.internal.Workbench;
 import org.eclipse.ui.internal.WorkbenchPlugin;
 import org.eclipse.ui.internal.WorkspaceLock;
@@ -953,11 +952,6 @@ public class IDEApplication implements IApplication, IExecutableExtension {
 
 		}
 
-		if (control instanceof ExpandableComposite expandable) {
-			expandable.setTitleBarForeground(fg);
-			expandable.setToggleColor(fg);
-			expandable.setActiveToggleColor(fg);
-		}
 		if (control instanceof Composite composite) {
 			for (Control child : composite.getChildren()) {
 				applyStylesRecursive(child, bg, fg, linkColor);


### PR DESCRIPTION
## Summary

Neither `ChooseWorkspaceDialog` nor `ChooseWorkspaceWithSettingsDialog` uses `ExpandableComposite` any longer, so the `ExpandableComposite` branch in `IDEApplication#applyStylesRecursive` (used for early dark-theme styling of the workspace selection dialog) is dead code.

- Drop the `ExpandableComposite` styling branch
- Drop the unused `org.eclipse.ui.forms.widgets.ExpandableComposite` import
- Drop the `org.eclipse.ui.forms` dependency from `MANIFEST.MF` (no other usages in this bundle)

## Test plan

- [ ] Start the IDE with a dark theme, confirm the workspace selection dialog still looks correct (background, labels, links, buttons).
- [ ] Start the IDE with a light theme, confirm nothing changed.
- [ ] `org.eclipse.ui.ide.application` builds cleanly with `-Pbuild-individual-bundles`.