### PR TITLE
Expose Expand All icon through ISharedImages API

### DIFF
--- a/bundles/org.eclipse.ui.workbench/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.ui.workbench/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.ui.workbench; singleton:=true
-Bundle-Version: 3.138.100.qualifier
+Bundle-Version: 3.139.0.qualifier
 Bundle-Activator: org.eclipse.ui.internal.WorkbenchPlugin
 Bundle-ActivationPolicy: lazy
 Bundle-Vendor: %providerName

--- a/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/ISharedImages.java
+++ b/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/ISharedImages.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2025 IBM Corporation and others.
+ * Copyright (c) 2000, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -70,6 +70,20 @@ public interface ISharedImages {
 	 * @since 3.4
 	 */
 	String IMG_ELCL_COLLAPSEALL_DISABLED = "IMG_ELCL_COLLAPSEALL_DISABLED"; //$NON-NLS-1$
+
+	/**
+	 * Identifies the expand all image in the enabled state.
+	 *
+	 * @since 3.139
+	 */
+	String IMG_ELCL_EXPANDALL = "IMG_ELCL_EXPANDALL"; //$NON-NLS-1$
+
+	/**
+	 * Identifies the expand all image in the disabled state.
+	 *
+	 * @since 3.139
+	 */
+	String IMG_ELCL_EXPANDALL_DISABLED = "IMG_ELCL_EXPANDALL_DISABLED"; //$NON-NLS-1$
 
 	/**
 	 * Identifies the remove image in the enabled state.

--- a/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/dialogs/FilteredItemsSelectionDialog.java
+++ b/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/dialogs/FilteredItemsSelectionDialog.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2025 IBM Corporation and others.
+ * Copyright (c) 2000, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -244,7 +244,7 @@ public abstract class FilteredItemsSelectionDialog extends SelectionStatusDialog
 	 * to deterministically wait for the filter/refresh pipeline to settle.
 	 *
 	 * @noreference This field is not intended to be referenced by clients.
-	 * @since 3.138
+	 * @since 3.139
 	 */
 	public static final Object JOB_FAMILY = new Object();
 

--- a/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/WorkbenchImages.java
+++ b/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/WorkbenchImages.java
@@ -189,8 +189,8 @@ public/* final */class WorkbenchImages {
 		declareImage(ISharedImages.IMG_ELCL_SYNCED, ISharedImages.IMG_ELCL_SYNCED_DISABLED, //
 				PATH_ELOCALTOOL + "synced.svg", true); //$NON-NLS-1$
 
-		declareImage(ISharedImages.IMG_ELCL_COLLAPSEALL, ISharedImages.IMG_ELCL_COLLAPSEALL_DISABLED, //
-				PATH_ELOCALTOOL + "collapseall.svg", true); //$NON-NLS-1$
+		declareImage(ISharedImages.IMG_ELCL_EXPANDALL, ISharedImages.IMG_ELCL_EXPANDALL_DISABLED, //
+				PATH_ELOCALTOOL + "expandall.svg", true); //$NON-NLS-1$
 
 		declareImage(ISharedImages.IMG_ELCL_REMOVE, ISharedImages.IMG_ELCL_REMOVE_DISABLED, //
 				PATH_ELOCALTOOL + "remove.svg", true); //$NON-NLS-1$


### PR DESCRIPTION
This change exposes the existing Expand All toolbar icon through the shared workbench image API, similar to the already available Collapse All image.

Currently, collapseall is accessible via ISharedImages, while expandall requires bundle-specific image loading or direct resource access. This leads to duplicated image handling and inconsistent usage across the workbench.

This PR:
- Adds shared image constants and registrations for the existing expandall icon
- Makes the icon accessible through PlatformUI.getWorkbench().getSharedImages()
- Aligns Expand All usage with the existing Collapse All API pattern
- Avoids fragile programmatic bundle resource lookups in downstream consumers

The intent is to provide a reusable, centralized API for any component that needs standard Expand All toolbar imagery.

This arises from https://github.com/eclipse-platform/eclipse.platform.ui/pull/3968#discussion_r3199104404