### PR TITLE
Fix find/replace overlay asyncExecIfOpen running on disposed container

### DIFF
--- a/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/overlay/FindReplaceOverlay.java
+++ b/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/overlay/FindReplaceOverlay.java
@@ -352,7 +352,7 @@ public class FindReplaceOverlay {
 	private void asyncExecIfOpen(Runnable operation) {
 		if (!containerControl.isDisposed()) {
 			containerControl.getDisplay().asyncExec(() -> {
-				if (containerControl != null || containerControl.isDisposed()) {
+				if (containerControl != null && !containerControl.isDisposed()) {
 					operation.run();
 				}
 			});


### PR DESCRIPTION
The inner guard in the find/replace overlay's `asyncExecIfOpen` used `||` instead of `&&` and was missing the `!` negation on `isDisposed()`. Since `containerControl` is never `null`, the condition always short-circuited to `true`, making the guard ineffective. This allowed `updatePlacementAndVisibility` to run on a disposed container, causing an `SWTException: Widget is disposed`. 
This change fixes the condition so the operation only runs when the container is still alive.