### PR TITLE
Allow to ignore explicitly defined disabled icons

### DIFF
--- a/bundles/org.eclipse.e4.ui.workbench.renderers.swt/src/org/eclipse/e4/ui/workbench/renderers/swt/AbstractContributionItem.java
+++ b/bundles/org.eclipse.e4.ui.workbench.renderers.swt/src/org/eclipse/e4/ui/workbench/renderers/swt/AbstractContributionItem.java
@@ -38,6 +38,7 @@ import org.eclipse.e4.ui.workbench.IResourceUtilities;
 import org.eclipse.e4.ui.workbench.modeling.EModelService;
 import org.eclipse.e4.ui.workbench.swt.util.ISWTResourceUtilities;
 import org.eclipse.emf.common.util.URI;
+import org.eclipse.jface.action.ActionContributionItem;
 import org.eclipse.jface.action.ContributionItem;
 import org.eclipse.jface.action.IContributionManager;
 import org.eclipse.jface.action.IMenuCreator;
@@ -211,6 +212,9 @@ public abstract class AbstractContributionItem extends ContributionItem {
 	}
 
 	private String getDisabledIconURI(MItem toolItem) {
+		if (!ActionContributionItem.getUseDisabledIcons()) {
+			return ""; //$NON-NLS-1$
+		}
 		Object obj = toolItem.getTransientData().get(IPresentationEngine.DISABLED_ICON_IMAGE_KEY);
 		return obj instanceof String s ? s : ""; //$NON-NLS-1$
 	}

--- a/bundles/org.eclipse.jface/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.jface/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.jface;singleton:=true
-Bundle-Version: 3.39.100.qualifier
+Bundle-Version: 3.40.0.qualifier
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Export-Package: org.eclipse.jface,

--- a/bundles/org.eclipse.jface/src/org/eclipse/jface/action/ActionContributionItem.java
+++ b/bundles/org.eclipse.jface/src/org/eclipse/jface/action/ActionContributionItem.java
@@ -57,6 +57,12 @@ import org.eclipse.swt.widgets.Widget;
 public class ActionContributionItem extends ContributionItem {
 
 	/**
+	 * System property for specifying whether custom disabled icons for actions
+	 * shall be used or whether all disabled icons shall be generated on-the-fly.
+	 */
+	private static final String SYSTEM_PROPERTY_USE_DISABLED_ICONS = "org.eclipse.jface.action.useDisabledIcons"; //$NON-NLS-1$
+
+	/**
 	 * Mode bit: Show text on tool items or buttons, even if an image is
 	 * present. If this mode bit is not set, text is only shown on tool items if
 	 * there is no image present.
@@ -94,6 +100,32 @@ public class ActionContributionItem extends ContributionItem {
 	 */
 	public static void setUseColorIconsInToolbars(boolean useColorIcons) {
 		USE_COLOR_ICONS = useColorIcons;
+	}
+
+	private static boolean USE_DISABLED_ICONS = Boolean.getBoolean(SYSTEM_PROPERTY_USE_DISABLED_ICONS);
+
+	/**
+	 * Returns whether disabled icons assigned to actions shall be used or whether
+	 * all such disabled icons shall be generated on-the-fly.
+	 *
+	 * @return <code>true</code> if disabled icons assigned to actions shall be
+	 *         used, <code>false</code> otherwise
+	 * @since 3.40
+	 */
+	public static boolean getUseDisabledIcons() {
+		return USE_DISABLED_ICONS;
+	}
+
+	/**
+	 * Sets whether disabled icons assigned to actions shall be used or whether all
+	 * such disabled icons shall be generated on-the-fly.
+	 *
+	 * @param useDisabledIcons <code>true</code> if disabled icons set to actions
+	 *                         shall be used, <code>false</code> otherwise
+	 * @noreference This method is not intended to be referenced by clients.
+	 */
+	public static void setUseDisabledIcons(boolean useDisabledIcons) {
+		USE_DISABLED_ICONS = useDisabledIcons;
 	}
 
 	/**
@@ -988,7 +1020,10 @@ public class ActionContributionItem extends ContributionItem {
 		if (widget instanceof ToolItem) {
 			ImageDescriptor image = action.getImageDescriptor();
 			ImageDescriptor hoverImage = action.getHoverImageDescriptor();
-			ImageDescriptor disabledImage = action.getDisabledImageDescriptor();
+			ImageDescriptor disabledImage = null;
+			if (getUseDisabledIcons()) {
+				disabledImage = action.getDisabledImageDescriptor();
+			}
 			// Make sure there is a valid image in case images are forced.
 			if (image == null && forceImage) {
 				image = ImageDescriptor.getMissingImageDescriptor();

--- a/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/menus/CommandContributionItem.java
+++ b/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/menus/CommandContributionItem.java
@@ -28,6 +28,7 @@ import org.eclipse.core.commands.ParameterizedCommand;
 import org.eclipse.core.commands.common.NotDefinedException;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Status;
+import org.eclipse.jface.action.ActionContributionItem;
 import org.eclipse.jface.action.ContributionItem;
 import org.eclipse.jface.action.IContributionManager;
 import org.eclipse.jface.action.IMenuListener2;
@@ -892,7 +893,9 @@ public class CommandContributionItem extends ContributionItem {
 			localResourceManager = m;
 		} else if (widget instanceof ToolItem item) {
 			LocalResourceManager m = new LocalResourceManager(JFaceResources.getResources());
-			item.setDisabledImage(disabledIcon == null ? null : m.create(disabledIcon));
+			if (ActionContributionItem.getUseDisabledIcons()) {
+				item.setDisabledImage(disabledIcon == null ? null : m.create(disabledIcon));
+			}
 			item.setHotImage(hoverIcon == null ? null : m.create(hoverIcon));
 			item.setImage(icon == null ? null : m.create(icon));
 			disposeOldImages();

--- a/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/action/ToolBarManagerTest.java
+++ b/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/action/ToolBarManagerTest.java
@@ -141,8 +141,10 @@ public class ToolBarManagerTest {
 	@Test
 	public void testDefaultImageIsGray() {
 		boolean oldState = ActionContributionItem.getUseColorIconsInToolbars();
+		boolean oldStateUseDisabled = ActionContributionItem.getUseDisabledIcons();
 		try {
 			ActionContributionItem.setUseColorIconsInToolbars(false);
+			ActionContributionItem.setUseDisabledIcons(true);
 			ToolBarManager manager = new ToolBarManager();
 			Action action = new Action("Button with Hover") {
 			};
@@ -165,14 +167,17 @@ public class ToolBarManagerTest {
 			assertImageEqualsDescriptor(ImageDescriptor.createWithFlags(descriptor, SWT.IMAGE_GRAY), item.getImage());
 		} finally {
 			ActionContributionItem.setUseColorIconsInToolbars(oldState);
+			ActionContributionItem.setUseDisabledIcons(oldStateUseDisabled);
 		}
 	}
 
 	@Test
 	public void testActionImagesAreSet() {
 		boolean oldState = ActionContributionItem.getUseColorIconsInToolbars();
+		boolean oldStateUseDisabled = ActionContributionItem.getUseDisabledIcons();
 		try {
 			ActionContributionItem.setUseColorIconsInToolbars(true);
+			ActionContributionItem.setUseDisabledIcons(true);
 			ToolBarManager manager = new ToolBarManager();
 			Action action = new Action("Button with Hover") {
 			};
@@ -195,6 +200,7 @@ public class ToolBarManagerTest {
 			assertImageEqualsDescriptor(disabledDescriptor, item.getDisabledImage());
 		} finally {
 			ActionContributionItem.setUseColorIconsInToolbars(oldState);
+			ActionContributionItem.setUseDisabledIcons(oldStateUseDisabled);
 		}
 	}
 


### PR DESCRIPTION
This change allows to ignore explicitly defined disabled icons (as SWT provides a [proper way to do it on-the-fly since 2025-06](https://eclipse.dev/eclipse/markdown/?f=news/4.36/platform.md#improved-disabled-icons-generation)) and enabled that behavior by default.

This is an extract of:
- https://github.com/eclipse-platform/eclipse.platform.ui/pull/3760

In that PR, no objections have been raised on always using the on-the-fly generation of disabled icons. I thus intend to merge this at the beginning of 4.41 development in case no objections are raised until then.

@HannesWell we had discussed the extraction of this rather non-controversial change offline. Maybe you want to have a quick a look.

### Description

The algorithm for generating disabled icons on-the-fly has recently been enhanced. Most explicit disabled icons that have been embedded into bundles conform to what now can be generated on-the-fly. In addition, the algorithm is interchangeable, allowing custom stylings of disabled icons. However, when there are still bundles, such as extensions out of our control, that still explicitly define disabled icons, exchanging the algorithm for disabled icons will lead to inconsistent appearance as only the on-the-fly generated icons will adhere to that.

This change allows to ignore explicitly defined disabled icons, such that even if some bundles defined disabled icons, they will be ignored and on-the-fly generated disabled icons according to the selected algorithm will be used instead. An according preference that can be configured via the appearance tab is added.

### How to test

The enhancement is configurable via preference, thus can be tested by enabling/disabling it:
<img width="669" height="550" alt="image" src="https://github.com/user-attachments/assets/2d3cbc5d-e381-4d45-b97e-6aa9ddaeba16" />

As an example, this is what the main toolbar looks like with different configurations:

#### Existing
<img width="1095" height="31" alt="image" src="https://github.com/user-attachments/assets/66e14774-5394-4781-ae0f-87ec9328034e" />

#### No pregenerated disabled icons
<img width="1093" height="28" alt="image" src="https://github.com/user-attachments/assets/7d5a9802-4616-42d0-ae05-6f9671241804" />