### PR TITLE
Use TestExecutionListener to log test start and end in org.eclipse.ui.tests

### DIFF
--- a/tests/org.eclipse.ui.tests.harness/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.ui.tests.harness/META-INF/MANIFEST.MF
@@ -10,7 +10,9 @@ Require-Bundle: org.eclipse.ui;bundle-version="3.208.0",
  org.eclipse.core.resources
 Bundle-ActivationPolicy: lazy
 Import-Package: org.junit.jupiter.api;version="[5.0.0,6.0.0)",
- org.junit.jupiter.api.extension;version="[5.0.0,6.0.0)"
+ org.junit.jupiter.api.extension;version="[5.0.0,6.0.0)",
+ org.junit.platform.engine;version="[1.14.0,2.0.0)",
+ org.junit.platform.launcher;version="[1.14.0,2.0.0)"
 Export-Package: org.eclipse.ui.tests.harness,
  org.eclipse.ui.tests.harness.tests,
  org.eclipse.ui.tests.harness.util,

--- a/tests/org.eclipse.ui.tests.harness/src/org/eclipse/ui/tests/harness/util/LogTestListener.java
+++ b/tests/org.eclipse.ui.tests.harness/src/org/eclipse/ui/tests/harness/util/LogTestListener.java
@@ -1,0 +1,40 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Simeon Andreev and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Simeon Andreev - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.ui.tests.harness.util;
+
+import org.eclipse.core.runtime.Status;
+import org.eclipse.ui.internal.UIPlugin;
+import org.junit.platform.engine.TestExecutionResult;
+import org.junit.platform.launcher.TestExecutionListener;
+import org.junit.platform.launcher.TestIdentifier;
+
+/**
+ * Logs tests start and end.
+ */
+public class LogTestListener implements TestExecutionListener {
+
+	@Override
+	public void executionStarted(TestIdentifier id) {
+		logInfo(id.getDisplayName() + " STARTING");
+	}
+
+	@Override
+	public void executionFinished(TestIdentifier id, TestExecutionResult result) {
+		logInfo(id.getDisplayName() + " DONE: " + result.getStatus());
+	}
+
+	private static void logInfo(String message) {
+		UIPlugin.getDefault().getLog().log(Status.info(message));
+	}
+}

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/MultipleWindowsTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/MultipleWindowsTest.java
@@ -19,20 +19,15 @@ import org.eclipse.ui.IWorkbench;
 import org.eclipse.ui.IWorkbenchWindow;
 import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.WorkbenchException;
-import org.eclipse.ui.tests.harness.util.TestRunLogUtil;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.TestWatcher;
 
 /**
  * A set of tests for multiple monitor situations that ensures interactions are
  * isolated to the respective window.
  */
 public class MultipleWindowsTest {
-	@Rule
-	public TestWatcher LOG_TESTRUN = TestRunLogUtil.LOG_TESTRUN;
 
 	IWorkbench wb;
 	IWorkbenchWindow win1;

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/filteredtree/PatternFilterTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/filteredtree/PatternFilterTest.java
@@ -23,15 +23,10 @@ import org.eclipse.jface.viewers.ContentViewer;
 import org.eclipse.jface.viewers.ISelection;
 import org.eclipse.swt.widgets.Control;
 import org.eclipse.ui.dialogs.PatternFilter;
-import org.eclipse.ui.tests.harness.util.TestRunLogUtil;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.TestWatcher;
 
 public class PatternFilterTest {
-	@Rule
-	public TestWatcher LOG_TESTRUN = TestRunLogUtil.LOG_TESTRUN;
 
 	private class MockViewer extends ContentViewer {
 

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/markers/MarkerHelpRegistryReaderTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/markers/MarkerHelpRegistryReaderTest.java
@@ -22,17 +22,12 @@ import static org.mockito.Mockito.verify;
 import org.eclipse.ui.internal.ide.registry.MarkerHelpRegistry;
 import org.eclipse.ui.internal.ide.registry.MarkerHelpRegistryReader;
 import org.eclipse.ui.internal.ide.registry.MarkerQuery;
-import org.eclipse.ui.tests.harness.util.TestRunLogUtil;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.TestWatcher;
 
 /**
  * The test class for {@link MarkerHelpRegistryReader}.
  */
 public class MarkerHelpRegistryReaderTest {
-	@Rule
-	public TestWatcher LOG_TESTRUN = TestRunLogUtil.LOG_TESTRUN;
 
 	/**
 	 * Tests if the matchChildren flag of the contributions to the markerHelp

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/markers/MarkerHelpRegistryTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/markers/MarkerHelpRegistryTest.java
@@ -25,19 +25,14 @@ import org.eclipse.core.resources.IWorkspaceRoot;
 import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.ui.internal.ide.registry.MarkerHelpRegistry;
 import org.eclipse.ui.internal.ide.registry.MarkerHelpRegistryReader;
-import org.eclipse.ui.tests.harness.util.TestRunLogUtil;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.TestWatcher;
 
 /**
  * The test class for {@link MarkerHelpRegistry}.
  */
 public class MarkerHelpRegistryTest {
-	@Rule
-	public TestWatcher LOG_TESTRUN = TestRunLogUtil.LOG_TESTRUN;
 
 	static final String ATT_HELP_CONTEXT = "helpContext";
 	static final String ATT_HAS_HELP = "hasHelp";

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/markers/MarkerQueryTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/markers/MarkerQueryTest.java
@@ -21,19 +21,14 @@ import org.eclipse.core.resources.IMarker;
 import org.eclipse.core.resources.IWorkspaceRoot;
 import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.ui.internal.ide.registry.MarkerQuery;
-import org.eclipse.ui.tests.harness.util.TestRunLogUtil;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.TestWatcher;
 
 /**
  * The test class for {@link MarkerQuery}.
  */
 public class MarkerQueryTest {
-	@Rule
-	public TestWatcher LOG_TESTRUN = TestRunLogUtil.LOG_TESTRUN;
 
 	private IMarker marker;
 	private IMarker child_marker;

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/preferences/ZoomAndPreferencesFontTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/preferences/ZoomAndPreferencesFontTest.java
@@ -35,23 +35,18 @@ import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.commands.ICommandService;
 import org.eclipse.ui.internal.themes.ColorsAndFontsPreferencePage;
 import org.eclipse.ui.part.FileEditorInput;
-import org.eclipse.ui.tests.harness.util.TestRunLogUtil;
 import org.eclipse.ui.texteditor.AbstractTextEditor;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Assume;
 import org.junit.Before;
 import org.junit.BeforeClass;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.TestWatcher;
 
 /**
  * @since 3.11
  */
 public class ZoomAndPreferencesFontTest {
-	@Rule
-	public TestWatcher LOG_TESTRUN = TestRunLogUtil.LOG_TESTRUN;
 
 	private static IProject project;
 	private static IFile file;

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/progress/JobInfoTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/progress/JobInfoTest.java
@@ -25,15 +25,10 @@ import java.util.List;
 import org.eclipse.core.runtime.jobs.Job;
 import org.eclipse.ui.internal.progress.JobInfo;
 import org.eclipse.ui.internal.progress.JobSnapshot;
-import org.eclipse.ui.tests.harness.util.TestRunLogUtil;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.TestWatcher;
 
 public class JobInfoTest {
-	@Rule
-	public TestWatcher LOG_TESTRUN = TestRunLogUtil.LOG_TESTRUN;
 
 
 	/**

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/progress/JobInfoTestOrdering.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/progress/JobInfoTestOrdering.java
@@ -25,14 +25,9 @@ import java.util.List;
 import org.eclipse.core.runtime.jobs.Job;
 import org.eclipse.ui.internal.progress.JobInfo;
 import org.eclipse.ui.internal.progress.JobSnapshot;
-import org.eclipse.ui.tests.harness.util.TestRunLogUtil;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.TestWatcher;
 
 public class JobInfoTestOrdering {
-	@Rule
-	public TestWatcher LOG_TESTRUN = TestRunLogUtil.LOG_TESTRUN;
 
 	/**
 	 * Test that checks when jobs sorted by their state, the running ones

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/progress/ProgressAnimationItemTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/progress/ProgressAnimationItemTest.java
@@ -46,16 +46,11 @@ import org.eclipse.ui.internal.progress.ProgressAnimationItem;
 import org.eclipse.ui.internal.progress.ProgressManager;
 import org.eclipse.ui.internal.progress.ProgressRegion;
 import org.eclipse.ui.progress.IProgressConstants;
-import org.eclipse.ui.tests.harness.util.TestRunLogUtil;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.TestWatcher;
 
 public class ProgressAnimationItemTest {
-	@Rule
-	public TestWatcher LOG_TESTRUN = TestRunLogUtil.LOG_TESTRUN;
 
 	private Shell shell;
 	private ProgressAnimationItem animationItem;

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/releng/PluginActivationTests.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/releng/PluginActivationTests.java
@@ -24,12 +24,9 @@ import org.eclipse.core.runtime.Platform;
 import org.eclipse.ui.IWorkbenchWindow;
 import org.eclipse.ui.PartInitException;
 import org.eclipse.ui.PlatformUI;
-import org.eclipse.ui.tests.harness.util.TestRunLogUtil;
 import org.junit.Before;
 import org.junit.Ignore;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.TestWatcher;
 import org.osgi.framework.Bundle;
 import org.osgi.framework.FrameworkUtil;
 
@@ -47,8 +44,6 @@ import org.osgi.framework.FrameworkUtil;
  */
 
 public class PluginActivationTests {
-	@Rule
-	public TestWatcher LOG_TESTRUN = TestRunLogUtil.LOG_TESTRUN;
 
 	private static List<String> NOT_ACTIVE_BUNDLES = List.of(
 			"org.apache.xerces",

--- a/tests/org.eclipse.ui.tests/META-INF/services/org.junit.platform.launcher.TestExecutionListener
+++ b/tests/org.eclipse.ui.tests/META-INF/services/org.junit.platform.launcher.TestExecutionListener
@@ -1,0 +1,1 @@
+org.eclipse.ui.tests.harness.util.LogTestListener


### PR DESCRIPTION
Add a JUnit Jupiter `TestExecutionListener` to `org.eclipse.ui.tests`, which logs test start and end events via `UIPlugin`.
The listener is defined in `org.eclipse.ui.tests.harness`, so that it can be reused by other test bundles.

Fixes: https://github.com/eclipse-platform/eclipse.platform.ui/issues/4032
