### PR TITLE
Fix empty page tree in pre-filtered preference dialog

### DIFF
--- a/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/dialogs/FilteredPreferenceDialog.java
+++ b/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/dialogs/FilteredPreferenceDialog.java
@@ -126,8 +126,12 @@ public abstract class FilteredPreferenceDialog extends PreferenceDialog implemen
 
 		@Override
 		public void setInitialText(String text) {
+			// Track initialText for the empty-filter check and accessible name, and show it
+			// as the field's placeholder hint. Unlike the base implementation we never write
+			// it into the field, so addFilter() cannot turn the hint into an active pattern.
+			initialText = text != null ? text : ""; //$NON-NLS-1$
 			if (filterText != null && !filterText.isDisposed()) {
-				filterText.setMessage(text != null ? text : ""); //$NON-NLS-1$
+				filterText.setMessage(initialText);
 			}
 		}
 
@@ -140,7 +144,8 @@ public abstract class FilteredPreferenceDialog extends PreferenceDialog implemen
 			getViewer().addFilter(filter);
 
 			if (filterText != null) {
-				setFilterText(WorkbenchMessages.FilteredTree_FilterMessage);
+				// Keep the field empty so the viewer filter narrows the pages; the
+				// hint text would otherwise be applied as a pattern and hide all pages.
 				textChanged();
 			}
 


### PR DESCRIPTION
Forward fix for #4041 on master (the 4.40 maintenance branch gets the plain revert in #4043).

The native search field rework in #3925 stopped maintaining the inherited initialText sentinel, so the hint that addFilter() wrote into the field was applied as a real filter pattern and hid every preference page. This keeps the sentinel in sync and no longer writes the hint into the field, so a pre-filtered dialog (for example Preferences from a Java editor context menu) shows its pages again. The native search field is preserved, and the "type filter text" hint is kept as the placeholder message so the field still signals that it filters the pages.