### PR TITLE
Use dialog font in editor drop-down

### DIFF
--- a/bundles/org.eclipse.e4.ui.workbench.renderers.swt/src/org/eclipse/e4/ui/internal/workbench/renderers/swt/AbstractTableInformationControl.java
+++ b/bundles/org.eclipse.e4.ui.workbench.renderers.swt/src/org/eclipse/e4/ui/internal/workbench/renderers/swt/AbstractTableInformationControl.java
@@ -134,6 +134,7 @@ public abstract class AbstractTableInformationControl {
 		fTableViewer = createTableViewer(fComposite, controlStyle);
 
 		final Table table = fTableViewer.getTable();
+		table.setFont(JFaceResources.getDialogFont());
 		table.addKeyListener(KeyListener.keyPressedAdapter(e -> {
 			switch (e.keyCode) {
 			case SWT.ESC:
@@ -314,10 +315,11 @@ public abstract class AbstractTableInformationControl {
 
 	protected Text createFilterText(Composite parent) {
 		fFilterText = new Text(parent, SWT.NONE);
+		fFilterText.setFont(JFaceResources.getDialogFont());
 
 		GridData data = new GridData();
 		GC gc = new GC(parent);
-		gc.setFont(parent.getFont());
+		gc.setFont(fFilterText.getFont());
 		FontMetrics fontMetrics = gc.getFontMetrics();
 		gc.dispose();
 


### PR DESCRIPTION
The chevron drop-down on editor stacks inherited the SWT system font, which on many platforms looks out of place compared to the rest of the IDE chrome. This change switches both the filter text and the result table to `JFaceResources.getDialogFont()` so the list matches the Quick Switch Editor (Ctrl+E) dialog and other workbench dialogs.

The bold-when-hidden marker that this PR previously removed has been kept, following review feedback that it is useful for spotting which tabs are currently visible.