### PR TITLE
Fix dark styling for popup shells in workspace selection

### DIFF
--- a/bundles/org.eclipse.ui.ide.application/src/org/eclipse/ui/internal/ide/application/IDEApplication.java
+++ b/bundles/org.eclipse.ui.ide.application/src/org/eclipse/ui/internal/ide/application/IDEApplication.java
@@ -901,9 +901,16 @@ public class IDEApplication implements IApplication, IExecutableExtension {
 			darkThemeShowListener = event -> {
 				if (event.widget instanceof Shell shell) {
 					applyDarkStyles(shell);
+					// Re-apply after the current event to cover popup shells (e.g. content
+					// proposal) whose content is populated after the SWT.Show event fires.
+					display.asyncExec(() -> {
+						if (!shell.isDisposed()) {
+							applyDarkStyles(shell);
+						}
+					});
 				}
 			};
-			display.addListener(SWT.Show, darkThemeShowListener);
+			display.addFilter(SWT.Show, darkThemeShowListener);
 		}
 	}
 
@@ -914,7 +921,7 @@ public class IDEApplication implements IApplication, IExecutableExtension {
 	 */
 	protected void resetEarlyDarkTheme(Display display) {
 		if (darkThemeShowListener != null) {
-			display.removeListener(SWT.Show, darkThemeShowListener);
+			display.removeFilter(SWT.Show, darkThemeShowListener);
 			darkThemeShowListener = null;
 		}
 		if (isDark) {


### PR DESCRIPTION
## Summary
- Use `display.addFilter` instead of `addListener` for `SWT.Show` so the early dark-theme listener actually fires for child popup shells (e.g. the content-proposal popup in the workspace selection combo). `Display.addListener` only catches events sent to the Display widget itself, not events on child shells — so the listener was previously a no-op for popups.
- Re-apply styles asynchronously to cover widgets that finish initializing after `SWT.Show` (e.g. the `SWT.VIRTUAL` proposal `Table` whose rows are populated lazily).

The two existing dark dialogs (workspace selection, version warning) appeared dark only because their `createContents()` overrides call `applyDarkStyles(getShell())` directly. The content-proposal popup is created by JFace's `ContentProposalAdapter` where we have no such hook, so it stayed light.

Reproducible on Windows; not reproducible on Linux.

