### PR TITLE
Restore Section title bar background lost after #3808

### DIFF
--- a/bundles/org.eclipse.ui.forms/src/org/eclipse/ui/forms/widgets/Section.java
+++ b/bundles/org.eclipse.ui.forms/src/org/eclipse/ui/forms/widgets/Section.java
@@ -464,11 +464,12 @@ public class Section extends ExpandableComposite {
 	}
 	private void updateHeaderImage(Color bg, Rectangle bounds, int theight, int realtheight) {
 		Color gradient = getTitleBarGradientBackground() != null ? getTitleBarGradientBackground() : getBackground();
-		if (gradient.equals(bg)) {
-			// Flat look: gradient and background are the same, no image needed
+		if (gradient.equals(bg) && bg.equals(getBackground())) {
+			// Section is uniform; the body background already fills everything.
 			super.setBackgroundImage(null);
 			return;
 		}
+		// Image paints the title bar contrast against the section body.
 		Image image = FormImages.getInstance().getSectionGradientImage(gradient, bg, realtheight,
 				theight, marginHeight, getDisplay());
 		super.setBackgroundImage(image);


### PR DESCRIPTION
The flat-look optimization in #3808 added an early return in `Section.updateHeaderImage` whenever the title-bar gradient color matched the title-bar background color. That fired in the common case where the title-bar background is set distinct from the section body (e.g. `#eaeaea` on a `#ffffff` body), and the image it skipped was what painted that contrast across the title-bar area, so the title bar visually collapsed into the body.

Tighten the short-circuit to also require `bg.equals(getBackground())`, so the image is only skipped when title-bar gradient, title-bar background and section body background are all the same color. The optimization is preserved for genuinely flat sections; non-flat title bars get their image back.

Fixes #3945