### PR TITLE
[#3958] fix key command action handler gets deleted by content assist

### DIFF
--- a/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/texteditor/KeyBindingSupportForAssistant.java
+++ b/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/texteditor/KeyBindingSupportForAssistant.java
@@ -136,6 +136,11 @@ public final class KeyBindingSupportForAssistant implements ICompletionListener 
 
 	@Override
 	public void assistSessionStarted(ContentAssistEvent event) {
+		// Do not replace commands twice if several processors are registered. This
+		// method gets called for each processor.
+		if (fReplacedCommands != null && !fReplacedCommands.isEmpty()) {
+			return;
+		}
 		ICommandService commandService= PlatformUI.getWorkbench().getService(ICommandService.class);
 		IHandler handler= getHandler(ContentAssistant.SELECT_NEXT_PROPOSAL_COMMAND_ID);
 		fReplacedCommands= new ArrayList<>(10);


### PR DESCRIPTION
fixes #3958 by handling multiple calls on assistSessionStarted(ContentAssistEvent)