### PR TITLE
Update schema doc references to non-deprecated contentTypes id

### DIFF
--- a/bundles/org.eclipse.core.filebuffers/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.core.filebuffers/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.core.filebuffers; singleton:=true
-Bundle-Version: 3.8.500.qualifier
+Bundle-Version: 3.8.600.qualifier
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Export-Package: 

--- a/bundles/org.eclipse.core.filebuffers/schema/annotationModelCreation.exsd
+++ b/bundles/org.eclipse.core.filebuffers/schema/annotationModelCreation.exsd
@@ -76,7 +76,7 @@
          <attribute name="contentTypeId" type="string">
             <annotation>
                <documentation>
-                  the id of a content type as defined by the &lt;code&gt;org.eclipse.core.runtime.contentTypes&lt;/code&gt; extension point for which this factory should be used
+                  the id of a content type as defined by the &lt;code&gt;org.eclipse.core.contenttype.contentTypes&lt;/code&gt; extension point for which this factory should be used
                </documentation>
             </annotation>
          </attribute>

--- a/bundles/org.eclipse.core.filebuffers/schema/documentCreation.exsd
+++ b/bundles/org.eclipse.core.filebuffers/schema/documentCreation.exsd
@@ -88,7 +88,7 @@
          <attribute name="contentTypeId" type="string">
             <annotation>
                <documentation>
-                  the id of a content type as defined by the &lt;code&gt;org.eclipse.core.runtime.contentTypes&lt;/code&gt; extension point for which this factory should be used
+                  the id of a content type as defined by the &lt;code&gt;org.eclipse.core.contenttype.contentTypes&lt;/code&gt; extension point for which this factory should be used
                </documentation>
             </annotation>
          </attribute>

--- a/bundles/org.eclipse.core.filebuffers/schema/documentSetup.exsd
+++ b/bundles/org.eclipse.core.filebuffers/schema/documentSetup.exsd
@@ -80,7 +80,7 @@ As of 3.2, a warning is written to the log file if this isn&apos;t followed.
          <attribute name="contentTypeId" type="string">
             <annotation>
                <documentation>
-                  the id of a content type as defined by the &lt;code&gt;org.eclipse.core.runtime.contentTypes&lt;/code&gt; extension point for which this participant should be used.
+                  the id of a content type as defined by the &lt;code&gt;org.eclipse.core.contenttype.contentTypes&lt;/code&gt; extension point for which this participant should be used.
                </documentation>
             </annotation>
          </attribute>

--- a/bundles/org.eclipse.ui.workbench.texteditor/schema/rulerColumns.exsd
+++ b/bundles/org.eclipse.ui.workbench.texteditor/schema/rulerColumns.exsd
@@ -144,7 +144,7 @@
    <element name="targetContentType">
       <annotation>
          <documentation>
-            Describes a content type that the column is contributed to. See the &lt;tt&gt;org.eclipse.core.runtime.contentTypes&lt;/tt&gt; extension point. Note that the rulerColumns extension point is typically only supported by line based text editors.
+            Describes a content type that the column is contributed to. See the &lt;tt&gt;org.eclipse.core.contenttype.contentTypes&lt;/tt&gt; extension point. Note that the rulerColumns extension point is typically only supported by line based text editors.
          </documentation>
       </annotation>
       <complexType>


### PR DESCRIPTION
Four schema files still pointed at the deprecated `org.eclipse.core.runtime.contentTypes` extension point in their `<documentation>` text. That id was removed in eclipse-platform/eclipse.platform#1644, so update the references to the non-deprecated `org.eclipse.core.contenttype.contentTypes` equivalent. Documentation-only change.