### PR TITLE
Revert "PreferenceDialog: render filter as native search field"

### DIFF
--- a/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/dialogs/FilteredPreferenceDialog.java
+++ b/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/dialogs/FilteredPreferenceDialog.java
@@ -119,18 +119,6 @@ public abstract class FilteredPreferenceDialog extends PreferenceDialog implemen
 			super(parent, treeStyle, filter, true, true);
 		}
 
-		@Override
-		protected Text doCreateFilterText(Composite parent) {
-			return new Text(parent, SWT.SINGLE | SWT.BORDER | SWT.SEARCH | SWT.ICON_SEARCH | SWT.ICON_CANCEL);
-		}
-
-		@Override
-		public void setInitialText(String text) {
-			if (filterText != null && !filterText.isDisposed()) {
-				filterText.setMessage(text != null ? text : ""); //$NON-NLS-1$
-			}
-		}
-
 		/**
 		 * Add an additional, optional filter to the viewer. If the filter text is
 		 * cleared, this filter will be removed from the TreeViewer.


### PR DESCRIPTION
Reverts #3925, the cause of #4041: the pre-filtered preference dialog (for example opening Preferences from a Java editor context menu) shows an empty page tree because the filter hint is applied as an actual filter pattern that matches no pages.

As agreed in the issue, this restores the previous working behavior for the 4.40 RC2a respin. A proper forward fix on master is handled separately.