### PR TITLE
Support concurrent access on ContextTypeRegistry.fContextTypes

### DIFF
--- a/bundles/org.eclipse.text/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.text/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.text
-Bundle-Version: 3.14.700.qualifier
+Bundle-Version: 3.14.800.qualifier
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Bundle-Activator: org.eclipse.text.internal.Activator

--- a/bundles/org.eclipse.text/src/org/eclipse/text/templates/ContextTypeRegistry.java
+++ b/bundles/org.eclipse.text/src/org/eclipse/text/templates/ContextTypeRegistry.java
@@ -14,8 +14,8 @@
 package org.eclipse.text.templates;
 
 import java.util.Iterator;
-import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 import org.eclipse.jface.text.templates.TemplateContextType;
 
@@ -32,7 +32,7 @@ import org.eclipse.jface.text.templates.TemplateContextType;
 public class ContextTypeRegistry {
 
 	/** all known context types */
-	private final Map<String, TemplateContextType> fContextTypes= new LinkedHashMap<>();
+	private final Map<String, TemplateContextType> fContextTypes= new ConcurrentHashMap<>();
 
 	/**
 	 * Adds a context type to the registry. If there already is a context type


### PR DESCRIPTION
This change adjusts `ContextTypeRegistry` to use a `ConcurrentHashMap`.

NOTE: As a result, iteration order of `contextTypes()` is no longer deterministic, previously this was guaranteed by the underlying `LinkedHashMap`.

Fixes: https://github.com/eclipse-platform/eclipse.platform.ui/issues/4020