### PR TITLE
Avoid flashing shutdown dialog when save is fast

### DIFF
--- a/bundles/org.eclipse.ui.ide.application/src/org/eclipse/ui/internal/ide/application/IDEWorkbenchAdvisor.java
+++ b/bundles/org.eclipse.ui.ide.application/src/org/eclipse/ui/internal/ide/application/IDEWorkbenchAdvisor.java
@@ -61,6 +61,7 @@ import org.eclipse.swt.custom.BusyIndicator;
 import org.eclipse.swt.graphics.Resource;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Listener;
+import org.eclipse.swt.widgets.Shell;
 import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.application.IWorkbenchConfigurer;
 import org.eclipse.ui.application.IWorkbenchWindowConfigurer;
@@ -79,7 +80,6 @@ import org.eclipse.ui.internal.ide.IDEWorkbenchErrorHandler;
 import org.eclipse.ui.internal.ide.IDEWorkbenchMessages;
 import org.eclipse.ui.internal.ide.IDEWorkbenchPlugin;
 import org.eclipse.ui.internal.ide.undo.WorkspaceUndoMonitor;
-import org.eclipse.ui.internal.progress.ProgressManagerUtil;
 import org.eclipse.ui.internal.progress.ProgressMonitorJobsDialog;
 import org.eclipse.ui.progress.IProgressService;
 import org.eclipse.ui.statushandlers.AbstractStatusHandler;
@@ -498,12 +498,12 @@ public class IDEWorkbenchAdvisor extends WorkbenchAdvisor {
 
 		final Display display = Display.getCurrent();
 		final int longOperationTime = savedLongOperationTime;
-		final Runnable openDialog = () -> {
-			if (ProgressManagerUtil.safeToOpen(dialog, null)) {
+		final Runnable openDialogLater = () -> {
+			if (!display.isDisposed() && !hasModalShell(display)) {
 				dialog.open();
 			}
 		};
-		display.timerExec(longOperationTime, openDialog);
+		display.timerExec(longOperationTime, openDialogLater);
 
 		try {
 			BusyIndicator.showWhile(display, () -> {
@@ -518,7 +518,8 @@ public class IDEWorkbenchAdvisor extends WorkbenchAdvisor {
 				}
 			});
 		} finally {
-			display.timerExec(-1, openDialog);
+			// Cancel openDialogLater if it is still pending; no-op if it already ran.
+			display.timerExec(-1, openDialogLater);
 		}
 
 		if (!status.isOK()) {
@@ -526,6 +527,16 @@ public class IDEWorkbenchAdvisor extends WorkbenchAdvisor {
 					IStatus.ERROR | IStatus.WARNING);
 			IDEWorkbenchPlugin.log(IDEWorkbenchMessages.ProblemsSavingWorkspace, status);
 		}
+	}
+
+	private static boolean hasModalShell(Display display) {
+		final int modal = SWT.APPLICATION_MODAL | SWT.SYSTEM_MODAL | SWT.PRIMARY_MODAL;
+		for (Shell shell : display.getShells()) {
+			if (!shell.isDisposed() && shell.isVisible() && (shell.getStyle() & modal) != 0) {
+				return true;
+			}
+		}
+		return false;
 	}
 
 	@Override

--- a/bundles/org.eclipse.ui.ide.application/src/org/eclipse/ui/internal/ide/application/IDEWorkbenchAdvisor.java
+++ b/bundles/org.eclipse.ui.ide.application/src/org/eclipse/ui/internal/ide/application/IDEWorkbenchAdvisor.java
@@ -153,6 +153,13 @@ public class IDEWorkbenchAdvisor extends WorkbenchAdvisor {
 	 */
 	private final int workspaceWaitDelay;
 
+	/**
+	 * Captured during {@link #initialize(IWorkbenchConfigurer)} so
+	 * {@link #disconnectFromWorkspace()} does not have to reach through
+	 * {@link PlatformUI#getWorkbench()} after the workbench has been shut down.
+	 */
+	private int savedLongOperationTime;
+
 	private final Listener closeListener = event -> {
 		boolean doExit = IDEWorkbenchWindowAdvisor.promptOnExit(null);
 		event.doit = doExit;
@@ -190,6 +197,8 @@ public class IDEWorkbenchAdvisor extends WorkbenchAdvisor {
 
 	@Override
 	public void initialize(IWorkbenchConfigurer configurer) {
+
+		savedLongOperationTime = configurer.getWorkbench().getProgressService().getLongOperationTime();
 
 		PluginActionBuilder.setAllowIdeLogging(true);
 
@@ -487,8 +496,8 @@ public class IDEWorkbenchAdvisor extends WorkbenchAdvisor {
 			}
 		};
 
-		final Display display = PlatformUI.getWorkbench().getDisplay();
-		final int longOperationTime = PlatformUI.getWorkbench().getProgressService().getLongOperationTime();
+		final Display display = Display.getCurrent();
+		final int longOperationTime = savedLongOperationTime;
 		final Runnable openDialog = () -> {
 			if (ProgressManagerUtil.safeToOpen(dialog, null)) {
 				dialog.open();

--- a/bundles/org.eclipse.ui.ide.application/src/org/eclipse/ui/internal/ide/application/IDEWorkbenchAdvisor.java
+++ b/bundles/org.eclipse.ui.ide.application/src/org/eclipse/ui/internal/ide/application/IDEWorkbenchAdvisor.java
@@ -42,7 +42,6 @@ import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.MultiStatus;
 import org.eclipse.core.runtime.Platform;
-import org.eclipse.core.runtime.ProgressMonitorWrapper;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.core.runtime.jobs.ISchedulingRule;
 import org.eclipse.core.runtime.jobs.Job;
@@ -58,13 +57,10 @@ import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.jface.util.Policy;
 import org.eclipse.jface.window.Window;
 import org.eclipse.swt.SWT;
-import org.eclipse.swt.events.SelectionAdapter;
-import org.eclipse.swt.events.SelectionEvent;
+import org.eclipse.swt.custom.BusyIndicator;
 import org.eclipse.swt.graphics.Resource;
-import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Listener;
-import org.eclipse.swt.widgets.Shell;
 import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.application.IWorkbenchConfigurer;
 import org.eclipse.ui.application.IWorkbenchWindowConfigurer;
@@ -83,6 +79,7 @@ import org.eclipse.ui.internal.ide.IDEWorkbenchErrorHandler;
 import org.eclipse.ui.internal.ide.IDEWorkbenchMessages;
 import org.eclipse.ui.internal.ide.IDEWorkbenchPlugin;
 import org.eclipse.ui.internal.ide.undo.WorkspaceUndoMonitor;
+import org.eclipse.ui.internal.progress.ProgressManagerUtil;
 import org.eclipse.ui.internal.progress.ProgressMonitorJobsDialog;
 import org.eclipse.ui.progress.IProgressService;
 import org.eclipse.ui.statushandlers.AbstractStatusHandler;
@@ -464,119 +461,61 @@ public class IDEWorkbenchAdvisor extends WorkbenchAdvisor {
 		}
 	}
 
-	protected static class CancelableProgressMonitorWrapper extends
-			ProgressMonitorWrapper {
-		private double total = 0;
-		private final ProgressMonitorJobsDialog dialog;
-
-		CancelableProgressMonitorWrapper(IProgressMonitor monitor,
-				ProgressMonitorJobsDialog dialog) {
-			super(monitor);
-			this.dialog = dialog;
-		}
-
-		@Override
-		public void internalWorked(double work) {
-			super.internalWorked(work);
-			total += work;
-			updateProgressDetails();
-		}
-
-		@Override
-		public void worked(int work) {
-			super.worked(work);
-			total += work;
-			updateProgressDetails();
-		}
-
-		@Override
-		public void beginTask(String name, int totalWork) {
-			super.beginTask(name, totalWork);
-			subTask(IDEWorkbenchMessages.IDEWorkbenchAdvisor_preHistoryCompaction);
-		}
-
-		private void updateProgressDetails() {
-			if (!isCanceled() && Math.abs(total - 4.0) < 0.0001 /* right before history compacting */) {
-				subTask(IDEWorkbenchMessages.IDEWorkbenchAdvisor_cancelHistoryPruning);
-				dialog.setCancelable(true);
-			}
-			if (Math.abs(total - 5.0) < 0.0001 /* history compacting finished */) {
-				subTask(IDEWorkbenchMessages.IDEWorkbenchAdvisor_postHistoryCompaction);
-				dialog.setCancelable(false);
-			}
-		}
-	}
-
-	protected static class CancelableProgressMonitorJobsDialog extends
-			ProgressMonitorJobsDialog {
-
-		public CancelableProgressMonitorJobsDialog(Shell parent) {
-			super(parent);
-		}
-
-		@Override
-		protected void createButtonsForButtonBar(Composite parent) {
-			super.createButtonsForButtonBar(parent);
-			registerCancelButtonListener();
-		}
-
-		public void registerCancelButtonListener() {
-			cancel.addSelectionListener(new SelectionAdapter() {
-				@Override
-				public void widgetSelected(SelectionEvent e) {
-					subTaskLabel.setText(""); //$NON-NLS-1$
-				}
-			});
-		}
-	}
-
 	/**
 	 * Disconnect from the core workspace.
+	 *
+	 * Shows the progress dialog only if the save operation takes longer than
+	 * the {@link IProgressService#getLongOperationTime() long operation time};
+	 * otherwise a busy cursor is shown while the save runs on a worker thread.
+	 * This avoids a flashing dialog for fast shutdowns.
 	 *
 	 * Locks workspace in a background thread, should not be called while
 	 * holding any workspace locks.
 	 */
 	protected void disconnectFromWorkspace() {
-		// save the workspace
 		final MultiStatus status = new MultiStatus(IDEWorkbenchPlugin.IDE_WORKBENCH, 1,
 				IDEWorkbenchMessages.ProblemSavingWorkbench);
+
+		final ProgressMonitorJobsDialog dialog = new ProgressMonitorJobsDialog(null);
+		dialog.setOpenOnRun(false);
+
+		IRunnableWithProgress runnable = monitor -> {
+			try {
+				status.merge(((Workspace) ResourcesPlugin.getWorkspace()).save(true, true, monitor));
+			} catch (CoreException e) {
+				status.merge(e.getStatus());
+			}
+		};
+
+		final Display display = PlatformUI.getWorkbench().getDisplay();
+		final int longOperationTime = PlatformUI.getWorkbench().getProgressService().getLongOperationTime();
+		final Runnable openDialog = () -> {
+			if (ProgressManagerUtil.safeToOpen(dialog, null)) {
+				dialog.open();
+			}
+		};
+		display.timerExec(longOperationTime, openDialog);
+
 		try {
-			final ProgressMonitorJobsDialog p = new CancelableProgressMonitorJobsDialog(
-					null);
-
-			final boolean applyPolicy = ResourcesPlugin.getWorkspace()
-					.getDescription().isApplyFileStatePolicy();
-
-			IRunnableWithProgress runnable = monitor -> {
+			BusyIndicator.showWhile(display, () -> {
 				try {
-					if (applyPolicy) {
-						monitor = new CancelableProgressMonitorWrapper(monitor, p);
-					}
-
-					status.merge(((Workspace) ResourcesPlugin.getWorkspace()).save(true, true, monitor));
-				} catch (CoreException e) {
-					status.merge(e.getStatus());
+					dialog.run(true, false, runnable);
+				} catch (InvocationTargetException e) {
+					status.merge(new Status(IStatus.ERROR, IDEWorkbenchPlugin.IDE_WORKBENCH, 1,
+							IDEWorkbenchMessages.InternalError, e.getTargetException()));
+				} catch (InterruptedException e) {
+					status.merge(new Status(IStatus.ERROR, IDEWorkbenchPlugin.IDE_WORKBENCH, 1,
+							IDEWorkbenchMessages.InternalError, e));
 				}
-			};
-
-			p.run(true, false, runnable);
-		} catch (InvocationTargetException e) {
-			status
-					.merge(new Status(IStatus.ERROR,
-							IDEWorkbenchPlugin.IDE_WORKBENCH, 1,
-							IDEWorkbenchMessages.InternalError, e
-									.getTargetException()));
-		} catch (InterruptedException e) {
-			status.merge(new Status(IStatus.ERROR,
-					IDEWorkbenchPlugin.IDE_WORKBENCH, 1,
-					IDEWorkbenchMessages.InternalError, e));
+			});
+		} finally {
+			display.timerExec(-1, openDialog);
 		}
+
 		if (!status.isOK()) {
-			ErrorDialog.openError(null,
-					IDEWorkbenchMessages.ProblemsSavingWorkspace, null, status,
+			ErrorDialog.openError(null, IDEWorkbenchMessages.ProblemsSavingWorkspace, null, status,
 					IStatus.ERROR | IStatus.WARNING);
-			IDEWorkbenchPlugin.log(
-					IDEWorkbenchMessages.ProblemsSavingWorkspace, status);
+			IDEWorkbenchPlugin.log(IDEWorkbenchMessages.ProblemsSavingWorkspace, status);
 		}
 	}
 

--- a/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/ide/IDEWorkbenchMessages.java
+++ b/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/ide/IDEWorkbenchMessages.java
@@ -37,9 +37,6 @@ public class IDEWorkbenchMessages extends NLS {
 	// package: org.eclipse.ui.ide
 
 	public static String IDEWorkbenchAdvisor_noPerspective;
-	public static String IDEWorkbenchAdvisor_cancelHistoryPruning;
-	public static String IDEWorkbenchAdvisor_preHistoryCompaction;
-	public static String IDEWorkbenchAdvisor_postHistoryCompaction;
 
 	public static String IDE_noFileEditorSelectedUserCanceled;
 	public static String IDE_noFileEditorFound;

--- a/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/ide/messages.properties
+++ b/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/ide/messages.properties
@@ -41,9 +41,6 @@
 # package: org.eclipse.ui.ide
 
 IDEWorkbenchAdvisor_noPerspective=No perspectives are open. To open a perspective, press this button:
-IDEWorkbenchAdvisor_cancelHistoryPruning=Cancel to skip compacting local history.
-IDEWorkbenchAdvisor_preHistoryCompaction=Saving workbench state.
-IDEWorkbenchAdvisor_postHistoryCompaction=Disconnecting from workspace.
 
 IDE_noFileEditorSelectedUserCanceled = No editor selected, operation canceled by user.
 IDE_noFileEditorFound = No editor found to edit the file resource.

--- a/tests/org.eclipse.ui.ide.application.tests/src/org/eclipse/ui/internal/ide/application/IDEWorkbenchAdvisorTest.java
+++ b/tests/org.eclipse.ui.ide.application.tests/src/org/eclipse/ui/internal/ide/application/IDEWorkbenchAdvisorTest.java
@@ -20,6 +20,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.Closeable;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
 
 import org.eclipse.core.resources.ISaveContext;
 import org.eclipse.core.resources.ISaveParticipant;
@@ -212,14 +213,16 @@ public class IDEWorkbenchAdvisorTest {
 	@Test
 	public void testShutdownWithSlowSave() throws CoreException {
 		try (SaveHook saveHook = new SaveHook()) {
-			// Exceeds the default IProgressService#getLongOperationTime (800ms),
-			// so the new code path schedules and opens the progress dialog.
-			final long sleepMillis = 1200L;
+			// Sleep duration is derived from the live IProgressService#getLongOperationTime()
+			// value in postStartup(), so the test exercises the delayed-open path even if
+			// the platform default ever changes.
+			final long sleepMarginMillis = 500L;
+			final AtomicLong sleepMillis = new AtomicLong();
 			workspace.addSaveParticipant(PLUGIN_ID + ".slow", new ISaveParticipant() {
 				@Override
 				public void saving(ISaveContext context) {
 					try {
-						Thread.sleep(sleepMillis);
+						Thread.sleep(sleepMillis.get());
 					} catch (InterruptedException e) {
 						Thread.currentThread().interrupt();
 					}
@@ -242,6 +245,9 @@ public class IDEWorkbenchAdvisorTest {
 					@Override
 					public void postStartup() {
 						super.postStartup();
+						long longOperationTime = PlatformUI.getWorkbench().getProgressService()
+								.getLongOperationTime();
+						sleepMillis.set(longOperationTime + sleepMarginMillis);
 						display.asyncExec(() -> PlatformUI.getWorkbench().close());
 					}
 				};

--- a/tests/org.eclipse.ui.ide.application.tests/src/org/eclipse/ui/internal/ide/application/IDEWorkbenchAdvisorTest.java
+++ b/tests/org.eclipse.ui.ide.application.tests/src/org/eclipse/ui/internal/ide/application/IDEWorkbenchAdvisorTest.java
@@ -41,6 +41,7 @@ public class IDEWorkbenchAdvisorTest {
 	private static final String PLUGIN_ID = "org.eclipse.ui.ide.application.tests";
 	private Display display = null;
 	private ISchedulingRule rule;
+	private final IWorkspace workspace = ResourcesPlugin.getWorkspace();
 
 	private static final class SaveHook implements ISaveParticipant, Closeable {
 		public ISaveContext saving = null;
@@ -197,6 +198,64 @@ public class IDEWorkbenchAdvisorTest {
 			assertEquals(expectedLogs, logs.get(), message);
 		} finally {
 			IDEWorkbenchPlugin.getDefault().getLog().removeLogListener(listener);
+		}
+	}
+
+	/**
+	 * Workbench shutdown should complete cleanly when the workspace save takes
+	 * longer than the progress service's long operation time. In that case the
+	 * progress dialog is expected to open after the delay, but the save must
+	 * still run to completion and the save hooks must fire.
+	 *
+	 * Regression test for issue 1269 (flashing shutdown dialog).
+	 */
+	@Test
+	public void testShutdownWithSlowSave() throws CoreException {
+		try (SaveHook saveHook = new SaveHook()) {
+			// Exceeds the default IProgressService#getLongOperationTime (800ms),
+			// so the new code path schedules and opens the progress dialog.
+			final long sleepMillis = 1200L;
+			workspace.addSaveParticipant(PLUGIN_ID + ".slow", new ISaveParticipant() {
+				@Override
+				public void saving(ISaveContext context) {
+					try {
+						Thread.sleep(sleepMillis);
+					} catch (InterruptedException e) {
+						Thread.currentThread().interrupt();
+					}
+				}
+
+				@Override
+				public void prepareToSave(ISaveContext context) {
+				}
+
+				@Override
+				public void doneSaving(ISaveContext context) {
+				}
+
+				@Override
+				public void rollback(ISaveContext context) {
+				}
+			});
+			try {
+				IDEWorkbenchAdvisor advisor = new IDEWorkbenchAdvisor() {
+					@Override
+					public void postStartup() {
+						super.postStartup();
+						display.asyncExec(() -> PlatformUI.getWorkbench().close());
+					}
+				};
+				int returnCode = PlatformUI.createAndRunWorkbench(display, advisor);
+				assertEquals(PlatformUI.RETURN_OK, returnCode);
+				dispatchDisplay();
+
+				assertNotNull(saveHook.prepareToSave);
+				assertNotNull(saveHook.saving);
+				assertNotNull(saveHook.doneSaving);
+				assertNull(saveHook.rollback);
+			} finally {
+				workspace.removeSaveParticipant(PLUGIN_ID + ".slow");
+			}
 		}
 	}
 


### PR DESCRIPTION
Fixes #1269. The IDE's shutdown save dialog currently pops up and vanishes in a blink on fast machines. This change replaces the eager `CancelableProgressMonitorJobsDialog` with a plain `ProgressMonitorJobsDialog` that opens only after `IProgressService#getLongOperationTime` has elapsed; fast shutdowns now just show a busy cursor, slow ones still show a real progress dialog.

The cancel path that went away was effectively broken anyway. Its button only cleared a sub-task label, and the `CancelableProgressMonitorWrapper` used hard-coded work-amount math (`Math.abs(total - 4.0)`) to toggle cancellation around history pruning, an assumption that had drifted out of sync with `SaveManager`. Removing it also drops three no-longer-referenced message keys.

A new `IDEWorkbenchAdvisorTest#testShutdownWithSlowSave` exercises the delayed-open path via a save participant that sleeps past the long-operation threshold, asserting that the save still completes and hooks fire.