### PR TITLE
Disable test_PlaceholderOnTopStackSwitch() on MacOS

### DIFF
--- a/tests/org.eclipse.e4.ui.tests/src/org/eclipse/e4/ui/tests/model/test/util/E4UITestUtils.java
+++ b/tests/org.eclipse.e4.ui.tests/src/org/eclipse/e4/ui/tests/model/test/util/E4UITestUtils.java
@@ -1,0 +1,33 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Simeon Andreev and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Simeon Andreev - initial API and implementation
+ ******************************************************************************/
+
+package org.eclipse.e4.ui.tests.model.test.util;
+
+public class E4UITestUtils {
+
+	public static final String JENKINS_JOB_NAME_ENV_VAR = "JOB_NAME";
+
+	/**
+	 * Return {@code true} if we are probably running on Jenkins, i.e. if
+	 * {@link #JENKINS_JOB_NAME_ENV_VAR} is set. Jenkins jobs are:
+	 * <ul>
+	 * <li>I-builds</li>
+	 * <li>GitHub PR test job, excluding the Windows/Linux/MacOS test jobs ran with
+	 * Tycho</li>
+	 * </ul>
+	 */
+	public static boolean isRunningOnJenkins() {
+		return System.getenv(JENKINS_JOB_NAME_ENV_VAR) != null;
+	}
+}

--- a/tests/org.eclipse.e4.ui.tests/src/org/eclipse/e4/ui/tests/workbench/PartOnTopManagerTest.java
+++ b/tests/org.eclipse.e4.ui.tests/src/org/eclipse/e4/ui/tests/workbench/PartOnTopManagerTest.java
@@ -19,6 +19,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import jakarta.inject.Inject;
+import org.eclipse.core.runtime.Platform;
 import org.eclipse.e4.ui.internal.workbench.PartOnTopManager;
 import org.eclipse.e4.ui.model.application.MApplication;
 import org.eclipse.e4.ui.model.application.ui.MContext;
@@ -29,10 +30,12 @@ import org.eclipse.e4.ui.model.application.ui.basic.MPart;
 import org.eclipse.e4.ui.model.application.ui.basic.MPartSashContainer;
 import org.eclipse.e4.ui.model.application.ui.basic.MPartStack;
 import org.eclipse.e4.ui.model.application.ui.basic.MWindow;
+import org.eclipse.e4.ui.tests.model.test.util.E4UITestUtils;
 import org.eclipse.e4.ui.tests.rules.WorkbenchContextExtension;
 import org.eclipse.e4.ui.workbench.IWorkbench;
 import org.eclipse.e4.ui.workbench.modeling.EModelService;
 import org.eclipse.e4.ui.workbench.modeling.EPartService;
+import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
@@ -136,6 +139,8 @@ public class PartOnTopManagerTest {
 
 	@Test
 	public void test_PlaceholderOnTopStackSwitch() {
+		Assumptions.assumeFalse(Platform.OS.isMac() && E4UITestUtils.isRunningOnJenkins(),
+				"test fails stably on MacOS I-builds, its unclear how to fix it, see: https://github.com/eclipse-platform/eclipse.platform.ui/issues/3893");
 		MWindow window = ems.createModelElement(MWindow.class);
 		application.getChildren().add(window);
 		application.setSelectedElement(window);


### PR DESCRIPTION
`PartOnTopManagerTest.test_PlaceholderOnTopStackSwitch()` fails stabily in MacOS I-builds.

Since its unclear what is wrong, the test is now disabled to reduce noise in test results.

See: https://github.com/eclipse-platform/eclipse.platform.ui/issues/3893