### PR TITLE
Show theme-default checkbox only when workbench theme actually changed

### DIFF
--- a/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/dialogs/ViewsPreferencePage.java
+++ b/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/dialogs/ViewsPreferencePage.java
@@ -508,10 +508,11 @@ public class ViewsPreferencePage extends PreferencePage implements IWorkbenchPre
 		boolean showRestartDialog = false;
 		String restartDialogTitle = null;
 		String restartDialogMessage = null;
+		boolean themeChanged = false;
 
 		if (isThemingPossible()) {
 			ITheme theme = getSelectedTheme();
-			boolean themeChanged = theme != null && !theme.equals(currentTheme);
+			themeChanged = theme != null && !theme.equals(currentTheme);
 			boolean colorsAndFontsThemeChanged = !PlatformUI.getWorkbench().getThemeManager().getCurrentTheme().getId()
 					.equals(currentColorsAndFontsTheme.getId());
 
@@ -546,7 +547,7 @@ public class ViewsPreferencePage extends PreferencePage implements IWorkbenchPre
 
 		if (showRestartDialog) {
 			String themeId = null;
-			if (isThemingPossible()) {
+			if (themeChanged) {
 				ITheme theme = getSelectedTheme();
 				if (theme != null) {
 					themeId = theme.getId();


### PR DESCRIPTION
Fixes #4003. The restart dialog on the Appearance preferences page surfaced a "Use as default theme" checkbox whenever theming was enabled, even when the user only changed an unrelated setting like monitor-specific UI scaling. The checkbox is now gated on the workbench theme having actually changed, which also prevents the same misleading offer when only the colors-and-fonts theme was changed.