### PR TITLE
Fix Windows Defender status retrieval under Java-25 or later

### DIFF
--- a/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/WindowsDefenderConfigurator.java
+++ b/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/WindowsDefenderConfigurator.java
@@ -31,6 +31,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.eclipse.core.runtime.CoreException;
@@ -389,7 +390,7 @@ public class WindowsDefenderConfigurator implements EventHandler {
 				Thread.onSpinWait();
 				Thread.sleep(5);
 			}
-			if (process.isAlive()) {
+			if (!process.waitFor(5, TimeUnit.SECONDS)) {
 				process.destroyForcibly();
 				process.descendants().forEach(ProcessHandle::destroyForcibly);
 				throw new IOException("Process timed-out and it was attempted to forcefully terminate it"); //$NON-NLS-1$


### PR DESCRIPTION
In recent Java versions `Process.isAlive()` seems to report the termination of a process a little bit later then before, relative to the time when the process output reader is closed, which leads to false errors about process time-out.

Fixes errors like:
```
!MESSAGE Failed to obtain 'WinDefend' service state
!STACK 0
java.io.IOException: Process timed-out and it was attempted to forcefully terminate it
	at org.eclipse.ui.internal.WindowsDefenderConfigurator.runProcess(WindowsDefenderConfigurator.java:395)
	at org.eclipse.ui.internal.WindowsDefenderConfigurator.runPowershell(WindowsDefenderConfigurator.java:369)
	at org.eclipse.ui.internal.WindowsDefenderConfigurator.isWindowsDefenderServiceRunning(WindowsDefenderConfigurator.java:302)
	at org.eclipse.ui.internal.WindowsDefenderConfigurator.runExclusionCheck(WindowsDefenderConfigurator.java:159)
	at org.eclipse.ui.internal.WindowsDefenderConfigurator.lambda$0(WindowsDefenderConfigurator.java:106)
	at org.eclipse.core.runtime.jobs.Job$2.run(Job.java:187)
	at org.eclipse.core.internal.jobs.Worker.run(Worker.java:63)
```

I cannot yet tell why, because I haven’t investigated the details yet.

CC @merks and @azoitl 
Does this also help for 
- https://github.com/eclipse-platform/eclipse.platform.ui/issues/3591

