### PR TITLE
Revert "Defer expensive project reference computation during selection changes"

### DIFF
--- a/bundles/org.eclipse.ui.ide/extensions/org/eclipse/ui/actions/CloseUnrelatedProjectsAction.java
+++ b/bundles/org.eclipse.ui.ide/extensions/org/eclipse/ui/actions/CloseUnrelatedProjectsAction.java
@@ -30,7 +30,6 @@ import org.eclipse.core.runtime.CoreException;
 import org.eclipse.jface.dialogs.IDialogConstants;
 import org.eclipse.jface.dialogs.MessageDialogWithToggle;
 import org.eclipse.jface.preference.IPreferenceStore;
-import org.eclipse.jface.viewers.IStructuredSelection;
 import org.eclipse.jface.window.IShellProvider;
 import org.eclipse.osgi.util.NLS;
 import org.eclipse.swt.widgets.Shell;
@@ -129,25 +128,6 @@ public class CloseUnrelatedProjectsAction extends CloseResourceAction {
 				IDEWorkbenchMessages.CloseUnrelatedProjectsAction_text_plural,
 				IDEWorkbenchMessages.CloseUnrelatedProjectsAction_toolTip_plural);
 		initAction();
-	}
-
-	/**
-	 * Overrides to avoid calling the expensive
-	 * {@code computeRelated(List)} during selection changes. Uses only
-	 * the raw selection to determine enablement.
-	 */
-	@Override
-	protected boolean updateSelection(IStructuredSelection s) {
-		selectionDirty = true;
-		if (!selectionIsOfType(IResource.PROJECT)) {
-			return false;
-		}
-		for (IResource resource : super.getSelectedResources()) {
-			if (resource instanceof IProject project && project.isOpen()) {
-				return true;
-			}
-		}
-		return false;
 	}
 
 	@Override


### PR DESCRIPTION
Reverts PR #3871 (commit 3aaea37e05) and the follow-up Javadoc fix in 3b23ac5263.

After #3871 the cheap `updateSelection()` override stopped consulting the project graph, so `CloseUnrelatedProjectsAction` stayed enabled after the last unrelated project was closed (also visible as an RCPTT regression on platform staging). Reverting restores the previous correct enablement; the original UI-thread cost addressed in #3871 can be tackled separately without breaking the action.

Closes #3941.

Refs https://github.com/eclipse-platform/eclipse.platform.ui/issues/2636