### PR TITLE
Adjust wait for initial dialog contents in QuickAccessDialogTest

### DIFF
--- a/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/misc/Policy.java
+++ b/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/misc/Policy.java
@@ -113,6 +113,11 @@ public class Policy {
 	public static boolean DEBUG_OPERATIONS = DEFAULT;
 
 	/**
+	 * Whether to print debugging information for quick access processing.
+	 */
+	public static boolean DEBUG_QUICK_ACCESS = DEFAULT;
+
+	/**
 	 * Whether to print out verbose information about the operation histories,
 	 * including all notifications sent.
 	 */
@@ -178,6 +183,7 @@ public class Policy {
 			DEBUG_HANDLERS_PERFORMANCE = getDebugOption("/trace/handlers.performance"); //$NON-NLS-1$
 			DEBUG_HANDLERS_VERBOSE = getDebugOption("/trace/handlers.verbose"); //$NON-NLS-1$
 			DEBUG_OPERATIONS = getDebugOption("/trace/operations"); //$NON-NLS-1$
+			DEBUG_QUICK_ACCESS = getDebugOption("/trace/quickaccess"); //$NON-NLS-1$
 			DEBUG_OPERATIONS_VERBOSE = getDebugOption("/trace/operations.verbose"); //$NON-NLS-1$
 			DEBUG_SHOW_ALL_JOBS = getDebugOption("/debug/showAllJobs"); //$NON-NLS-1$
 			DEBUG_STALE_JOBS = getDebugOption("/debug/job.stale"); //$NON-NLS-1$

--- a/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/quickaccess/QuickAccessContents.java
+++ b/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/quickaccess/QuickAccessContents.java
@@ -36,6 +36,8 @@ import java.util.function.Function;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.eclipse.core.commands.internal.util.Tracing;
 import org.eclipse.core.runtime.Adapters;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
@@ -81,6 +83,7 @@ import org.eclipse.swt.widgets.Text;
 import org.eclipse.ui.IWorkbenchPreferenceConstants;
 import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.internal.WorkbenchPlugin;
+import org.eclipse.ui.internal.misc.Policy;
 import org.eclipse.ui.keys.IBindingService;
 import org.eclipse.ui.progress.UIJob;
 import org.eclipse.ui.quickaccess.QuickAccessElement;
@@ -183,6 +186,12 @@ public abstract class QuickAccessContents {
 				computingFeedbackJob.cancel();
 				if (computeProposalsJob == currentComputeEntriesJob && event.getResult().isOK()
 						&& !table.isDisposed()) {
+					if (Policy.DEBUG_QUICK_ACCESS) {
+						Tracing.printTrace(QuickAccessContents.class.getName(),
+								"[" + Thread.currentThread().getName() + "] Setting quick access contents: " + //$NON-NLS-1$ //$NON-NLS-2$
+										Stream.of(entries.get()).flatMap(List::stream).map(e -> e.element.getId())
+												.toList());
+					}
 					display.asyncExec(() -> {
 						computingFeedbackJob.cancel();
 						refreshTable(perfectMatch, entries.get(), filter);

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/quickaccess/QuickAccessDialogTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/quickaccess/QuickAccessDialogTest.java
@@ -45,11 +45,14 @@ import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.commands.ICommandService;
 import org.eclipse.ui.handlers.IHandlerService;
 import org.eclipse.ui.ide.IDE;
+import org.eclipse.ui.internal.misc.Policy;
 import org.eclipse.ui.internal.quickaccess.QuickAccessDialog;
 import org.eclipse.ui.internal.quickaccess.QuickAccessMessages;
 import org.eclipse.ui.tests.harness.util.CloseTestWindowsExtension;
 import org.eclipse.ui.tests.harness.util.DisplayHelper;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -63,6 +66,8 @@ public class QuickAccessDialogTest {
 
 	private class TestQuickAccessDialog extends QuickAccessDialog {
 
+		private volatile String infoText;
+
 		public TestQuickAccessDialog(IWorkbenchWindow activeWorkbenchWindow, Command command) {
 			super(activeWorkbenchWindow, command);
 		}
@@ -70,6 +75,12 @@ public class QuickAccessDialogTest {
 		@Override
 		protected IDialogSettings getDialogSettings() {
 			return dialogSettings;
+		}
+
+		@Override
+		protected void setInfoText(String text) {
+			super.setInfoText(text);
+			infoText = text;
 		}
 	}
 
@@ -81,6 +92,15 @@ public class QuickAccessDialogTest {
 	private IDialogSettings dialogSettings;
 	private IWorkbenchWindow activeWorkbenchWindow;
 
+	@BeforeAll
+	public static void enableDebugOutputs() {
+		Policy.DEBUG_QUICK_ACCESS = true;
+	}
+
+	@AfterAll
+	public static void disableDebugOutputs() {
+		Policy.DEBUG_QUICK_ACCESS = false;
+	}
 
 	@BeforeEach
 	public void setUp() throws Exception {
@@ -294,17 +314,16 @@ public class QuickAccessDialogTest {
 	@Test
 	public void testPreviousChoicesAvailableForExtension() {
 		// add one selection to history
-		QuickAccessDialog dialog = new TestQuickAccessDialog(activeWorkbenchWindow, null);
+		TestQuickAccessDialog dialog = new TestQuickAccessDialog(activeWorkbenchWindow, null);
 		Text text = dialog.getQuickAccessContents().getFilterText();
-		text.setText("initial test");
 		dialog.open();
 		/*
-		 * wait for the initial dialog contents, to avoid race conditions later on in the test, see:
+		 * wait for the dialog initialization, to avoid race conditions later on in the test, see:
 		 * https://github.com/eclipse-platform/eclipse.platform.ui/issues/4009
 		 */
-		assertTrue(DisplayHelper.waitForCondition(text.getDisplay(), TIMEOUT,
-				() -> dialogContains(dialog, "initial test")),
-				"Unexpected dialog contents: " + getAllEntries(dialog.getQuickAccessContents().getTable()));
+		assertTrue(DisplayHelper.waitForCondition(text.getDisplay(), TIMEOUT * 1000,
+				() -> dialog.infoText != null),
+				"Unexpected dialog info: " + dialog.infoText);
 		text.setText(TestQuickAccessComputer.TEST_QUICK_ACCESS_PROPOSAL_LABEL);
 		final Table firstTable = dialog.getQuickAccessContents().getTable();
 		assertTrue(DisplayHelper.waitForCondition(text.getDisplay(), TIMEOUT,


### PR DESCRIPTION
Adjusted the wait for initial dialog contents in
`QuickAccessDialogTest.testPreviousChoicesAvailableForExtension()`, to rely on `QuickAccessDialog.setInfoText()` instead of relying on specific dialog contents set during the test.

See: https://github.com/eclipse-platform/eclipse.platform.ui/issues/4009