### PR TITLE
Remove unnecessary "Apply and Close" button from Properties dialog

### DIFF
--- a/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/dialogs/PropertyDialog.java
+++ b/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/dialogs/PropertyDialog.java
@@ -17,6 +17,7 @@ package org.eclipse.ui.internal.dialogs;
 
 import java.util.Iterator;
 import org.eclipse.core.runtime.Adapters;
+import org.eclipse.jface.dialogs.IDialogConstants;
 import org.eclipse.jface.dialogs.MessageDialog;
 import org.eclipse.jface.preference.IPreferenceNode;
 import org.eclipse.jface.preference.PreferenceManager;
@@ -24,6 +25,7 @@ import org.eclipse.jface.viewers.ISelection;
 import org.eclipse.jface.viewers.IStructuredSelection;
 import org.eclipse.jface.viewers.StructuredSelection;
 import org.eclipse.osgi.util.NLS;
+import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.Shell;
 import org.eclipse.ui.PlatformUI;
@@ -89,6 +91,20 @@ public class PropertyDialog extends FilteredPreferenceDialog {
 
 		return propertyDialog;
 
+	}
+	
+	@Override
+	protected void buttonPressed(int buttonId) {
+		if (buttonId == IDialogConstants.CLOSE_ID) {
+			cancelPressed();
+			return;
+		}
+		super.buttonPressed(buttonId);
+	}
+
+	@Override
+	protected void createButtonsForButtonBar(Composite parent) {
+		createButton(parent, IDialogConstants.CLOSE_ID, IDialogConstants.CLOSE_LABEL, true);
 	}
 
 	@Override
@@ -160,6 +176,11 @@ public class PropertyDialog extends FilteredPreferenceDialog {
 	@Override
 	protected String getSelectedNodePreference() {
 		return lastPropertyId;
+	}
+
+	@Override
+	public void updateButtons() {
+		// This function is overridden to remove the Apply and close button
 	}
 
 	/**


### PR DESCRIPTION
The Properties dialog opened from `Installation Details → Properties` does not have any option to edit or make any modifications to the properties. Despite this it still displays both `Cancel` and `Apply and Close` buttons.

Since no changes can be made in this dialog, the `Apply and Close` button is basically redundant here and performs the same action as `Cancel`. This could be confusing to the users hence this commit removes the unnecessary `Apply and Close` button and retain only the `cancel` option.

Fixes :https://github.com/eclipse-equinox/p2/issues/1049

Before: 
<img width="673" height="500" alt="Screenshot 2026-05-18 at 4 53 37 PM" src="https://github.com/user-attachments/assets/60d613db-ab92-42d3-991f-babed96f4c30" />

After: 
<img width="673" height="500" alt="Screenshot 2026-05-18 at 4 54 13 PM" src="https://github.com/user-attachments/assets/cc5fde12-828d-4c85-95c7-0ec4e8946506" />

