### PR TITLE
Remove unnecessary compiler warning with latest ecj

### DIFF
--- a/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/viewers/VirtualTableViewerTest.java
+++ b/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/viewers/VirtualTableViewerTest.java
@@ -279,7 +279,6 @@ public class VirtualTableViewerTest extends TableViewerTest {
 		IStructuredSelection result = fViewer.getStructuredSelection();
 		assertEquals(children.length, result.size(), "Size was " + result.size() + " expected " + children.length);
 		Set<TestElement> childrenSet = new HashSet<>(Arrays.asList(children));
-		@SuppressWarnings("unchecked")
 		Set<?> selectedSet = new HashSet<Object>(result.toList());
 		assertTrue(childrenSet.equals(selectedSet), "Elements do not match ");
 	}


### PR DESCRIPTION
See https://github.com/eclipse-jdt/eclipse.jdt.core/pull/5054 
Fixes https://github.com/eclipse-platform/eclipse.platform.ui/issues/3992