### PR TITLE
Use java.text.BreakIterator in DefaultTextDoubleClickStrategy

### DIFF
--- a/bundles/org.eclipse.jface.text/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.jface.text/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.jface.text
-Bundle-Version: 3.31.0.qualifier
+Bundle-Version: 3.31.100.qualifier
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Export-Package: 

--- a/bundles/org.eclipse.jface.text/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.jface.text/META-INF/MANIFEST.MF
@@ -38,7 +38,6 @@ Require-Bundle:
  org.eclipse.text;bundle-version="[3.8.0,4.0.0)";visibility:=reexport,
  org.eclipse.swt;bundle-version="[3.133.0,4.0.0)",
  org.eclipse.jface;bundle-version="[3.39.0,4.0.0)"
-Import-Package: com.ibm.icu.text
 Bundle-RequiredExecutionEnvironment: JavaSE-21
 Automatic-Module-Name: org.eclipse.jface.text
 Bundle-Activator: org.eclipse.jface.text.Activator

--- a/bundles/org.eclipse.jface.text/src/org/eclipse/jface/text/DefaultTextDoubleClickStrategy.java
+++ b/bundles/org.eclipse.jface.text/src/org/eclipse/jface/text/DefaultTextDoubleClickStrategy.java
@@ -14,11 +14,9 @@
 
 package org.eclipse.jface.text;
 
+import java.text.BreakIterator;
 import java.text.CharacterIterator;
 import java.util.Locale;
-
-import com.ibm.icu.text.BreakIterator;
-
 
 
 /**
@@ -223,7 +221,52 @@ public class DefaultTextDoubleClickStrategy implements ITextDoubleClickStrategy 
 	 * @since 3.5
 	 */
 	protected IRegion findWord(IDocument document, int offset) {
+		IRegion identifier= findIdentifierAt(document, offset);
+		if (identifier != null) {
+			return identifier;
+		}
 		return findWord(document, offset, getWordBreakIterator());
+	}
+
+	/**
+	 * If the offset lies on an ASCII identifier character ({@code [A-Za-z0-9_]}), or
+	 * just after one, returns the maximal contiguous identifier run. Otherwise
+	 * returns {@code null} so the caller falls back to the locale-aware
+	 * {@link BreakIterator}. This handles identifier-style words containing runs
+	 * of {@code '_'} (e.g. {@code foo__bar}, {@code __aaaa}) consistently across
+	 * JDK versions, since {@link BreakIterator#getWordInstance()} places word
+	 * boundaries between consecutive underscores while users expect such tokens
+	 * to be selected as a single word.
+	 */
+	private static IRegion findIdentifierAt(IDocument document, int offset) {
+		try {
+			IRegion line= document.getLineInformationOfOffset(offset);
+			int lineStart= line.getOffset();
+			int lineEnd= lineStart + line.getLength();
+			int probe;
+			if (offset < lineEnd && isIdentifierPart(document.getChar(offset))) {
+				probe= offset;
+			} else if (offset > lineStart && isIdentifierPart(document.getChar(offset - 1))) {
+				probe= offset - 1;
+			} else {
+				return null;
+			}
+			int start= probe;
+			while (start > lineStart && isIdentifierPart(document.getChar(start - 1))) {
+				start--;
+			}
+			int end= probe + 1;
+			while (end < lineEnd && isIdentifierPart(document.getChar(end))) {
+				end++;
+			}
+			return new Region(start, end - start);
+		} catch (BadLocationException e) {
+			return null;
+		}
+	}
+
+	private static boolean isIdentifierPart(char c) {
+		return c == '_' || (c < 128 && (c >= '0' && c <= '9' || c >= 'A' && c <= 'Z' || c >= 'a' && c <= 'z'));
 	}
 
 	/**

--- a/tests/org.eclipse.jface.text.tests/src/org/eclipse/jface/text/tests/DefaultTextDoubleClickStrategyTest.java
+++ b/tests/org.eclipse.jface.text.tests/src/org/eclipse/jface/text/tests/DefaultTextDoubleClickStrategyTest.java
@@ -55,6 +55,113 @@ public class DefaultTextDoubleClickStrategyTest {
 		assertEquals("you", document.get(selection.getOffset(), selection.getLength()), "Unexpected selection");
 	}
 
+	@Test
+	public void testClickJustPastIdentifierSelectsThatIdentifier() throws Exception {
+		String content= "foo bar baz";
+		IDocument document= new Document(content);
+		TestSpecificDefaultTextDoubleClickStrategy strategy= new TestSpecificDefaultTextDoubleClickStrategy();
+		// Click at offset 3: the space right after "foo".
+		IRegion selection= strategy.findWord(document, 3);
+		assertNotNull(selection);
+		assertEquals("foo", document.get(selection.getOffset(), selection.getLength()));
+	}
+
+	@Test
+	public void testClickAtIdentifierStartSelectsWholeIdentifier() throws Exception {
+		String content= "foo __aaaa bar";
+		IDocument document= new Document(content);
+		TestSpecificDefaultTextDoubleClickStrategy strategy= new TestSpecificDefaultTextDoubleClickStrategy();
+		// Click at offset 4: the first '_' starting "__aaaa".
+		IRegion selection= strategy.findWord(document, 4);
+		assertNotNull(selection);
+		assertEquals("__aaaa", document.get(selection.getOffset(), selection.getLength()));
+	}
+
+	@Test
+	public void testIdentifierAtLineStartAndEnd() throws Exception {
+		String content= "_foo___\nbar_baz";
+		IDocument document= new Document(content);
+		TestSpecificDefaultTextDoubleClickStrategy strategy= new TestSpecificDefaultTextDoubleClickStrategy();
+		// First line: every offset 0..7 should yield "_foo___".
+		for (int offset= 0; offset <= 7; offset++) {
+			IRegion selection= strategy.findWord(document, offset);
+			assertNotNull(selection, "no selection at offset " + offset);
+			assertEquals("_foo___", document.get(selection.getOffset(), selection.getLength()),
+					"unexpected selection at offset " + offset);
+		}
+		// Second line.
+		IRegion selection= strategy.findWord(document, 11);
+		assertNotNull(selection);
+		assertEquals("bar_baz", document.get(selection.getOffset(), selection.getLength()));
+	}
+
+	@Test
+	public void testSingleLineDocument() throws Exception {
+		String content= "abc";
+		IDocument document= new Document(content);
+		TestSpecificDefaultTextDoubleClickStrategy strategy= new TestSpecificDefaultTextDoubleClickStrategy();
+		IRegion selection= strategy.findWord(document, 0);
+		assertNotNull(selection);
+		assertEquals("abc", document.get(selection.getOffset(), selection.getLength()));
+		selection= strategy.findWord(document, document.getLength());
+		assertNotNull(selection);
+		assertEquals("abc", document.get(selection.getOffset(), selection.getLength()));
+	}
+
+	@Test
+	public void testIdentifierSurroundedByPunctuation() throws Exception {
+		String content= "(foo_bar);";
+		IDocument document= new Document(content);
+		TestSpecificDefaultTextDoubleClickStrategy strategy= new TestSpecificDefaultTextDoubleClickStrategy();
+		// Click in the middle of the identifier.
+		IRegion selection= strategy.findWord(document, 4);
+		assertNotNull(selection);
+		assertEquals("foo_bar", document.get(selection.getOffset(), selection.getLength()));
+	}
+
+	@Test
+	public void testCjkWordSelection() throws Exception {
+		// Japanese text without spaces. The word break iterator segments it into a
+		// Hiragana run ("こんにちは") followed by a Kanji run
+		// ("世界"). This segmentation is locale-independent, so double-click
+		// selects the script run the click lands in rather than the whole line.
+		String content= "こんにちは世界";
+		IDocument document= new Document(content);
+		TestSpecificDefaultTextDoubleClickStrategy strategy= new TestSpecificDefaultTextDoubleClickStrategy();
+		// Click inside the Hiragana run.
+		IRegion selection= strategy.findWord(document, 2);
+		assertNotNull(selection);
+		assertEquals("こんにちは", document.get(selection.getOffset(), selection.getLength()));
+		// Click inside the Kanji run.
+		selection= strategy.findWord(document, 6);
+		assertNotNull(selection);
+		assertEquals("世界", document.get(selection.getOffset(), selection.getLength()));
+	}
+
+	@Test
+	public void testCjkTokenBetweenSpaces() throws Exception {
+		String content= "foo 我是 bar";
+		IDocument document= new Document(content);
+		TestSpecificDefaultTextDoubleClickStrategy strategy= new TestSpecificDefaultTextDoubleClickStrategy();
+		// Click inside the CJK token.
+		IRegion selection= strategy.findWord(document, 5);
+		assertNotNull(selection);
+		assertEquals("我是", document.get(selection.getOffset(), selection.getLength()));
+	}
+
+	@Test
+	public void testThaiTokenBetweenSpaces() throws Exception {
+		// Dictionary-based segmentation of a contiguous Thai run only happens under a
+		// Thai locale, so this test delimits the token with spaces to stay
+		// locale-independent: double-click selects the whole Thai token.
+		String content= "foo ไทย bar";
+		IDocument document= new Document(content);
+		TestSpecificDefaultTextDoubleClickStrategy strategy= new TestSpecificDefaultTextDoubleClickStrategy();
+		IRegion selection= strategy.findWord(document, 5);
+		assertNotNull(selection);
+		assertEquals("ไทย", document.get(selection.getOffset(), selection.getLength()));
+	}
+
 	private static final class TestSpecificDefaultTextDoubleClickStrategy extends DefaultTextDoubleClickStrategy {
 
 		@Override


### PR DESCRIPTION
Replaces `com.ibm.icu.text.BreakIterator` with `java.text.BreakIterator` in `DefaultTextDoubleClickStrategy` and drops the matching `Import-Package: com.ibm.icu.text` from the bundle manifest. The JDK `BreakIterator` exposes the same API (`getWordInstance`, `preceding`, `following`, `isBoundary`, `setText`, `DONE`) and the existing POSIX-locale workaround for `.` not being treated as a word boundary continues to work. This removes the last `com.ibm.icu` reference from `org.eclipse.jface.text`.

**Planned for 4.41**