### PR TITLE
Wire CompositeTest and PaddingTest into CssSwtTestSuite

### DIFF
--- a/tests/org.eclipse.e4.ui.tests.css.swt/src/org/eclipse/e4/ui/tests/css/CssSwtTestSuite.java
+++ b/tests/org.eclipse.e4.ui.tests.css.swt/src/org/eclipse/e4/ui/tests/css/CssSwtTestSuite.java
@@ -36,6 +36,7 @@ import org.eclipse.e4.ui.tests.css.swt.CSSSWTWidgetTest;
 import org.eclipse.e4.ui.tests.css.swt.CTabFolderTest;
 import org.eclipse.e4.ui.tests.css.swt.CTabItemTest;
 import org.eclipse.e4.ui.tests.css.swt.ColorDefinitionTest;
+import org.eclipse.e4.ui.tests.css.swt.CompositeTest;
 import org.eclipse.e4.ui.tests.css.swt.DescendentTest;
 import org.eclipse.e4.ui.tests.css.swt.FontDefinitionTest;
 import org.eclipse.e4.ui.tests.css.swt.GradientTest;
@@ -47,6 +48,7 @@ import org.eclipse.e4.ui.tests.css.swt.LabelTest;
 import org.eclipse.e4.ui.tests.css.swt.LabelTextTransformTest;
 import org.eclipse.e4.ui.tests.css.swt.LinkTest;
 import org.eclipse.e4.ui.tests.css.swt.MarginTest;
+import org.eclipse.e4.ui.tests.css.swt.PaddingTest;
 import org.eclipse.e4.ui.tests.css.swt.ShellActiveTest;
 import org.eclipse.e4.ui.tests.css.swt.ShellTest;
 import org.eclipse.e4.ui.tests.css.swt.TableTest;
@@ -69,7 +71,8 @@ import org.junit.platform.suite.api.Suite;
 		ButtonTextTransformTest.class, LabelTextTransformTest.class, TextTextTransformTest.class, DescendentTest.class,
 		ThemeTest.class, Bug459961Test.class, Bug419482Test.class, ShellActiveTest.class, InheritTest.class,
 		TableTest.class, TreeTest.class, TabbedPropertiesListTest.class, TabbedPropertiesTitleTest.class,
-		ExpandableCompositeTest.class, SectionTest.class })
+		ExpandableCompositeTest.class, SectionTest.class,
+		CompositeTest.class, PaddingTest.class })
 public class CssSwtTestSuite {
 
 }


### PR DESCRIPTION
Both test classes are present in the source tree but never registered in `CssSwtTestSuite`, so the nightly integration build (which runs the suite through `test.xml`) silently skipped them. Tycho's class-name discovery still ran them on PR builds, which is why the gap went unnoticed. Adding both entries plus their imports so the integration build covers them too.