### PR TITLE
Read splash shell title directly from the product in IDEApplication

### DIFF
--- a/bundles/org.eclipse.ui.ide.application/src/org/eclipse/ui/internal/ide/application/IDEApplication.java
+++ b/bundles/org.eclipse.ui.ide.application/src/org/eclipse/ui/internal/ide/application/IDEApplication.java
@@ -166,11 +166,13 @@ public class IDEApplication implements IApplication, IExecutableExtension {
 			// look and see if there's a splash shell we can parent off of
 			Shell shell = WorkbenchPlugin.getSplashShell(display);
 			if (shell != null) {
-				// should should set the icon and message for this shell to be the
-				// same as the chooser dialog - this will be the guy that lives in
-				// the task bar and without these calls you'd have the default icon
-				// with no message.
-				shell.setText(ChooseWorkspaceDialog.getWindowTitle());
+				// Set the taskbar title and icon for the splash shell. The title
+				// is taken from the configured product; if no product is set, the
+				// launcher's default title is kept.
+				IProduct product = Platform.getProduct();
+				if (product != null && product.getName() != null) {
+					shell.setText(product.getName());
+				}
 				shell.setImages(Window.getDefaultImages());
 			}
 


### PR DESCRIPTION
## Summary

`IDEApplication.start` used `ChooseWorkspaceDialog.getWindowTitle()` to set the splash shell's taskbar title. That helper belongs to the workspace chooser dialog: it returns `Platform.getProduct().getName()` with a fallback to `IDEWorkbenchMessages.ChooseWorkspaceDialog_defaultProductName`, an NLS string tied to the chooser dialog's presentation.

The splash shell is owned by the application, not the chooser dialog, and the dialog's NLS fallback is not appropriate for a splash taskbar entry. This change reads the product name directly in `IDEApplication`. When no product is configured, the launcher's default title is kept.

`ChooseWorkspaceDialog.getWindowTitle()` is kept for use inside the chooser dialog itself.

## Behavior

For Eclipse IDE products, which always have a product name, the taskbar text on the splash shell is unchanged. For applications without a configured product, the launcher's default title is preserved instead of being replaced by a chooser-dialog placeholder.

## Test plan

- [ ] Start an Eclipse IDE build; splash taskbar entry shows the product name as before.
- [ ] Start a minimal RCP application without a configured product; launcher's default title remains.
- [ ] Workspace chooser dialog title is unaffected (still uses `ChooseWorkspaceDialog.getWindowTitle()` internally).