### PR TITLE
Use ILog.of(Class) instead of Platform.getLog(Class)

### DIFF
--- a/bundles/org.eclipse.e4.ui.css.swt.theme/src/org/eclipse/e4/ui/css/swt/internal/theme/ThemeEngine.java
+++ b/bundles/org.eclipse.e4.ui.css.swt.theme/src/org/eclipse/e4/ui/css/swt/internal/theme/ThemeEngine.java
@@ -37,6 +37,7 @@ import org.eclipse.core.runtime.IConfigurationElement;
 import org.eclipse.core.runtime.IExtension;
 import org.eclipse.core.runtime.IExtensionPoint;
 import org.eclipse.core.runtime.IExtensionRegistry;
+import org.eclipse.core.runtime.ILog;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.Platform;
 import org.eclipse.core.runtime.RegistryFactory;
@@ -431,7 +432,7 @@ public class ThemeEngine implements IThemeEngine {
 			}
 		}
 		// Theme not found (e.g. it was uninstalled); fall back to default
-		Platform.getLog(ThemeEngine.class)
+		ILog.of(ThemeEngine.class)
 				.warn("Theme '" + themeId + "' not found; falling back to default theme."); //$NON-NLS-1$ //$NON-NLS-2$
 		if (!E4_DEFAULT_THEME_ID.equals(themeId)) {
 			setTheme(E4_DEFAULT_THEME_ID, restore);

--- a/bundles/org.eclipse.ui.genericeditor/src/org/eclipse/ui/internal/genericeditor/preferences/GenericEditorPreferencePage.java
+++ b/bundles/org.eclipse.ui.genericeditor/src/org/eclipse/ui/internal/genericeditor/preferences/GenericEditorPreferencePage.java
@@ -18,7 +18,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.eclipse.core.runtime.Platform;
+import org.eclipse.core.runtime.ILog;
 import org.eclipse.core.runtime.preferences.PreferenceMetadata;
 import org.eclipse.jface.dialogs.Dialog;
 import org.eclipse.jface.dialogs.IMessageProvider;
@@ -75,7 +75,7 @@ public class GenericEditorPreferencePage extends PreferencePage implements IWork
 			try {
 				scopedStore.save();
 			} catch (IOException e) {
-				Platform.getLog(getClass()).error("Cannot to save preferences.", e); //$NON-NLS-1$
+				ILog.of(getClass()).error("Cannot to save preferences.", e); //$NON-NLS-1$
 				return false;
 			}
 		}

--- a/bundles/org.eclipse.ui.genericeditor/src/org/eclipse/ui/internal/genericeditor/preferences/GenericEditorPreferencePage.java
+++ b/bundles/org.eclipse.ui.genericeditor/src/org/eclipse/ui/internal/genericeditor/preferences/GenericEditorPreferencePage.java
@@ -75,7 +75,7 @@ public class GenericEditorPreferencePage extends PreferencePage implements IWork
 			try {
 				scopedStore.save();
 			} catch (IOException e) {
-				ILog.of(getClass()).error("Cannot to save preferences.", e); //$NON-NLS-1$
+				ILog.of(getClass()).error("Cannot save preferences.", e); //$NON-NLS-1$
 				return false;
 			}
 		}


### PR DESCRIPTION
## Summary
- Replace the two remaining `Platform.getLog(Class)` call sites with the equivalent `ILog.of(Class)` (in `ThemeEngine` and `GenericEditorPreferencePage`), aligning with the convention used after the recent logging cleanup passes. Functionally identical (both return the bundle's `ILog` without a round-trip through the Activator).
- Fix a small typo in the `GenericEditorPreferencePage` log message: *"Cannot to save preferences."* -> *"Cannot save preferences."*

## Test plan
- [x] `mvn clean compile -pl :org.eclipse.e4.ui.css.swt.theme,:org.eclipse.ui.genericeditor -Pbuild-individual-bundles` -> BUILD SUCCESS
- [ ] CI green