### PR TITLE
Fix sticky scroll height calculation for variable line heights

### DIFF
--- a/bundles/org.eclipse.ui.editors/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.ui.editors/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.ui.editors; singleton:=true
-Bundle-Version: 3.22.0.qualifier
+Bundle-Version: 3.22.100.qualifier
 Bundle-Activator: org.eclipse.ui.internal.editors.text.EditorsPlugin
 Bundle-ActivationPolicy: lazy
 Bundle-Vendor: %providerName

--- a/bundles/org.eclipse.ui.editors/src/org/eclipse/ui/internal/texteditor/stickyscroll/StickyScrollingControl.java
+++ b/bundles/org.eclipse.ui.editors/src/org/eclipse/ui/internal/texteditor/stickyscroll/StickyScrollingControl.java
@@ -331,7 +331,10 @@ public class StickyScrollingControl {
 		StyledText textWidget= sourceViewer.getTextWidget();
 
 		int numberStickyLines= getNumberStickyLines();
-		int lineHeight= stickyLineText.getLineHeight() * numberStickyLines;
+		int lineHeight = 0;
+		for (int i = 0; i < numberStickyLines; i++) {
+			lineHeight += stickyLineText.getLineHeight(stickyLineText.getOffsetAtLine(i));
+		}
 		int spacingHeight= stickyLineText.getLineSpacing() * (numberStickyLines - 1);
 		int separatorHeight= bottomSeparator.getBounds().height;
 
@@ -450,7 +453,8 @@ public class StickyScrollingControl {
 	}
 
 	private void limitVisibleStickyLinesToTextWidgetHeight(StyledText textWidget) {
-		int lineHeight= textWidget.getLineHeight() + textWidget.getLineSpacing();
+		int topOffset = textWidget.getOffsetAtLine(textWidget.getTopIndex());
+		int lineHeight = textWidget.getLineHeight(topOffset) + textWidget.getLineSpacing();
 		int textWidgetHeight= textWidget.getBounds().height;
 
 		int visibleLinesInTextWidget= textWidgetHeight / lineHeight;

--- a/tests/org.eclipse.ui.editors.tests/src/org/eclipse/ui/internal/texteditor/stickyscroll/StickyScrollingControlTest.java
+++ b/tests/org.eclipse.ui.editors.tests/src/org/eclipse/ui/internal/texteditor/stickyscroll/StickyScrollingControlTest.java
@@ -17,6 +17,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -234,6 +235,33 @@ public class StickyScrollingControlTest {
 		assertEquals(10, stickyLineText.getLineSpacing());
 		assertEquals(font, stickyLineText.getFont());
 		assertEquals(hoverColor, stickyLineText.getForeground());
+	}
+
+	@Test
+	void testCanvasBoundsHeightAdjustsForVariableLineHeights() {
+		sourceViewer.getTextWidget().setBounds(0, 0, 200, 200);
+
+		// Step 1: Set 2 plain-text sticky lines and record canvas height
+		List<IStickyLine> plainLines = List.of(new StickyLineStub("line 1", 0), new StickyLineStub("line 2", 1));
+		stickyScrollingControl.setStickyLines(plainLines);
+		Canvas stickyControlCanvas = getStickyControlCanvas(shell);
+		int heightWithPlainText = stickyControlCanvas.getBounds().height;
+
+		// Step 2: Replace second sticky line with line requiring space
+		Font largerFont = new Font(Display.getDefault(),
+				new FontData(shell.getFont().getFontData()[0].getName(), 40, SWT.NORMAL));
+		String bigText = "line 2 big"; //$NON-NLS-1$
+		StyleRange bigFontRange = new StyleRange(0, bigText.length(), null, null);
+		bigFontRange.font = largerFont;
+		List<IStickyLine> linesWithLargerFont = List.of(new StickyLineStub("line 1", 0),
+				new StickyLineStub(bigText, 1, new StyleRange[] { bigFontRange }));
+		stickyScrollingControl.setStickyLines(linesWithLargerFont);
+		int heightWithLargerFont = getStickyControlCanvas(shell).getBounds().height;
+
+		assertTrue(heightWithLargerFont > heightWithPlainText,
+				"Canvas height must increase when one sticky line has a larger font"); //$NON-NLS-1$
+
+		largerFont.dispose();
 	}
 
 	@Test


### PR DESCRIPTION
**Description:**  
`StickyScrollingControl` was computing the sticky area height by multiplying a single line height by the number of sticky lines. This assumption breaks when content like emoji causes individual lines to render taller than the default — the canvas ends up too short, clipping the sticky lines visually.

`calculateCanvasBounds` now sums the actual height of each sticky line using `getLineHeight(offset)` instead of using a uniform `getLineHeight()`. 

**Reproduce:**  
Create an XML file with the content below. Enable sticky scrolling and scroll a few lines:
                                                                                                                       
```xml
<?xml version="1.0" encoding="UTF-8"?>
<test>
	<test2 name="👍">
		<test3 name="👎" />
		<!--
    Extended comment section 
    to demonstrate 
    sticky scrolling 
    functionality
  -->
	</test2>
</test>
```                                                                                                                 

<img width="572" height="526" alt="image" src="https://github.com/user-attachments/assets/28027490-3858-4911-a049-968b5fa8eabe" />

Follow up of #3748 