### PR TITLE
Give FormHeading a distinct background in the light theme

### DIFF
--- a/bundles/org.eclipse.ui.themes/css/light/e4-light_globalstyle.css
+++ b/bundles/org.eclipse.ui.themes/css/light/e4-light_globalstyle.css
@@ -14,15 +14,13 @@
  *******************************************************************************/
 
 
-Form, FormHeading {
+Form {
 	background-color: #ffffff;
 	background: #ffffff;
 	color: #505050;
-}
 
-Form {
 	/* Bug 465148: Additional styling for the Form */
-	text-background-color: #ffffff;
+	text-background-color: #eaeaea;
 
 	tb-toggle-hover-color: #505050;
 	tb-toggle-color: #505050;
@@ -30,6 +28,12 @@ Form {
 	h-hover-light-color: #505050;
 	h-bottom-keyline-2-color: #eaeaea;
 	h-bottom-keyline-1-color: #eaeaea;
+}
+
+FormHeading {
+	background-color: #eaeaea;
+	background: #eaeaea;
+	color: #505050;
 }
 
 


### PR DESCRIPTION
The light theme set both `Form` and `FormHeading` to `#ffffff` plus a matching `text-background-color`, so the form heading area (the bar containing the editor title and toolbar icons) was visually indistinguishable from the form body and the icons looked free-floating.

Split the joint `Form, FormHeading` rule in `e4-light_globalstyle.css` and give `FormHeading` (and the Form's `text-background-color`) `#eaeaea` — the same color the Section title bars already use — so the heading reads as a distinct band against the white body.