### PR TITLE
Show filename in Quick Diff progress job label

### DIFF
--- a/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/texteditor/quickdiff/DocumentLineDiffer.java
+++ b/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/texteditor/quickdiff/DocumentLineDiffer.java
@@ -179,6 +179,8 @@ public class DocumentLineDiffer implements ILineDiffer, IDocumentListener, IAnno
 	private final List<IAnnotationModelListener> fAnnotationModelListeners= new ArrayList<>();
 	/** The job currently initializing the differ, or <code>null</code> if there is none. */
 	private Job fInitializationJob;
+	/** Optional display name (e.g. editor input name) used to label progress reporting. */
+	private String fDisplayName;
 	/** Stores <code>DocumentEvents</code> while an initialization is going on. */
 	private final List<DocumentEvent> fStoredEvents= new ArrayList<>();
 	/**
@@ -500,6 +502,16 @@ public class DocumentLineDiffer implements ILineDiffer, IDocumentListener, IAnno
 	}
 
 	/**
+	 * Sets an optional display name used to label this differ's background job in the
+	 * Progress view. Typically the name of the editor input being compared.
+	 *
+	 * @param displayName the display name, or <code>null</code> to use the generic label
+	 */
+	public void setDisplayName(String displayName) {
+		fDisplayName= displayName;
+	}
+
+	/**
 	 * (Re-)initializes the differ using the current reference and <code>DiffInitializer</code>.
 	 *
 	 * @since 3.2 protected for testing reasons, package visible before
@@ -533,7 +545,10 @@ public class DocumentLineDiffer implements ILineDiffer, IDocumentListener, IAnno
 			oldJob.cancel();
 		}
 
-		fInitializationJob= new Job(QuickDiffMessages.quickdiff_initialize) {
+		String jobName= fDisplayName != null
+				? NLSUtility.format(QuickDiffMessages.quickdiff_initialize_file, fDisplayName)
+				: QuickDiffMessages.quickdiff_initialize;
+		fInitializationJob= new Job(jobName) {
 
 			/*
 			 * This is run in a different thread. As the documents might be synchronized, never ever

--- a/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/texteditor/quickdiff/QuickDiffMessages.java
+++ b/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/texteditor/quickdiff/QuickDiffMessages.java
@@ -47,6 +47,7 @@ public final class QuickDiffMessages extends NLS {
 	public static String quickdiff_toggle_enable;
 	public static String quickdiff_toggle_disable;
 	public static String quickdiff_initialize;
+	public static String quickdiff_initialize_file;
 	public static String quickdiff_nonsynchronized;
 	public static String quickdiff_annotation_changed;
 	public static String quickdiff_annotation_added;

--- a/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/texteditor/quickdiff/QuickDiffMessages.properties
+++ b/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/texteditor/quickdiff/QuickDiffMessages.properties
@@ -15,6 +15,7 @@ quickdiff_toggle_enable= Enable Q&uick Diff
 quickdiff_toggle_disable= Disable Q&uick Diff
 
 quickdiff_initialize= Initializing Quick Diff
+quickdiff_initialize_file= Quick Diff: comparing {0}
 quickdiff_nonsynchronized= Quick Diff Is Not in Sync - Cannot Restore
 quickdiff_annotation_changed={0} changed
 quickdiff_annotation_added={0} added

--- a/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/texteditor/quickdiff/ReferenceSelectionAction.java
+++ b/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/texteditor/quickdiff/ReferenceSelectionAction.java
@@ -166,6 +166,7 @@ public class ReferenceSelectionAction extends Action implements IUpdate {
 		// create if needed
 		if (differ == null && createIfNeeded) {
 			differ= new DocumentLineDiffer();
+			differ.setDisplayName(editorInput.getName());
 			model.addAnnotationModel(IChangeRulerColumn.QUICK_DIFF_MODEL_ID, differ);
 		}
 

--- a/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/texteditor/quickdiff/QuickDiff.java
+++ b/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/texteditor/quickdiff/QuickDiff.java
@@ -139,10 +139,19 @@ public class QuickDiff {
 		IQuickDiffReferenceProvider provider= getReferenceProviderOrDefault(editor, id);
 		if (provider != null) {
 			DocumentLineDiffer differ= new DocumentLineDiffer();
+			differ.setDisplayName(getEditorInputName(editor));
 			differ.setReferenceProvider(provider);
 			return differ;
 		}
 		return null;
+	}
+
+	private static String getEditorInputName(ITextEditor editor) {
+		if (editor == null) {
+			return null;
+		}
+		var input= editor.getEditorInput();
+		return input != null ? input.getName() : null;
 	}
 
 	/**


### PR DESCRIPTION
The `DocumentLineDiffer` background job is currently labelled "Initializing Quick Diff" for every editor. The name is misleading because the job is not a one-time initialization (it also re-runs on every save and whenever the reference document changes), and identical labels give no hint which editor each Progress view entry belongs to.

This change passes the editor input name into the differ so the job appears as "Quick Diff: comparing <filename>" when a name is available, falling back to the generic label otherwise. `DocumentLineDiffer` is internal, so the new setter is not API; `IEditorInput.getName()` is existing API.