### PR TITLE
Evaluate visibleWhen expressions for "Show in" menu

### DIFF
--- a/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/ShowInMenu.java
+++ b/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/ShowInMenu.java
@@ -27,6 +27,7 @@ import org.eclipse.e4.ui.internal.workbench.ContributionsAnalyzer;
 import org.eclipse.e4.ui.model.application.MApplication;
 import org.eclipse.e4.ui.model.application.commands.MCommand;
 import org.eclipse.e4.ui.model.application.commands.MParameter;
+import org.eclipse.e4.ui.model.application.ui.MExpression;
 import org.eclipse.e4.ui.model.application.ui.menu.MHandledMenuItem;
 import org.eclipse.e4.ui.model.application.ui.menu.MMenu;
 import org.eclipse.e4.ui.model.application.ui.menu.MMenuContribution;
@@ -247,7 +248,12 @@ public class ShowInMenu extends ContributionItem implements IWorkbenchContributi
 							ccip.parameters.put(menuParam.getName(), menuParam.getValue());
 						}
 					}
-					innerMgr.add(new CommandContributionItem(ccip));
+					CommandContributionItem cci = new CommandContributionItem(ccip);
+					MExpression visibleWhen = menuElement.getVisibleWhen();
+					if (visibleWhen != null) {
+						cci.setVisible(ContributionsAnalyzer.isVisible(visibleWhen, eContext));
+					}
+					innerMgr.add(cci);
 				}
 			}
 		}

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/menus/MenusTestSuite.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/menus/MenusTestSuite.java
@@ -31,6 +31,7 @@ import org.junit.platform.suite.api.Suite;
 		DynamicMenuTest.class,
 		Bug231304Test.class,
 		ShowViewMenuTest.class,
+		ShowInMenuTest.class,
 		Bug264804Test.class,
 		MenuHelperTest.class,
 		Bug410426Test.class,

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/menus/ShowInMenuTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/menus/ShowInMenuTest.java
@@ -1,0 +1,108 @@
+package org.eclipse.ui.tests.menus;
+
+import static org.eclipse.ui.tests.harness.util.UITestUtil.openTestWindow;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+import java.util.List;
+
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.jface.action.ContributionItem;
+import org.eclipse.jface.action.IContributionItem;
+import org.eclipse.jface.viewers.ISelectionProvider;
+import org.eclipse.jface.viewers.StructuredSelection;
+import org.eclipse.swt.widgets.Menu;
+import org.eclipse.swt.widgets.MenuItem;
+import org.eclipse.ui.IPageLayout;
+import org.eclipse.ui.IViewPart;
+import org.eclipse.ui.IWorkbenchPage;
+import org.eclipse.ui.IWorkbenchWindow;
+import org.eclipse.ui.actions.ContributionItemFactory;
+import org.eclipse.ui.ide.IDE;
+import org.eclipse.ui.internal.ide.handlers.ShowInSystemExplorerHandler;
+import org.eclipse.ui.tests.harness.util.CloseTestWindowsExtension;
+import org.eclipse.ui.tests.harness.util.EditorTestHelper;
+import org.eclipse.ui.tests.harness.util.FileUtil;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@ExtendWith(CloseTestWindowsExtension.class)
+public class ShowInMenuTest {
+
+	private static final String TEST_ITEM_ID = "org.eclipse.ui.tests.menus.showInMenuTestItem";
+
+	private IWorkbenchWindow window;
+	private IWorkbenchPage page;
+	private List<IProject> projects;
+
+	@BeforeEach
+	public final void setUp() throws Exception {
+		window = openTestWindow(IDE.RESOURCE_PERSPECTIVE_ID);
+		page = window.getActivePage();
+		projects = List.of(FileUtil.createProject("a"), FileUtil.createProject("b"));
+	}
+
+	@AfterEach
+	public final void tearDown() throws Exception {
+		for (IProject project : projects) {
+			FileUtil.deleteProject(project);
+		}
+	}
+
+	@Test
+	void testVisibleWhenEvaluation() throws CoreException {
+		IViewPart viewPart = page.showView(IPageLayout.ID_PROJECT_EXPLORER);
+		ISelectionProvider selectionProvider = viewPart.getSite().getSelectionProvider();
+		IWorkbenchWindow workbenchWindow = EditorTestHelper.getActiveWorkbenchWindow();
+
+		// Test item should be visible when selecting a single project
+		selectionProvider.setSelection(new StructuredSelection(projects.get(0)));
+		Menu menu = computeShowInMenu(workbenchWindow);
+
+		assertNotNull(getContributionItemById(menu, TEST_ITEM_ID));
+
+		// Test item should be hidden when selecting multiple projects
+		selectionProvider.setSelection(new StructuredSelection(projects));
+		menu = computeShowInMenu(workbenchWindow);
+
+		assertNull(getContributionItemById(menu, TEST_ITEM_ID));
+	}
+
+	@Test
+	void testVisibleWhenEvaluationForShowInSystemExplorer() throws CoreException {
+		IViewPart viewPart = page.showView(IPageLayout.ID_PROJECT_EXPLORER);
+		ISelectionProvider selectionProvider = viewPart.getSite().getSelectionProvider();
+		IWorkbenchWindow workbenchWindow = EditorTestHelper.getActiveWorkbenchWindow();
+
+		// "Show in System Explorer" should be visible when selecting a single project
+		selectionProvider.setSelection(new StructuredSelection(projects.get(0)));
+		Menu menu = computeShowInMenu(workbenchWindow);
+
+		assertNotNull(getContributionItemById(menu, ShowInSystemExplorerHandler.ID));
+
+		// "Show in System Explorer" should be hidden when selecting multiple projects
+		selectionProvider.setSelection(new StructuredSelection(projects));
+		menu = computeShowInMenu(workbenchWindow);
+
+		assertNull(getContributionItemById(menu, ShowInSystemExplorerHandler.ID));
+	}
+
+	private static Menu computeShowInMenu(IWorkbenchWindow workbenchWindow) {
+		IContributionItem contributionItem = ContributionItemFactory.VIEWS_SHOW_IN.create(workbenchWindow);
+		Menu menu = new Menu(workbenchWindow.getShell());
+		contributionItem.fill(menu, 0);
+		return menu;
+	}
+
+	private static ContributionItem getContributionItemById(Menu menu, String id) {
+		for (MenuItem item : menu.getItems()) {
+			if (item.getData() instanceof ContributionItem contributionItem && contributionItem.getId().equals(id)) {
+				return contributionItem;
+			}
+		}
+		return null;
+	}
+}

--- a/tests/org.eclipse.ui.tests/plugin.xml
+++ b/tests/org.eclipse.ui.tests/plugin.xml
@@ -3911,6 +3911,24 @@
                style="push">
          </command>
       </menuContribution>
+      <menuContribution
+            allPopups="false"
+            locationURI="popup:org.eclipse.ui.menus.showInMenu">
+         <command
+               commandId="org.eclipse.ui.tests.menus.showInMenuTestItem"
+               label="Show In Menu Test Item"
+               style="push">
+            <visibleWhen
+                  checkEnabled="false">
+               <with
+                     variable="selection">
+                  <count
+                        value="1">
+                  </count>
+               </with>
+            </visibleWhen>
+         </command>
+      </menuContribution>
    </extension>
    <extension
          point="org.eclipse.ui.contexts">


### PR DESCRIPTION
Fixes https://github.com/eclipse-platform/eclipse.platform.ui/issues/3969

Currently, visibleWhen expressions are not evaluated for the "ShowIn"-menu. Because of this problem, entries in the "ShowIn"-menu can be disabled, but cannot be made invisible.

This PR fixes the issue by evaluating visibleWhen expressions before creating the command contribution items for the menu.

This also fixes an existing problem for the "Show in" -> "System explorer" entry. According to the definition of the menu contribution, this entry should be hidden when selecting multiple projects. Currently, it is shown as disabled because the visibleWhen expression of the menu contribution is not evaluated (only the enabledWhen expression of the handler gets evaluated correctly which disables the entry).

<img width="532" height="171" alt="image" src="https://github.com/user-attachments/assets/8158ac17-e9b3-44af-9c94-000b977aade6" />

Menu contribution (in /org.eclipse.ui.ide/plugin.xml):
<img width="472" height="241" alt="image" src="https://github.com/user-attachments/assets/af138b7a-c421-46d6-8d94-a40410458152" />

"org.eclipse.ui.ide.showInDefinition" definition (in /org.eclipse.ui.ide/plugin.xml):
<img width="612" height="405" alt="image" src="https://github.com/user-attachments/assets/ee966d64-2c7b-4532-a59a-85c8bc60c293" />

Handler (in /org.eclipse.ui.ide/plugin.xml):
<img width="580" height="138" alt="image" src="https://github.com/user-attachments/assets/e9e69f1b-6109-4177-bad9-ca36f85febfc" />

This PR also adds a test case documenting the changed behavior of the  "Show in" -> "System explorer" entry