### PR TITLE
PreferenceDialog: render filter as native search field

### DIFF
--- a/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/dialogs/FilteredPreferenceDialog.java
+++ b/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/dialogs/FilteredPreferenceDialog.java
@@ -119,6 +119,18 @@ public abstract class FilteredPreferenceDialog extends PreferenceDialog implemen
 			super(parent, treeStyle, filter, true, true);
 		}
 
+		@Override
+		protected Text doCreateFilterText(Composite parent) {
+			return new Text(parent, SWT.SINGLE | SWT.BORDER | SWT.SEARCH | SWT.ICON_SEARCH | SWT.ICON_CANCEL);
+		}
+
+		@Override
+		public void setInitialText(String text) {
+			if (filterText != null && !filterText.isDisposed()) {
+				filterText.setMessage(text != null ? text : ""); //$NON-NLS-1$
+			}
+		}
+
 		/**
 		 * Add an additional, optional filter to the viewer. If the filter text is
 		 * cleared, this filter will be removed from the TreeViewer.


### PR DESCRIPTION
## Summary
- Use `SWT.SEARCH | SWT.ICON_SEARCH | SWT.ICON_CANCEL` for the filter field in `FilteredPreferenceDialog`'s `PreferenceFilteredTree`, so it is rendered as a native search field with magnifier and cancel icons.
- Override `setInitialText` to expose the filter hint via `Text#setMessage` only, rather than inserting it as real field content. The dialog auto-focuses the filter field on open, which made the old initial-text fallback behave poorly: users saw the hint as actual text and had to delete it before typing.

## Test plan
- [x] Open Window > Preferences and confirm the filter field renders with a magnifier icon and a cancel (x) icon once text is typed.
- [x] Verify the "type filter text" hint is shown as a placeholder and disappears when focus/typing begins, without needing to be deleted.
- [x] Filter by typing; verify the cancel icon clears the filter and restores the full tree.