### PR TITLE
Match SourceViewer canvas background to text widget

### DIFF
--- a/bundles/org.eclipse.jface.text/src/org/eclipse/jface/text/source/SourceViewer.java
+++ b/bundles/org.eclipse.jface.text/src/org/eclipse/jface/text/source/SourceViewer.java
@@ -26,6 +26,7 @@ import java.util.Stack;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.custom.StyleRange;
 import org.eclipse.swt.custom.StyledText;
+import org.eclipse.swt.graphics.Color;
 import org.eclipse.swt.graphics.Point;
 import org.eclipse.swt.graphics.Rectangle;
 import org.eclipse.swt.widgets.Canvas;
@@ -467,6 +468,25 @@ public class SourceViewer extends TextViewer
 		}
 		if (fOverviewRuler != null) {
 			fOverviewRuler.createControl(fComposite, this);
+		}
+
+		if (fComposite != null) {
+			StyledText textWidget= getTextWidget();
+			if (textWidget != null) {
+				// Match the canvas background to the text widget so the RulerLayout gap blends in.
+				syncCompositeBackground(textWidget);
+				textWidget.addPaintListener(e -> syncCompositeBackground(textWidget));
+			}
+		}
+	}
+
+	private void syncCompositeBackground(StyledText textWidget) {
+		if (fComposite == null || fComposite.isDisposed() || textWidget.isDisposed()) {
+			return;
+		}
+		Color desired= textWidget.getBackground();
+		if (desired != null && !desired.equals(fComposite.getBackground())) {
+			fComposite.setBackground(desired);
 		}
 	}
 

--- a/bundles/org.eclipse.jface.text/src/org/eclipse/jface/text/source/SourceViewer.java
+++ b/bundles/org.eclipse.jface.text/src/org/eclipse/jface/text/source/SourceViewer.java
@@ -26,6 +26,7 @@ import java.util.Stack;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.custom.StyleRange;
 import org.eclipse.swt.custom.StyledText;
+import org.eclipse.swt.graphics.Color;
 import org.eclipse.swt.graphics.Point;
 import org.eclipse.swt.graphics.Rectangle;
 import org.eclipse.swt.widgets.Canvas;
@@ -467,6 +468,25 @@ public class SourceViewer extends TextViewer
 		}
 		if (fOverviewRuler != null) {
 			fOverviewRuler.createControl(fComposite, this);
+		}
+
+		if (fComposite != null) {
+			StyledText textWidget= getTextWidget();
+			if (textWidget != null) {
+				// Match the canvas background to the text widget so the RulerLayout gap blends in.
+				syncCompositeBackground(textWidget);
+				textWidget.addPaintListener(e -> syncCompositeBackground(textWidget));
+			}
+		}
+	}
+
+	private void syncCompositeBackground(StyledText textWidget) {
+		if (fComposite == null || fComposite.isDisposed() || textWidget.isDisposed()) {
+			return;
+		}
+		Color desired= textWidget.getBackground();
+		if (!desired.equals(fComposite.getBackground())) {
+			fComposite.setBackground(desired);
 		}
 	}
 

--- a/tests/org.eclipse.jface.text.tests/src/org/eclipse/jface/text/tests/JFaceTextTestSuite.java
+++ b/tests/org.eclipse.jface.text.tests/src/org/eclipse/jface/text/tests/JFaceTextTestSuite.java
@@ -33,6 +33,7 @@ import org.eclipse.jface.text.tests.rules.ScannerColumnTest;
 import org.eclipse.jface.text.tests.rules.WordRuleTest;
 import org.eclipse.jface.text.tests.source.AnnotationRulerColumnTest;
 import org.eclipse.jface.text.tests.source.LineNumberRulerColumnTest;
+import org.eclipse.jface.text.tests.source.SourceViewerBackgroundTest;
 import org.eclipse.jface.text.tests.source.SourceViewerComputeStyleRangesTest;
 import org.eclipse.jface.text.tests.source.inlined.AnnotationOnTabTest;
 import org.eclipse.jface.text.tests.source.inlined.LineContentBoundsDrawingTest;
@@ -47,6 +48,7 @@ import org.eclipse.jface.text.tests.templates.persistence.TemplatePersistenceDat
 @SelectClasses({
 		AnnotationRulerColumnTest.class,
 		LineNumberRulerColumnTest.class,
+		SourceViewerBackgroundTest.class,
 		SourceViewerComputeStyleRangesTest.class,
 		HTML2TextReaderTest.class,
 		TextHoverPopupTest.class,

--- a/tests/org.eclipse.jface.text.tests/src/org/eclipse/jface/text/tests/source/SourceViewerBackgroundTest.java
+++ b/tests/org.eclipse.jface.text.tests/src/org/eclipse/jface/text/tests/source/SourceViewerBackgroundTest.java
@@ -1,0 +1,89 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Lars Vogel and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Lars Vogel <Lars.Vogel@vogella.com> - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.jface.text.tests.source;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.custom.StyledText;
+import org.eclipse.swt.graphics.Color;
+import org.eclipse.swt.widgets.Display;
+import org.eclipse.swt.widgets.Event;
+import org.eclipse.swt.widgets.Shell;
+
+import org.eclipse.jface.text.Document;
+import org.eclipse.jface.text.source.SourceViewer;
+import org.eclipse.jface.text.source.VerticalRuler;
+
+/**
+ * Tests that the canvas behind a {@link SourceViewer} tracks the background of its text
+ * widget, so that the gap the ruler layout leaves is not visible.
+ */
+public class SourceViewerBackgroundTest {
+
+	private Shell shell;
+
+	@BeforeEach
+	public void setUp() {
+		shell= new Shell();
+	}
+
+	@AfterEach
+	public void tearDown() {
+		shell.dispose();
+	}
+
+	@Test
+	public void testCanvasBackgroundMatchesTextWidgetOnCreation() {
+		SourceViewer viewer= createViewer();
+
+		assertEquals(viewer.getTextWidget().getBackground(), viewer.getControl().getBackground());
+	}
+
+	@Test
+	public void testCanvasBackgroundFollowsTextWidgetBackground() {
+		SourceViewer viewer= createViewer();
+		StyledText textWidget= viewer.getTextWidget();
+		Color background= Display.getDefault().getSystemColor(SWT.COLOR_RED);
+
+		textWidget.setBackground(background);
+		textWidget.notifyListeners(SWT.Paint, new Event());
+
+		assertEquals(background, viewer.getControl().getBackground());
+	}
+
+	@Test
+	public void testCanvasBackgroundFollowsResetToDefault() {
+		SourceViewer viewer= createViewer();
+		StyledText textWidget= viewer.getTextWidget();
+		Color defaultBackground= textWidget.getBackground();
+
+		textWidget.setBackground(Display.getDefault().getSystemColor(SWT.COLOR_RED));
+		textWidget.notifyListeners(SWT.Paint, new Event());
+		textWidget.setBackground(null);
+		textWidget.notifyListeners(SWT.Paint, new Event());
+
+		assertEquals(defaultBackground, viewer.getControl().getBackground());
+	}
+
+	private SourceViewer createViewer() {
+		SourceViewer viewer= new SourceViewer(shell, new VerticalRuler(12), SWT.NONE);
+		viewer.setDocument(new Document("content")); //$NON-NLS-1$
+		return viewer;
+	}
+}


### PR DESCRIPTION
On dark editor themes a bright 1px vertical strip appears between the line numbers and the source code. The strip is the gap that `RulerLayout` leaves between the vertical ruler and the text widget; it exposes the parent `Canvas` of `SourceViewer`, whose background was never themed.

This change tracks the `StyledText` background and applies it to the canvas so the gap blends into the editor color scheme, and re-syncs on text widget paint events so preference-driven background changes propagate.

Fixes #3964