### PR TITLE
Improve fail message in QuickAccessDialogTest.testPreviousChoicesAvailableForExtension

### DIFF
--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/quickaccess/QuickAccessDialogTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/quickaccess/QuickAccessDialogTest.java
@@ -300,7 +300,8 @@ public class QuickAccessDialogTest {
 		text.setText(TestQuickAccessComputer.TEST_QUICK_ACCESS_PROPOSAL_LABEL);
 		final Table firstTable = dialog.getQuickAccessContents().getTable();
 		assertTrue(DisplayHelper.waitForCondition(text.getDisplay(), TIMEOUT,
-				() -> dialogContains(dialog, TestQuickAccessComputer.TEST_QUICK_ACCESS_PROPOSAL_LABEL)));
+				() -> dialogContains(dialog, TestQuickAccessComputer.TEST_QUICK_ACCESS_PROPOSAL_LABEL)),
+				"Unexpected dialog contents: " + getAllEntries(dialog.getQuickAccessContents().getTable()));
 		firstTable.select(0);
 		activateCurrentElement(dialog);
 		// then try in a new SearchField


### PR DESCRIPTION
This change includes quick assist dialog table contents in the fail message of `QuickAccessDialogTest.testPreviousChoicesAvailableForExtension`, in case the table contents dont contain the expected test proposal.

See: https://github.com/eclipse-platform/eclipse.platform.ui/issues/4009