### PR TITLE
Migrate test fixtures to non-deprecated contentTypes extension point

### DIFF
--- a/tests/org.eclipse.ui.tests.performance/plugin.xml
+++ b/tests/org.eclipse.ui.tests.performance/plugin.xml
@@ -51,7 +51,7 @@
    "regression test" for bug 107121. See OpenNavigatorFolderTest
    for more details. 
    -->
-   <extension point="org.eclipse.core.runtime.contentTypes">
+   <extension point="org.eclipse.core.contenttype.contentTypes">
    	<content-type 
    		file-extensions="htmltestonly" 
    		priority="high"

--- a/tests/org.eclipse.ui.tests/plugin.xml
+++ b/tests/org.eclipse.ui.tests/plugin.xml
@@ -1211,7 +1211,7 @@
    </extension>
    
    <extension
-   		point="org.eclipse.core.runtime.contentTypes">
+   		point="org.eclipse.core.contenttype.contentTypes">
    		
       	<!-- ObjectContributionTest: This is the content-type-based object contribution -->
 		<content-type 


### PR DESCRIPTION
Two test fixtures still contributed to the deprecated `org.eclipse.core.runtime.contentTypes` extension point, which is being removed in eclipse-platform/eclipse.platform#1644. Switches them to the non-deprecated `org.eclipse.core.contenttype.contentTypes` equivalent — only the `point=` attribute changes; the fixtures themselves (regression test for bug 107121 used by `OpenNavigatorFolderTest`, and `ObjectContributionTest`) are unaffected. Schema documentation references are handled separately in #3936.