### PR TITLE
Auto-open path completion on separator in workspace dialog

### DIFF
--- a/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/ide/DirectoryProposalContentAssist.java
+++ b/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/ide/DirectoryProposalContentAssist.java
@@ -165,7 +165,7 @@ public class DirectoryProposalContentAssist {
 			proposalProvider = new FileNameSubstringMatchContentProposalProvider();
 			KeyStroke triggeringKeyStroke = safeKeyStroke("Ctrl+Space"); //$NON-NLS-1$
 			adapter = new OpenableContentProposalAdapter(control, controlContentAdapter, proposalProvider,
-					triggeringKeyStroke, null);
+					triggeringKeyStroke, new char[] { '/', '\\' });
 			adapter.setPropagateKeys(true);
 			adapter.setProposalAcceptanceStyle(ContentProposalAdapter.PROPOSAL_REPLACE);
 		}


### PR DESCRIPTION
In the Choose Workspace dialog, the directory content assist popup currently only opens when the user presses Ctrl+Space. Typing a path separator (`/` or `\`) now auto-activates the popup, which matches how shells and most IDEs behave and makes path entry noticeably faster. Ctrl+Space still works as a manual trigger, so nothing is taken away from existing users.