### PR TITLE
Drop dead SAC parser entries from SACConstants and the factory

### DIFF
--- a/bundles/org.eclipse.e4.ui.css.core/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.e4.ui.css.core/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-SymbolicName: org.eclipse.e4.ui.css.core;singleton:=true
 Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
-Bundle-Version: 0.14.600.qualifier
+Bundle-Version: 0.14.700.qualifier
 Export-Package: org.eclipse.e4.ui.css.core;x-internal:=true,
  org.eclipse.e4.ui.css.core.css2;x-friends:="org.eclipse.e4.ui.css.swt.theme,org.eclipse.e4.ui.css.swt,org.eclipse.e4.ui.css.jface",
  org.eclipse.e4.ui.css.core.dom;x-friends:="org.eclipse.e4.ui.css.swt,org.eclipse.ui.views.properties.tabbed,org.eclipse.ui.forms",

--- a/bundles/org.eclipse.e4.ui.css.core/src/org/eclipse/e4/ui/css/core/SACConstants.java
+++ b/bundles/org.eclipse.e4.ui.css.core/src/org/eclipse/e4/ui/css/core/SACConstants.java
@@ -22,21 +22,6 @@ package org.eclipse.e4.ui.css.core;
 public class SACConstants {
 
 	/**
-	 * org.w3c.flute.parser.Parser SAC Parser.
-	 */
-	public static final String SACPARSER_FLUTE = "org.w3c.flute.parser.Parser";
-
-	/**
-	 * org.w3c.flute.parser.Parser SAC Parser.
-	 */
-	public static final String SACPARSER_FLUTE_CSS3 = "org.w3c.flute.parser.CSS3Parser";
-
-	/**
-	 * com.steadystate.css.parser.SACParser SAC Parser
-	 */
-	public static final String SACPARSER_STEADYSTATE = "com.steadystate.css.parser.SACParser";
-
-	/**
 	 * org.apache.batik.css.parser.Parser SAC Parser.
 	 */
 	public static final String SACPARSER_BATIK = "org.apache.batik.css.parser.Parser";

--- a/bundles/org.eclipse.e4.ui.css.core/src/org/eclipse/e4/ui/css/core/impl/sac/SACParserFactoryImpl.java
+++ b/bundles/org.eclipse.e4.ui.css.core/src/org/eclipse/e4/ui/css/core/impl/sac/SACParserFactoryImpl.java
@@ -21,26 +21,18 @@ import org.eclipse.e4.ui.css.core.sac.SACParserFactory;
 import org.w3c.css.sac.Parser;
 
 /**
- * SAC Parser factory implementation. By default, this SAC FActory support
- * Flute, SteadyState and Batik SAC Parser.
+ * SAC Parser factory implementation. The Batik SAC parser is the only
+ * parser shipped with Eclipse and is registered as the default.
  */
 public class SACParserFactoryImpl extends SACParserFactory {
 
 	private static Map<String, String> parsers = new HashMap<>();
 
 	static {
-		// Register Flute SAC Parser
-		registerSACParser(SACConstants.SACPARSER_FLUTE);
-		// Register Flute SAC CSS3Parser
-		registerSACParser(SACConstants.SACPARSER_FLUTE_CSS3);
-		// Register SteadyState SAC Parser
-		registerSACParser(SACConstants.SACPARSER_STEADYSTATE);
-		// Register Batik SAC Parser
 		registerSACParser(SACConstants.SACPARSER_BATIK);
 	}
 
 	public SACParserFactoryImpl() {
-		// Flute parser is the default SAC Parser to use.
 		super.setPreferredParserName(SACConstants.SACPARSER_BATIK);
 	}
 


### PR DESCRIPTION
Eclipse only ships the Batik CSS parser. The Flute, Flute CSS3, and SteadyState parser entries in SACConstants and the matching registerSACParser calls in SACParserFactoryImpl reference parser classes that are not on the runtime classpath; calling makeParser with any of those names would fail with ClassNotFoundException. Remove the three dead constants and registrations, and fix a stale comment that claimed Flute was the default parser when in fact the factory has always preferred Batik.