### PR TITLE
Wait on initial dialog processing in QuickAccessDialogTest

### DIFF
--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/quickaccess/QuickAccessDialogTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/quickaccess/QuickAccessDialogTest.java
@@ -295,8 +295,16 @@ public class QuickAccessDialogTest {
 	public void testPreviousChoicesAvailableForExtension() {
 		// add one selection to history
 		QuickAccessDialog dialog = new TestQuickAccessDialog(activeWorkbenchWindow, null);
-		dialog.open();
 		Text text = dialog.getQuickAccessContents().getFilterText();
+		text.setText("initial test");
+		dialog.open();
+		/*
+		 * wait for the initial dialog contents, to avoid race conditions later on in the test, see:
+		 * https://github.com/eclipse-platform/eclipse.platform.ui/issues/4009
+		 */
+		assertTrue(DisplayHelper.waitForCondition(text.getDisplay(), TIMEOUT,
+				() -> dialogContains(dialog, "initial test")),
+				"Unexpected dialog contents: " + getAllEntries(dialog.getQuickAccessContents().getTable()));
 		text.setText(TestQuickAccessComputer.TEST_QUICK_ACCESS_PROPOSAL_LABEL);
 		final Table firstTable = dialog.getQuickAccessContents().getTable();
 		assertTrue(DisplayHelper.waitForCondition(text.getDisplay(), TIMEOUT,


### PR DESCRIPTION
This change adjusts `QuickAccessDialogTest.testPreviousChoicesAvailableForExtension()` to show initial Quick Access dialog contents and wait on these contents. This hopefully avoids race conditions between asynchronous dialog processing and test code setting dialog text.

See: https://github.com/eclipse-platform/eclipse.platform.ui/issues/4009