### PR TITLE
Align dark theme form chrome with regular view styling

### DIFF
--- a/bundles/org.eclipse.ui.themes/css/dark/e4-dark_globalstyle.css
+++ b/bundles/org.eclipse.ui.themes/css/dark/e4-dark_globalstyle.css
@@ -194,15 +194,12 @@ WebSite {
     color: #dddddd;
 }
 
-Form,
-FormHeading {
-    background-color: #505F70;
-    color: #9AC9D8;
-}
-
 Form {
+    background-color: #2F2F2F;
+    color: #9AC9D8;
+
 	/* Bug 465148: Additional styling for the Form */
-    text-background-color: #505F70;
+    text-background-color: #2F2F2F;
 
 	tb-toggle-hover-color: #313538;
 	tb-toggle-color: #313538;
@@ -210,11 +207,11 @@ Form {
 	h-hover-light-color: #313538;
 	h-bottom-keyline-2-color: #313538;
 	h-bottom-keyline-1-color: #313538;
+}
 
-	/* We also have to force the background mode (the
-	 * Label/ToolBar in the heading should inherit it).
-	 */
-    swt-background-mode: 'force';
+FormHeading {
+    background-color: #2F2F2F;
+    color: #f4f7f7;
 }
 
 Section {

--- a/bundles/org.eclipse.ui.themes/css/dark/e4-dark_partstyle.css
+++ b/bundles/org.eclipse.ui.themes/css/dark/e4-dark_partstyle.css
@@ -94,22 +94,6 @@
     color: #BBBBBB;
 }
 
-.MPart FormHeading,
-.MPart FormHeading > TitleRegion,
-.MPart FormHeading > TitleRegion > Label,
-.MPart FormHeading > TitleRegion > StyledText {
-    background-color: #505f70;
-    color: #9ac9d8;
-}
-
-.MPart FormHeading,
-.MPart FormHeading > TitleRegion {
-    swt-background-mode: none;
-}
-.MPart FormHeading > CLabel {
-    background-color: #505f70;
-}
-
 .MPartFormHeaderCLabelError {
 	color:'#org-eclipse-ui-workbench-FORM_HEADING_ERROR_COLOR';
 }

--- a/bundles/org.eclipse.ui.themes/css/e4-dark_linux.css
+++ b/bundles/org.eclipse.ui.themes/css/e4-dark_linux.css
@@ -112,13 +112,6 @@ ImageBasedFrame,
     swt-selected-highlight-top: true;
 }
 
-.Editor Form Composite,
-.Editor Form Composite Tree,
-.MPartStack.active .Editor Form Composite Tree
-{
-	background-color: #1E1F22;
-}
-
 #org-eclipse-e4-ui-compatibility-editor Canvas,
 #org-eclipse-e4-ui-compatibility-editor Canvas > *
 {

--- a/bundles/org.eclipse.ui.themes/css/e4-dark_mac.css
+++ b/bundles/org.eclipse.ui.themes/css/e4-dark_mac.css
@@ -98,13 +98,6 @@ Button  {
     swt-selected-highlight-top: true;
 }
 
-.Editor Form Composite,
-.Editor Form Composite Tree,
-.MPartStack.active .Editor Form Composite Tree
-{
-	background-color: #1E1F22;
-}
-
 #org-eclipse-e4-ui-compatibility-editor Canvas,
 #org-eclipse-e4-ui-compatibility-editor Canvas > *
 {

--- a/bundles/org.eclipse.ui.themes/css/e4-dark_win.css
+++ b/bundles/org.eclipse.ui.themes/css/e4-dark_win.css
@@ -101,8 +101,8 @@ ImageBasedFrame,
 .MPartStack.active .MPart Form DependenciesComposite,
 .MPartStack.active .MPart Form ListEditorComposite,
 .MPartStack.active .MPart Form Text[style~='SWT.READ_ONLY'],
-.MPartStack.active .MPart Form DependenciesComposite > SashForm > Section > * { /* Section > DependenciesComposite$... */ 
-	background-color: #4f5355;
+.MPartStack.active .MPart Form DependenciesComposite > SashForm > Section > * { /* Section > DependenciesComposite$... */
+	background-color: #2F2F2F;
 	color: #f4f7f7;
 }
 #org-eclipse-help-ui-HelpView Form,
@@ -179,13 +179,6 @@ ImageBasedFrame,
     swt-selected-tab-highlight: '#2b79d7';
     swt-selected-highlight-top: true;
 } 
-
-.Editor Form Composite,
-.Editor Form Composite Tree,
-.MPartStack.active .Editor Form Composite Tree
-{
-	background-color: #1E1F22;
-}
 
 #org-eclipse-e4-ui-compatibility-editor Canvas,
 #org-eclipse-e4-ui-compatibility-editor Canvas > *


### PR DESCRIPTION
On the dark theme, the form heading and section title bars were collapsing into the form body in editors and the editor-form text contrast was visibly worse than the dialog labels. The cause was a chain of overrides built on top of an INHERIT_FORCE hack on `Form` that forced children to inherit the body color, which the form heading then had to fight against in `e4-dark_partstyle.css`, and a broad `.Editor Form Composite { #1E1F22 }` rule that pushed the editor body away from the view body color and incidentally flattened the section trees.

This change unifies the dark theme form chrome with the existing `.MPart Composite` / `.MPart Section` view styling: split `Form`/`FormHeading` in `e4-dark_globalstyle.css` to `#2F2F2F` body / `#f4f7f7` heading text, drop the `swt-background-mode: 'force'` hack, drop the now-unneeded `.MPart FormHeading > ...` counter-override in `e4-dark_partstyle.css`, align the Windows-specific `.MPart Form { #4f5355 }` block to `#2F2F2F`, and remove the redundant `.Editor Form Composite` block from the three platform-specific dark files. Net diff is +9 / -49 lines.