### PR TITLE
Migrate ProblemsViewPerformanceTest to JUnit 5

### DIFF
--- a/tests/org.eclipse.ui.tests.performance/src/org/eclipse/ui/tests/performance/ProblemsViewPerformanceTest.java
+++ b/tests/org.eclipse.ui.tests.performance/src/org/eclipse/ui/tests/performance/ProblemsViewPerformanceTest.java
@@ -16,7 +16,7 @@ package org.eclipse.ui.tests.performance;
 
 import static org.eclipse.ui.tests.harness.util.UITestUtil.openTestWindow;
 import static org.eclipse.ui.tests.harness.util.UITestUtil.processEvents;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -26,25 +26,28 @@ import org.eclipse.core.resources.IResource;
 import org.eclipse.core.resources.IWorkspaceRoot;
 import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.CoreException;
-import org.eclipse.test.performance.PerformanceTestCaseJunit4;
+import org.eclipse.test.performance.PerformanceTestCaseJunit5;
 import org.eclipse.ui.IWorkbenchPage;
 import org.eclipse.ui.IWorkbenchWindow;
 import org.eclipse.ui.PartInitException;
-import org.eclipse.ui.tests.harness.util.CloseTestWindowsRule;
+import org.eclipse.ui.tests.harness.util.CloseTestWindowsExtension;
 import org.eclipse.ui.tests.performance.parts.PerformanceProblemsView;
 import org.eclipse.ui.texteditor.MarkerUtilities;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 /**
  * The ProblemsViewPerformanceTest is a test of population of the problems view.
  *
  * @since 3.2
  */
-public class ProblemsViewPerformanceTest extends PerformanceTestCaseJunit4 {
+public class ProblemsViewPerformanceTest extends PerformanceTestCaseJunit5 {
 
-	@Rule
-	public final CloseTestWindowsRule closeTestWindows = new CloseTestWindowsRule();
+	@RegisterExtension
+	static UIPerformanceTestRule uiPerformanceTestRule = new UIPerformanceTestRule();
+
+	@RegisterExtension
+	CloseTestWindowsExtension closeTestWindows = new CloseTestWindowsExtension();
 
 	private final String EMPTY_PERSPECTIVE_ID = "org.eclipse.ui.tests.harness.util.EmptyPerspective";
 
@@ -81,7 +84,6 @@ public class ProblemsViewPerformanceTest extends PerformanceTestCaseJunit4 {
 		}
 		commitMeasurements();
 		assertPerformance();
-
 	}
 
 	/**


### PR DESCRIPTION
Migrate this performance test from JUnit 4 to JUnit 5. The test now extends `PerformanceTestCaseJunit5` (the JUnit 5 counterpart of the dropped `PerformanceTestCaseJunit4`), which manages the `PerformanceMeter` via `@BeforeEach`/`@AfterEach`, and `CloseTestWindowsRule` is replaced with `CloseTestWindowsExtension`. Reusing the shared base class keeps the meter handling consistent with all other performance tests instead of reimplementing it locally.