### PR TITLE
Set proper default for monitor-specific scaling preference

### DIFF
--- a/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/Workbench.java
+++ b/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/Workbench.java
@@ -254,6 +254,7 @@ import org.eclipse.ui.keys.IBindingService;
 import org.eclipse.ui.menus.IMenuService;
 import org.eclipse.ui.model.IContributionService;
 import org.eclipse.ui.operations.IWorkbenchOperationSupport;
+import org.eclipse.ui.preferences.ScopedPreferenceStore;
 import org.eclipse.ui.progress.IProgressService;
 import org.eclipse.ui.progress.WorkbenchJob;
 import org.eclipse.ui.services.IDisposable;
@@ -3690,8 +3691,8 @@ public final class Workbench extends EventManager implements IWorkbench, org.ecl
 						+ " is configured (e.g., via the INI), but the according preference should be preferred instead." //$NON-NLS-1$
 				));
 			} else {
-				boolean rescaleAtRuntime = ConfigurationScope.INSTANCE.getNode(WorkbenchPlugin.PI_WORKBENCH)
-						.getBoolean(IWorkbenchPreferenceConstants.RESCALING_AT_RUNTIME, true);
+				boolean rescaleAtRuntime = new ScopedPreferenceStore(ConfigurationScope.INSTANCE,
+						WorkbenchPlugin.PI_WORKBENCH).getBoolean(IWorkbenchPreferenceConstants.RESCALING_AT_RUNTIME);
 				System.setProperty(SWT_RESCALE_AT_RUNTIME_PROPERTY, Boolean.toString(rescaleAtRuntime));
 			}
 

--- a/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/dialogs/ViewsPreferencePage.java
+++ b/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/dialogs/ViewsPreferencePage.java
@@ -26,6 +26,7 @@ import static org.eclipse.ui.internal.registry.IWorkbenchRegistryConstants.ATT_O
 import static org.eclipse.ui.internal.registry.IWorkbenchRegistryConstants.ATT_THEME_ASSOCIATION;
 import static org.eclipse.ui.internal.registry.IWorkbenchRegistryConstants.ATT_THEME_ID;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -58,6 +59,7 @@ import org.eclipse.jface.dialogs.MessageDialog;
 import org.eclipse.jface.fieldassist.ControlDecoration;
 import org.eclipse.jface.fieldassist.FieldDecorationRegistry;
 import org.eclipse.jface.layout.GridDataFactory;
+import org.eclipse.jface.preference.IPersistentPreferenceStore;
 import org.eclipse.jface.preference.IPreferenceStore;
 import org.eclipse.jface.preference.PreferencePage;
 import org.eclipse.jface.viewers.ArrayContentProvider;
@@ -88,6 +90,7 @@ import org.eclipse.ui.internal.WorkbenchMessages;
 import org.eclipse.ui.internal.WorkbenchPlugin;
 import org.eclipse.ui.internal.themes.IThemeDescriptor;
 import org.eclipse.ui.internal.util.PrefUtil;
+import org.eclipse.ui.preferences.ScopedPreferenceStore;
 import org.eclipse.ui.themes.IThemeManager;
 import org.osgi.service.prefs.BackingStoreException;
 
@@ -238,8 +241,8 @@ public class ViewsPreferencePage extends PreferencePage implements IWorkbenchPre
 		}
 		createLabel(parent, ""); //$NON-NLS-1$
 
-		boolean initialStateRescaleAtRuntime = ConfigurationScope.INSTANCE.getNode(WorkbenchPlugin.PI_WORKBENCH)
-				.getBoolean(IWorkbenchPreferenceConstants.RESCALING_AT_RUNTIME, true);
+		boolean initialStateRescaleAtRuntime = new ScopedPreferenceStore(ConfigurationScope.INSTANCE,
+				WorkbenchPlugin.PI_WORKBENCH).getBoolean(IWorkbenchPreferenceConstants.RESCALING_AT_RUNTIME);
 		rescaleAtRuntime = createCheckButton(parent, WorkbenchMessages.RescaleAtRuntimeEnabled,
 				initialStateRescaleAtRuntime);
 		if (!DPIUtil.isSetupCompatibleToMonitorSpecificScaling()) {
@@ -486,16 +489,17 @@ public class ViewsPreferencePage extends PreferencePage implements IWorkbenchPre
 
 		boolean isRescaleAtRuntimeChanged = false;
 		if (rescaleAtRuntime != null) {
-			IEclipsePreferences configurationScopeNode = ConfigurationScope.INSTANCE
-					.getNode(WorkbenchPlugin.PI_WORKBENCH);
+			IPersistentPreferenceStore configurationScopeNode = new ScopedPreferenceStore(ConfigurationScope.INSTANCE,
+					WorkbenchPlugin.PI_WORKBENCH);
 			boolean initialStateRescaleAtRuntime = configurationScopeNode
-					.getBoolean(IWorkbenchPreferenceConstants.RESCALING_AT_RUNTIME, true);
+					.getBoolean(IWorkbenchPreferenceConstants.RESCALING_AT_RUNTIME);
 			isRescaleAtRuntimeChanged = initialStateRescaleAtRuntime != rescaleAtRuntime.getSelection();
-			configurationScopeNode.putBoolean(IWorkbenchPreferenceConstants.RESCALING_AT_RUNTIME,
-					rescaleAtRuntime.getSelection());
+			configurationScopeNode.setValue(IWorkbenchPreferenceConstants.RESCALING_AT_RUNTIME,
+					Boolean.toString(rescaleAtRuntime.getSelection()));
 			try {
-				configurationScopeNode.flush();
-			} catch (BackingStoreException e) {
+				configurationScopeNode.save();
+			} catch (IOException e) {
+				WorkbenchPlugin.log("Failed to set monitor-specific scaling preference", e); //$NON-NLS-1$
 			}
 		}
 
@@ -626,6 +630,12 @@ public class ViewsPreferencePage extends PreferencePage implements IWorkbenchPre
 		IPreferenceStore apiStore = PrefUtil.getAPIPreferenceStore();
 		useColoredLabels.setSelection(apiStore.getDefaultBoolean(IWorkbenchPreferenceConstants.USE_COLORED_LABELS));
 
+		if (rescaleAtRuntime != null) {
+			IPreferenceStore configurationStore = new ScopedPreferenceStore(ConfigurationScope.INSTANCE,
+					WorkbenchPlugin.PI_WORKBENCH);
+			rescaleAtRuntime.setSelection(
+					configurationStore.getDefaultBoolean(IWorkbenchPreferenceConstants.RESCALING_AT_RUNTIME));
+		}
 		enableMru.setSelection(defaultPrefs.getBoolean(StackRenderer.MRU_KEY_DEFAULT, StackRenderer.MRU_DEFAULT));
 		super.performDefaults();
 	}

--- a/bundles/org.eclipse.ui/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Plugin.name
 Bundle-SymbolicName: org.eclipse.ui; singleton:=true
-Bundle-Version: 3.209.0.qualifier
+Bundle-Version: 3.209.100.qualifier
 Bundle-Activator: org.eclipse.ui.internal.UIPlugin
 Bundle-ActivationPolicy: lazy
 Bundle-Vendor: %Plugin.providerName

--- a/bundles/org.eclipse.ui/src/org/eclipse/ui/internal/UIPreferenceInitializer.java
+++ b/bundles/org.eclipse.ui/src/org/eclipse/ui/internal/UIPreferenceInitializer.java
@@ -61,6 +61,7 @@ public class UIPreferenceInitializer extends AbstractPreferenceInitializer {
 		node.putBoolean(IWorkbenchPreferenceConstants.LINK_NAVIGATOR_TO_EDITOR,
 				false);
 
+		node.putBoolean(IWorkbenchPreferenceConstants.RESCALING_AT_RUNTIME, true);
 		node.putBoolean(IWorkbenchPreferenceConstants.USE_COLORED_LABELS, true);
 		node.putBoolean(
 				IWorkbenchPreferenceConstants.SHOW_TEXT_ON_PERSPECTIVE_BAR,


### PR DESCRIPTION
When restoring the default values for the "Appearance" preference page, the Windows-specific preference for enabling/disabling monitor-specific scaling is not updated. The default value for this preference is currently defined at every place accessing the preference redundantly.

With this change, a proper default value in the default preference scope is defined for the monitor-specific scaling preference. This value is used by all consumers of the preference via a ScopedPreferenceStore. The defaults restoration of the "Appearance" preference page is extended with a restore of the monitor-specific scaling preference.

### How to test

Open the "Apperance" page of the preference dialog and press "Restore Defaults". Without this change, the "Use monitor-specific UI scaling" option will not change. With this change, the default value (enabled) will be applied.

<img width="624" height="596" alt="image" src="https://github.com/user-attachments/assets/acc7b123-a368-4a28-8277-f941654bb9c8" />
