### PR TITLE
Use ILog.of(Class) in WorkbenchPreferenceInitializer

### DIFF
--- a/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/WorkbenchPreferenceInitializer.java
+++ b/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/WorkbenchPreferenceInitializer.java
@@ -22,9 +22,8 @@
  *******************************************************************************/
 package org.eclipse.ui.internal;
 
-import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.ILog;
 import org.eclipse.core.runtime.Platform;
-import org.eclipse.core.runtime.Status;
 import org.eclipse.core.runtime.preferences.AbstractPreferenceInitializer;
 import org.eclipse.core.runtime.preferences.DefaultScope;
 import org.eclipse.core.runtime.preferences.IEclipsePreferences;
@@ -143,9 +142,7 @@ public class WorkbenchPreferenceInitializer extends AbstractPreferenceInitialize
 						.addPreferenceChangeListener(PlatformUIPreferenceListener.getSingleton());
 			}
 		} catch (BackingStoreException e) {
-			IStatus status = new Status(IStatus.ERROR, WorkbenchPlugin.getDefault().getBundle().getSymbolicName(),
-					IStatus.ERROR, e.getLocalizedMessage(), e);
-			WorkbenchPlugin.getDefault().getLog().log(status);
+			ILog.of(WorkbenchPreferenceInitializer.class).error(e.getLocalizedMessage(), e);
 		}
 
 		LargeFileLimitsPreferenceHandler.setDefaults();


### PR DESCRIPTION
## Summary
- Replace `WorkbenchPlugin.getDefault().getLog().log(new Status(...))` with `ILog.of(WorkbenchPreferenceInitializer.class).error(...)`. Drops the Activator round-trip and the explicit Status allocation; the log channel stays in the same bundle.

## Test plan
- [x] `mvn clean compile -pl :org.eclipse.ui.workbench -Pbuild-individual-bundles` -> BUILD SUCCESS
- [ ] CI green