### PR TITLE
Increase AnimationManager debounce from 100 ms to 200 ms

### DIFF
--- a/bundles/org.eclipse.e4.ui.progress/src/org/eclipse/e4/ui/progress/internal/AnimationManager.java
+++ b/bundles/org.eclipse.e4.ui.progress/src/org/eclipse/e4/ui/progress/internal/AnimationManager.java
@@ -40,7 +40,7 @@ import jakarta.inject.Singleton;
 @Singleton
 public class AnimationManager {
 
-	private static final int DEBOUNCE_MILLIS = 100;
+	private static final int DEBOUNCE_MILLIS = 200;
 
 	volatile boolean animated = false;
 

--- a/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/progress/AnimationManager.java
+++ b/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/progress/AnimationManager.java
@@ -28,7 +28,7 @@ import org.eclipse.swt.widgets.Display;
  * update.
  */
 public class AnimationManager {
-	private static final int DEBOUNCE_MILLIS = 100;
+	private static final int DEBOUNCE_MILLIS = 200;
 
 	private static AnimationManager singleton;
 


### PR DESCRIPTION
Bumps `AnimationManager.DEBOUNCE_MILLIS` from 100 ms to 200 ms in both the workbench and e4.ui.progress copies. More short-lived jobs are suppressed (no visible spinner flash for jobs that finish within 200 ms), while staying under the ~250 to 300 ms threshold where users start to perceive UI lag, so long-running jobs still feel responsive.

Kept as a separate, isolated commit so it can be reasoned about and reverted independently of the JFace `Throttler` refactor in #3902.