### PR TITLE
Use OSGI tracing and debug options handling in org.eclipse.ui.workbench

### DIFF
--- a/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/ObjectActionContributor.java
+++ b/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/ObjectActionContributor.java
@@ -118,7 +118,7 @@ public class ObjectActionContributor extends PluginActionBuilder implements IObj
 			IStructuredSelection newSelection = LegacyResourceSupport.adaptSelection(ssel, getObjectClass());
 			if (newSelection.size() != ssel.size()) {
 				if (Policy.DEBUG_CONTRIBUTIONS) {
-					WorkbenchPlugin.log("Error adapting selection to " + getObjectClass() + //$NON-NLS-1$
+					WorkbenchPlugin.getDefault().getTrace().trace(Policy.DEBUG_CONTRIBUTIONS_FLAG, "Error adapting selection to " + getObjectClass() + //$NON-NLS-1$
 							". Contribution " + getID(config) + " is being ignored"); //$NON-NLS-1$ //$NON-NLS-2$
 				}
 				return false;
@@ -208,7 +208,7 @@ public class ObjectActionContributor extends PluginActionBuilder implements IObj
 			Object adapted = LegacyResourceSupport.getAdapter(object, getObjectClass());
 			if (adapted == null) {
 				if (Policy.DEBUG_CONTRIBUTIONS) {
-					WorkbenchPlugin.log("Error adapting " + object.getClass().getName() + //$NON-NLS-1$
+					WorkbenchPlugin.getDefault().getTrace().trace(Policy.DEBUG_CONTRIBUTIONS_FLAG, "Error adapting " + object.getClass().getName() + //$NON-NLS-1$
 							" to " //$NON-NLS-1$
 							+ getObjectClass() + ". Contribution " + getID(config) + " is being ignored"); //$NON-NLS-1$ //$NON-NLS-2$
 				}

--- a/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/WorkbenchImages.java
+++ b/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/WorkbenchImages.java
@@ -309,7 +309,7 @@ public/* final */class WorkbenchImages {
 		if (Policy.DEBUG_DECLARED_IMAGES) {
 			Image image = descriptor.createImage(false);
 			if (image == null) {
-				WorkbenchPlugin.log("Image not found in WorkbenchImages.declaredImage().  symbolicName=" + symbolicName //$NON-NLS-1$
+				WorkbenchPlugin.getDefault().getTrace().trace(Policy.DEBUG_DECLARED_IMAGES_FLAG, "Image not found in WorkbenchImages.declaredImage().  symbolicName=" + symbolicName //$NON-NLS-1$
 						+ " descriptor=" + descriptor, new Exception("stack dump")); //$NON-NLS-1$//$NON-NLS-2$
 			} else {
 				image.dispose();

--- a/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/WorkbenchPlugin.java
+++ b/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/WorkbenchPlugin.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2025 IBM Corporation and others.
+ * Copyright (c) 2000, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -16,11 +16,63 @@
 
 package org.eclipse.ui.internal;
 
+import static org.eclipse.ui.internal.misc.Policy.DEBUG_COMMANDS;
+import static org.eclipse.ui.internal.misc.Policy.DEBUG_COMMANDS_FLAG;
+import static org.eclipse.ui.internal.misc.Policy.DEBUG_CONTEXTS;
+import static org.eclipse.ui.internal.misc.Policy.DEBUG_CONTEXTS_FLAG;
+import static org.eclipse.ui.internal.misc.Policy.DEBUG_CONTEXTS_PERFORMANCE;
+import static org.eclipse.ui.internal.misc.Policy.DEBUG_CONTEXTS_PERFORMANCE_FLAG;
+import static org.eclipse.ui.internal.misc.Policy.DEBUG_CONTEXTS_VERBOSE;
+import static org.eclipse.ui.internal.misc.Policy.DEBUG_CONTEXTS_VERBOSE_FLAG;
+import static org.eclipse.ui.internal.misc.Policy.DEBUG_CONTRIBUTIONS;
+import static org.eclipse.ui.internal.misc.Policy.DEBUG_CONTRIBUTIONS_FLAG;
+import static org.eclipse.ui.internal.misc.Policy.DEBUG_DECLARED_IMAGES;
+import static org.eclipse.ui.internal.misc.Policy.DEBUG_DECLARED_IMAGES_FLAG;
+import static org.eclipse.ui.internal.misc.Policy.DEBUG_DRAG_DROP;
+import static org.eclipse.ui.internal.misc.Policy.DEBUG_DRAG_DROP_FLAG;
+import static org.eclipse.ui.internal.misc.Policy.DEBUG_HANDLERS;
+import static org.eclipse.ui.internal.misc.Policy.DEBUG_HANDLERS_FLAG;
+import static org.eclipse.ui.internal.misc.Policy.DEBUG_HANDLERS_PERFORMANCE;
+import static org.eclipse.ui.internal.misc.Policy.DEBUG_HANDLERS_PERFORMANCE_FLAG;
+import static org.eclipse.ui.internal.misc.Policy.DEBUG_HANDLERS_VERBOSE;
+import static org.eclipse.ui.internal.misc.Policy.DEBUG_HANDLERS_VERBOSE_COMMAND_ID;
+import static org.eclipse.ui.internal.misc.Policy.DEBUG_HANDLERS_VERBOSE_COMMAND_ID_FLAG;
+import static org.eclipse.ui.internal.misc.Policy.DEBUG_HANDLERS_VERBOSE_FLAG;
+import static org.eclipse.ui.internal.misc.Policy.DEBUG_KEY_BINDINGS;
+import static org.eclipse.ui.internal.misc.Policy.DEBUG_KEY_BINDINGS_FLAG;
+import static org.eclipse.ui.internal.misc.Policy.DEBUG_KEY_BINDINGS_VERBOSE;
+import static org.eclipse.ui.internal.misc.Policy.DEBUG_KEY_BINDINGS_VERBOSE_FLAG;
+import static org.eclipse.ui.internal.misc.Policy.DEBUG_MPE;
+import static org.eclipse.ui.internal.misc.Policy.DEBUG_MPE_FLAG;
+import static org.eclipse.ui.internal.misc.Policy.DEBUG_OPERATIONS;
+import static org.eclipse.ui.internal.misc.Policy.DEBUG_OPERATIONS_FLAG;
+import static org.eclipse.ui.internal.misc.Policy.DEBUG_OPERATIONS_VERBOSE;
+import static org.eclipse.ui.internal.misc.Policy.DEBUG_OPERATIONS_VERBOSE_FLAG;
+import static org.eclipse.ui.internal.misc.Policy.DEBUG_SHOW_ALL_JOBS;
+import static org.eclipse.ui.internal.misc.Policy.DEBUG_SHOW_ALL_JOBS_FLAG;
+import static org.eclipse.ui.internal.misc.Policy.DEBUG_SOURCES;
+import static org.eclipse.ui.internal.misc.Policy.DEBUG_SOURCES_FLAG;
+import static org.eclipse.ui.internal.misc.Policy.DEBUG_STALE_JOBS;
+import static org.eclipse.ui.internal.misc.Policy.DEBUG_STALE_JOBS_FLAG;
+import static org.eclipse.ui.internal.misc.Policy.DEBUG_SWT_DEBUG;
+import static org.eclipse.ui.internal.misc.Policy.DEBUG_SWT_DEBUG_FLAG;
+import static org.eclipse.ui.internal.misc.Policy.DEBUG_SWT_DEBUG_GLOBAL;
+import static org.eclipse.ui.internal.misc.Policy.DEBUG_SWT_DEBUG_GLOBAL_FLAG;
+import static org.eclipse.ui.internal.misc.Policy.DEBUG_SWT_GRAPHICS;
+import static org.eclipse.ui.internal.misc.Policy.DEBUG_SWT_GRAPHICS_FLAG;
+import static org.eclipse.ui.internal.misc.Policy.DEBUG_TOOLBAR_DISPOSAL;
+import static org.eclipse.ui.internal.misc.Policy.DEBUG_TOOLBAR_DISPOSAL_FLAG;
+import static org.eclipse.ui.internal.misc.Policy.DEBUG_WORKING_SETS;
+import static org.eclipse.ui.internal.misc.Policy.DEBUG_WORKING_SETS_FLAG;
+import static org.eclipse.ui.internal.misc.Policy.DEFAULT;
+import static org.eclipse.ui.internal.misc.Policy.EXPERIMENTAL_MENU;
+
 import java.text.Bidi;
 import java.text.MessageFormat;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.Hashtable;
 import java.util.Locale;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IConfigurationElement;
@@ -41,8 +93,11 @@ import org.eclipse.jface.resource.ImageRegistry;
 import org.eclipse.jface.util.BidiUtils;
 import org.eclipse.jface.window.Window;
 import org.eclipse.osgi.service.debug.DebugOptions;
+import org.eclipse.osgi.service.debug.DebugOptionsListener;
+import org.eclipse.osgi.service.debug.DebugTrace;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.custom.BusyIndicator;
+import org.eclipse.swt.graphics.Device;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Shell;
 import org.eclipse.ui.IDecoratorManager;
@@ -58,6 +113,7 @@ import org.eclipse.ui.internal.help.CommandHelpServiceImpl;
 import org.eclipse.ui.internal.help.HelpServiceImpl;
 import org.eclipse.ui.internal.intro.IIntroRegistry;
 import org.eclipse.ui.internal.intro.IntroRegistry;
+import org.eclipse.ui.internal.misc.Policy;
 import org.eclipse.ui.internal.misc.StatusUtil;
 import org.eclipse.ui.internal.operations.WorkbenchOperationSupport;
 import org.eclipse.ui.internal.progress.ProgressManager;
@@ -85,6 +141,7 @@ import org.osgi.framework.BundleContext;
 import org.osgi.framework.BundleEvent;
 import org.osgi.framework.BundleException;
 import org.osgi.framework.BundleListener;
+import org.osgi.framework.ServiceRegistration;
 import org.osgi.util.tracker.ServiceTracker;
 
 /**
@@ -103,7 +160,7 @@ import org.osgi.util.tracker.ServiceTracker;
  * createExecutableExtension to create an executable instance of our workbench
  * class.
  */
-public class WorkbenchPlugin extends AbstractUIPlugin {
+public class WorkbenchPlugin extends AbstractUIPlugin implements DebugOptionsListener {
 
 	/**
 	 * Splash shell constant.
@@ -163,6 +220,8 @@ public class WorkbenchPlugin extends AbstractUIPlugin {
 	// TODO we should just drop this constant and use PlatformUI.PLUGIN_ID instead
 	public static String PI_WORKBENCH = PlatformUI.PLUGIN_ID;
 
+	private static final String JFACE = "org.eclipse.jface"; //$NON-NLS-1$
+
 	/**
 	 * The character used to separate preference page category ids
 	 */
@@ -201,6 +260,10 @@ public class WorkbenchPlugin extends AbstractUIPlugin {
 	private EHelpService helpService;
 
 	private ICommandHelpService commandHelpService;
+
+	private ServiceRegistration<DebugOptionsListener> debugRegistration;
+
+	private DebugTrace trace;
 
 	/**
 	 * Create an instance of the WorkbenchPlugin. The workbench plugin is
@@ -762,6 +825,10 @@ public class WorkbenchPlugin extends AbstractUIPlugin {
 		parseBidiArguments();
 		Window.setDefaultOrientation(getDefaultOrientation());
 
+		Hashtable<String, String> properties = new Hashtable<>(2);
+		properties.put(DebugOptions.LISTENER_SYMBOLICNAME, PlatformUI.PLUGIN_ID);
+		debugRegistration = context.registerService(DebugOptionsListener.class, this, properties);
+
 		// The UI plugin needs to be initialized so that it can install the callback in
 		// PrefUtil,
 		// which needs to be done as early as possible, before the workbench
@@ -1060,6 +1127,10 @@ public class WorkbenchPlugin extends AbstractUIPlugin {
 		if (testableTracker != null) {
 			testableTracker.close();
 			testableTracker = null;
+		}
+		if (debugRegistration != null) {
+			debugRegistration.unregister();
+			debugRegistration = null;
 		}
 		super.stop(context);
 	}
@@ -1435,5 +1506,42 @@ public class WorkbenchPlugin extends AbstractUIPlugin {
 			testableTracker.open();
 		}
 		return (TestableObject) testableTracker.getService();
+	}
+
+	@Override
+	public void optionsChanged(DebugOptions options) {
+		trace = options.newDebugTrace(PlatformUI.PLUGIN_ID);
+		DEBUG_SWT_GRAPHICS = options.getBooleanOption(PlatformUI.PLUGIN_ID + DEBUG_SWT_GRAPHICS_FLAG, DEFAULT);
+		DEBUG_SWT_DEBUG = options.getBooleanOption(PlatformUI.PLUGIN_ID + DEBUG_SWT_DEBUG_FLAG, DEFAULT);
+		DEBUG_SWT_DEBUG_GLOBAL = options.getBooleanOption(PlatformUI.PLUGIN_ID + DEBUG_SWT_DEBUG_GLOBAL_FLAG, DEFAULT);
+		DEBUG_DRAG_DROP = options.getBooleanOption(PlatformUI.PLUGIN_ID + DEBUG_DRAG_DROP_FLAG, DEFAULT);
+		DEBUG_SOURCES = options.getBooleanOption(PlatformUI.PLUGIN_ID + DEBUG_SOURCES_FLAG, DEFAULT);
+		DEBUG_KEY_BINDINGS = options.getBooleanOption(PlatformUI.PLUGIN_ID + DEBUG_KEY_BINDINGS_FLAG, DEFAULT);
+		DEBUG_KEY_BINDINGS_VERBOSE = options.getBooleanOption(PlatformUI.PLUGIN_ID + DEBUG_KEY_BINDINGS_VERBOSE_FLAG, DEFAULT);
+		DEBUG_TOOLBAR_DISPOSAL = options.getBooleanOption(JFACE + DEBUG_TOOLBAR_DISPOSAL_FLAG, DEFAULT);
+		DEBUG_COMMANDS = options.getBooleanOption(PlatformUI.PLUGIN_ID + DEBUG_COMMANDS_FLAG, DEFAULT);
+		DEBUG_CONTEXTS = options.getBooleanOption(PlatformUI.PLUGIN_ID + DEBUG_CONTEXTS_FLAG, DEFAULT);
+		DEBUG_CONTEXTS_PERFORMANCE = options.getBooleanOption(PlatformUI.PLUGIN_ID + DEBUG_CONTEXTS_PERFORMANCE_FLAG, DEFAULT);
+		DEBUG_CONTEXTS_VERBOSE = options.getBooleanOption(PlatformUI.PLUGIN_ID + DEBUG_CONTEXTS_VERBOSE_FLAG, DEFAULT);
+		DEBUG_HANDLERS = options.getBooleanOption(PlatformUI.PLUGIN_ID + DEBUG_HANDLERS_FLAG, DEFAULT);
+		DEBUG_HANDLERS_PERFORMANCE = options.getBooleanOption(PlatformUI.PLUGIN_ID + DEBUG_HANDLERS_PERFORMANCE_FLAG, DEFAULT);
+		DEBUG_HANDLERS_VERBOSE = options.getBooleanOption(PlatformUI.PLUGIN_ID + DEBUG_HANDLERS_VERBOSE_FLAG, DEFAULT);
+		DEBUG_OPERATIONS = options.getBooleanOption(PlatformUI.PLUGIN_ID + DEBUG_OPERATIONS_FLAG, DEFAULT);
+		DEBUG_OPERATIONS_VERBOSE = options.getBooleanOption(PlatformUI.PLUGIN_ID + DEBUG_OPERATIONS_VERBOSE_FLAG, DEFAULT);
+		DEBUG_SHOW_ALL_JOBS = options.getBooleanOption(PlatformUI.PLUGIN_ID + DEBUG_SHOW_ALL_JOBS_FLAG, DEFAULT);
+		DEBUG_STALE_JOBS = options.getBooleanOption(PlatformUI.PLUGIN_ID + DEBUG_STALE_JOBS_FLAG, DEFAULT);
+		DEBUG_DECLARED_IMAGES = options.getBooleanOption(PlatformUI.PLUGIN_ID + DEBUG_DECLARED_IMAGES_FLAG, DEFAULT);
+		DEBUG_CONTRIBUTIONS = options.getBooleanOption(PlatformUI.PLUGIN_ID + DEBUG_CONTRIBUTIONS_FLAG, DEFAULT);
+		DEBUG_HANDLERS_VERBOSE_COMMAND_ID = options.getOption(PlatformUI.PLUGIN_ID + DEBUG_HANDLERS_VERBOSE_COMMAND_ID_FLAG, ""); //$NON-NLS-1$
+		EXPERIMENTAL_MENU = options.getBooleanOption(PlatformUI.PLUGIN_ID + DEBUG_CONTRIBUTIONS_FLAG, DEFAULT);
+		DEBUG_MPE = options.getBooleanOption(PlatformUI.PLUGIN_ID + DEBUG_MPE_FLAG, DEFAULT);
+		DEBUG_WORKING_SETS = options.getBooleanOption(PlatformUI.PLUGIN_ID + DEBUG_WORKING_SETS_FLAG, DEFAULT);
+		if (Policy.DEBUG_SWT_DEBUG_GLOBAL) {
+			Device.DEBUG = true;
+		}
+	}
+
+	public DebugTrace getTrace() {
+		return trace;
 	}
 }

--- a/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/WorkingSet.java
+++ b/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/WorkingSet.java
@@ -180,8 +180,7 @@ public class WorkingSet extends AbstractWorkingSet {
 					IAdaptable item = factory.createElement(itemMemento);
 					if (item == null) {
 						if (Policy.DEBUG_WORKING_SETS) {
-							WorkbenchPlugin
-									.log("Unable to restore working set item - cannot instantiate item: " + factoryID); //$NON-NLS-1$
+							WorkbenchPlugin.getDefault().getTrace().trace(Policy.DEBUG_WORKING_SETS_FLAG, "Unable to restore working set item - cannot instantiate item: " + factoryID); //$NON-NLS-1$
 						}
 					} else {
 						items.add(item);

--- a/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/misc/Policy.java
+++ b/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/misc/Policy.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2015 IBM Corporation and others.
+ * Copyright (c) 2000, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -13,10 +13,7 @@
  *******************************************************************************/
 package org.eclipse.ui.internal.misc;
 
-import org.eclipse.core.runtime.Platform;
-import org.eclipse.swt.graphics.Device;
 import org.eclipse.ui.ISourceProvider;
-import org.eclipse.ui.PlatformUI;
 
 /**
  * A common facility for parsing the <code>org.eclipse.ui/.options</code> file.
@@ -24,6 +21,33 @@ import org.eclipse.ui.PlatformUI;
  * @since 2.1
  */
 public class Policy {
+
+	public static final String DEBUG_SWT_GRAPHICS_FLAG = "/trace/graphics"; //$NON-NLS-1$
+	public static final String DEBUG_SWT_DEBUG_FLAG = "/debug/swtdebug"; //$NON-NLS-1$
+	public static final String DEBUG_SWT_DEBUG_GLOBAL_FLAG = "/debug/swtdebugglobal"; //$NON-NLS-1$
+	public static final String DEBUG_DRAG_DROP_FLAG = "/trace/dragDrop"; //$NON-NLS-1$
+	public static final String DEBUG_SOURCES_FLAG = "/trace/sources"; //$NON-NLS-1$
+	public static final String DEBUG_KEY_BINDINGS_FLAG = "/trace/keyBindings"; //$NON-NLS-1$
+	public static final String DEBUG_KEY_BINDINGS_VERBOSE_FLAG = "/trace/keyBindings.verbose"; //$NON-NLS-1$
+	public static final String DEBUG_TOOLBAR_DISPOSAL_FLAG = "/trace/toolbarDisposal"; //$NON-NLS-1$
+	public static final String DEBUG_COMMANDS_FLAG = "/trace/commands"; //$NON-NLS-1$
+	public static final String DEBUG_CONTEXTS_FLAG = "/trace/contexts"; //$NON-NLS-1$
+	public static final String DEBUG_CONTEXTS_PERFORMANCE_FLAG = "/trace/contexts.performance"; //$NON-NLS-1$
+	public static final String DEBUG_CONTEXTS_VERBOSE_FLAG = "/trace/contexts.verbose"; //$NON-NLS-1$
+	public static final String DEBUG_HANDLERS_FLAG = "/trace/handlers"; //$NON-NLS-1$
+	public static final String DEBUG_HANDLERS_PERFORMANCE_FLAG = "/trace/handlers.performance"; //$NON-NLS-1$
+	public static final String DEBUG_HANDLERS_VERBOSE_FLAG = "/trace/handlers.verbose"; //$NON-NLS-1$
+	public static final String DEBUG_OPERATIONS_FLAG = "/trace/operations"; //$NON-NLS-1$
+	public static final String DEBUG_OPERATIONS_VERBOSE_FLAG = "/trace/operations.verbose"; //$NON-NLS-1$
+	public static final String DEBUG_SHOW_ALL_JOBS_FLAG = "/debug/showAllJobs"; //$NON-NLS-1$
+	public static final String DEBUG_STALE_JOBS_FLAG = "/debug/job.stale"; //$NON-NLS-1$
+	public static final String DEBUG_DECLARED_IMAGES_FLAG = "/debug/declaredImages"; //$NON-NLS-1$
+	public static final String DEBUG_CONTRIBUTIONS_FLAG = "/debug/contributions"; //$NON-NLS-1$
+	public static final String DEBUG_HANDLERS_VERBOSE_COMMAND_ID_FLAG = ""; //$NON-NLS-1$
+	public static final String EXPERIMENTAL_MENU_FLAG = "/experimental/menus"; //$NON-NLS-1$
+	public static final String DEBUG_MPE_FLAG = "/trace/multipageeditor"; //$NON-NLS-1$
+	public static final String DEBUG_WORKING_SETS_FLAG = "/debug/workingSets"; //$NON-NLS-1$
+
 	public static boolean DEFAULT = false;
 
 	public static boolean DEBUG_SWT_GRAPHICS = DEFAULT;
@@ -158,47 +182,4 @@ public class Policy {
 	 * @since 3.4
 	 */
 	public static boolean DEBUG_WORKING_SETS = DEFAULT;
-
-	static {
-		if (getDebugOption("/debug")) { //$NON-NLS-1$
-			DEBUG_SWT_GRAPHICS = getDebugOption("/trace/graphics"); //$NON-NLS-1$
-			DEBUG_SWT_DEBUG = getDebugOption("/debug/swtdebug"); //$NON-NLS-1$
-			DEBUG_SWT_DEBUG_GLOBAL = getDebugOption("/debug/swtdebugglobal"); //$NON-NLS-1$
-			DEBUG_DRAG_DROP = getDebugOption("/trace/dragDrop"); //$NON-NLS-1$
-			DEBUG_SOURCES = getDebugOption("/trace/sources"); //$NON-NLS-1$
-			DEBUG_KEY_BINDINGS = getDebugOption("/trace/keyBindings"); //$NON-NLS-1$
-			DEBUG_KEY_BINDINGS_VERBOSE = getDebugOption("/trace/keyBindings.verbose"); //$NON-NLS-1$
-			DEBUG_TOOLBAR_DISPOSAL = "true" //$NON-NLS-1$
-					.equalsIgnoreCase(Platform.getDebugOption("org.eclipse.jface/trace/toolbarDisposal")); //$NON-NLS-1$
-			DEBUG_COMMANDS = getDebugOption("/trace/commands"); //$NON-NLS-1$
-			DEBUG_CONTEXTS = getDebugOption("/trace/contexts"); //$NON-NLS-1$
-			DEBUG_CONTEXTS_PERFORMANCE = getDebugOption("/trace/contexts.performance"); //$NON-NLS-1$
-			DEBUG_CONTEXTS_VERBOSE = getDebugOption("/trace/contexts.verbose"); //$NON-NLS-1$
-			DEBUG_HANDLERS = getDebugOption("/trace/handlers"); //$NON-NLS-1$
-			DEBUG_HANDLERS_PERFORMANCE = getDebugOption("/trace/handlers.performance"); //$NON-NLS-1$
-			DEBUG_HANDLERS_VERBOSE = getDebugOption("/trace/handlers.verbose"); //$NON-NLS-1$
-			DEBUG_OPERATIONS = getDebugOption("/trace/operations"); //$NON-NLS-1$
-			DEBUG_OPERATIONS_VERBOSE = getDebugOption("/trace/operations.verbose"); //$NON-NLS-1$
-			DEBUG_SHOW_ALL_JOBS = getDebugOption("/debug/showAllJobs"); //$NON-NLS-1$
-			DEBUG_STALE_JOBS = getDebugOption("/debug/job.stale"); //$NON-NLS-1$
-			DEBUG_HANDLERS_VERBOSE_COMMAND_ID = Platform
-					.getDebugOption(PlatformUI.PLUGIN_ID + "/trace/handlers.verbose.commandId"); //$NON-NLS-1$
-			if ("".equals(DEBUG_HANDLERS_VERBOSE_COMMAND_ID)) { //$NON-NLS-1$
-				DEBUG_HANDLERS_VERBOSE_COMMAND_ID = null;
-			}
-			DEBUG_DECLARED_IMAGES = getDebugOption("/debug/declaredImages"); //$NON-NLS-1$
-			DEBUG_CONTRIBUTIONS = getDebugOption("/debug/contributions"); //$NON-NLS-1$
-			EXPERIMENTAL_MENU = getDebugOption("/experimental/menus"); //$NON-NLS-1$
-			DEBUG_MPE = getDebugOption("/trace/multipageeditor"); //$NON-NLS-1$
-			DEBUG_WORKING_SETS = getDebugOption("/debug/workingSets"); //$NON-NLS-1$
-
-			if (DEBUG_SWT_DEBUG_GLOBAL) {
-				Device.DEBUG = true;
-			}
-		}
-	}
-
-	private static boolean getDebugOption(String option) {
-		return "true".equalsIgnoreCase(Platform.getDebugOption(PlatformUI.PLUGIN_ID + option)); //$NON-NLS-1$
-	}
 }

--- a/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/part/MultiPageEditorPart.java
+++ b/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/part/MultiPageEditorPart.java
@@ -23,7 +23,6 @@ import java.util.List;
 import org.eclipse.core.commands.AbstractHandler;
 import org.eclipse.core.commands.ExecutionEvent;
 import org.eclipse.core.commands.ExecutionException;
-import org.eclipse.core.commands.internal.util.Tracing;
 import org.eclipse.core.runtime.Adapters;
 import org.eclipse.core.runtime.Assert;
 import org.eclipse.core.runtime.ISafeRunnable;
@@ -123,11 +122,6 @@ public abstract class MultiPageEditorPart extends EditorPart implements IPageCha
 	 * @see #getPageSite(int)
 	 */
 	protected static final int PAGE_CONTAINER_SITE = 65535;
-
-	/**
-	 * Private tracing output.
-	 */
-	private static final String TRACING_COMPONENT = "MPE"; //$NON-NLS-1$
 
 	/**
 	 * The active service locator. This value may be <code>null</code> if there is
@@ -879,7 +873,7 @@ public abstract class MultiPageEditorPart extends EditorPart implements IPageCha
 					provider.fireSelectionChanged(event);
 					provider.firePostSelectionChanged(event);
 				} else if (Policy.DEBUG_MPE) {
-					Tracing.printTrace(TRACING_COMPONENT, "MultiPageEditorPart " + getTitle() //$NON-NLS-1$
+					WorkbenchPlugin.getDefault().getTrace().trace(Policy.DEBUG_MPE_FLAG, "MultiPageEditorPart " + getTitle() //$NON-NLS-1$
 							+ " did not propogate selection for " //$NON-NLS-1$
 							+ activeEditor.getTitle());
 				}


### PR DESCRIPTION
Moved debug option handling from `Policy` to `WorkbenchPlugin`, adjusted it to use OSGI debug option handling. Replaced standard out and log tracing in `org.eclipse.ui.workbench` with OSGI tracing.

Fixes: https://github.com/eclipse-platform/eclipse.platform.ui/issues/4033