### PR TITLE
Drop unreachable IOException from CSSEngine String overloads

### DIFF
--- a/bundles/org.eclipse.e4.ui.css.core/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.e4.ui.css.core/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-SymbolicName: org.eclipse.e4.ui.css.core;singleton:=true
 Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
-Bundle-Version: 0.14.600.qualifier
+Bundle-Version: 0.14.700.qualifier
 Export-Package: org.eclipse.e4.ui.css.core;x-internal:=true,
  org.eclipse.e4.ui.css.core.css2;x-friends:="org.eclipse.e4.ui.css.swt.theme,org.eclipse.e4.ui.css.swt,org.eclipse.e4.ui.css.jface",
  org.eclipse.e4.ui.css.core.dom;x-friends:="org.eclipse.e4.ui.css.swt,org.eclipse.ui.views.properties.tabbed,org.eclipse.ui.forms",

--- a/bundles/org.eclipse.e4.ui.css.core/src/org/eclipse/e4/ui/css/core/engine/CSSEngine.java
+++ b/bundles/org.eclipse.e4.ui.css.core/src/org/eclipse/e4/ui/css/core/engine/CSSEngine.java
@@ -61,7 +61,7 @@ public interface CSSEngine {
 	/**
 	 * Parse style declaration from String style.
 	 */
-	CSSStyleDeclaration parseStyleDeclaration(String style) throws IOException;
+	CSSStyleDeclaration parseStyleDeclaration(String style);
 
 	/**
 	 * Parse style declaration from Reader reader.
@@ -83,7 +83,7 @@ public interface CSSEngine {
 	/**
 	 * Parse CSSValue from String value.
 	 */
-	CSSValue parsePropertyValue(String value) throws IOException;
+	CSSValue parsePropertyValue(String value);
 
 	/**
 	 * Parse CSSValue from InputStream stream.
@@ -105,7 +105,7 @@ public interface CSSEngine {
 	/**
 	 * Parse Selectors from String value.
 	 */
-	SelectorList parseSelectors(String text) throws IOException;
+	SelectorList parseSelectors(String text);
 
 	/**
 	 * Parse Selectors from InputSource value.

--- a/bundles/org.eclipse.e4.ui.css.core/src/org/eclipse/e4/ui/css/core/impl/engine/AbstractCSSEngine.java
+++ b/bundles/org.eclipse.e4.ui.css.core/src/org/eclipse/e4/ui/css/core/impl/engine/AbstractCSSEngine.java
@@ -278,9 +278,12 @@ public abstract class AbstractCSSEngine implements CSSEngine {
 	/*--------------- Parse style declaration -----------------*/
 
 	@Override
-	public CSSStyleDeclaration parseStyleDeclaration(String style) throws IOException {
-		Reader reader = new StringReader(style);
-		return parseStyleDeclaration(reader);
+	public CSSStyleDeclaration parseStyleDeclaration(String style) {
+		try {
+			return parseStyleDeclaration(new StringReader(style));
+		} catch (IOException e) {
+			throw new IllegalStateException("StringReader cannot throw IOException", e); //$NON-NLS-1$
+		}
 	}
 
 	@Override
@@ -307,9 +310,12 @@ public abstract class AbstractCSSEngine implements CSSEngine {
 	/*--------------- Parse CSS Selector -----------------*/
 
 	@Override
-	public SelectorList parseSelectors(String selector) throws IOException {
-		Reader reader = new StringReader(selector);
-		return parseSelectors(reader);
+	public SelectorList parseSelectors(String selector) {
+		try {
+			return parseSelectors(new StringReader(selector));
+		} catch (IOException e) {
+			throw new IllegalStateException("StringReader cannot throw IOException", e); //$NON-NLS-1$
+		}
 	}
 
 	@Override
@@ -350,9 +356,12 @@ public abstract class AbstractCSSEngine implements CSSEngine {
 	}
 
 	@Override
-	public CSSValue parsePropertyValue(String value) throws IOException {
-		Reader reader = new StringReader(value);
-		return parsePropertyValue(reader);
+	public CSSValue parsePropertyValue(String value) {
+		try {
+			return parsePropertyValue(new StringReader(value));
+		} catch (IOException e) {
+			throw new IllegalStateException("StringReader cannot throw IOException", e); //$NON-NLS-1$
+		}
 	}
 
 	@Override


### PR DESCRIPTION
parseSelectors(String), parsePropertyValue(String), and parseStyleDeclaration(String) wrap the input in a StringReader and delegate to the Reader-based overload. StringReader.read() never throws IOException, but the signature of the Reader overload propagates IOException up from the SAC parser API, so the String forms used to declare a checked exception that could not actually fire. Drop throws IOException from the three String overloads on the internal CSSEngine interface and wrap the inner Reader call in AbstractCSSEngine in try/catch -> IllegalStateException to preserve the impossible case as a defensive guard. Bundle is x-friends so the signature change is internal-only.