### PR TITLE
Migrate try-catch-fail patterns to assertThrows in tests

### DIFF
--- a/tests/org.eclipse.e4.ui.tests.css.core/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.e4.ui.tests.css.core/META-INF/MANIFEST.MF
@@ -15,6 +15,7 @@ Export-Package: org.eclipse.e4.ui.tests.css.core;x-internal:=true,
  org.eclipse.e4.ui.tests.css.core.util;x-internal:=true
 Automatic-Module-Name: org.eclipse.e4.ui.tests.css.core
 Import-Package: org.junit.jupiter.api;version="[5.14.0,6.0.0)",
+ org.junit.jupiter.api.function;version="[5.14.0,6.0.0)",
  org.junit.platform.suite.api;version="[1.14.0,2.0.0)",
  org.w3c.css.sac;version="1.3.0"
 Bundle-Vendor: %Bundle-Vendor

--- a/tests/org.eclipse.e4.ui.tests.css.core/src/org/eclipse/e4/ui/tests/css/core/parser/SelectorTest.java
+++ b/tests/org.eclipse.e4.ui.tests.css.core/src/org/eclipse/e4/ui/tests/css/core/parser/SelectorTest.java
@@ -16,9 +16,7 @@ package org.eclipse.e4.ui.tests.css.core.parser;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.fail;
-
-import java.io.IOException;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.eclipse.e4.ui.css.core.engine.CSSEngine;
 import org.eclipse.e4.ui.tests.css.core.util.ParserTestUtil;
@@ -69,12 +67,7 @@ public class SelectorTest {
 	}
 
 	@Test
-	void testErrorAttributeSelector() throws IOException {
-		try {
-			engine.parseSelectors("*[class='Class1'"); // missing ']'
-			fail("Parser should have errored on missing bracket");
-		} catch (CSSParseException e) {
-			// ignore
-		}
+	void testErrorAttributeSelector() {
+		assertThrows(CSSParseException.class, () -> engine.parseSelectors("*[class='Class1'")); // missing ']'
 	}
 }

--- a/tests/org.eclipse.e4.ui.tests/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.e4.ui.tests/META-INF/MANIFEST.MF
@@ -39,6 +39,7 @@ Import-Package: jakarta.annotation,
  jakarta.inject,
  org.osgi.service.event,
  org.junit.jupiter.api;version="[5.14.0,6.0.0)",
+ org.junit.jupiter.api.function;version="[5.14.0,6.0.0)",
  org.junit.jupiter.api.extension;version="[5.14.0,6.0.0)",
  org.junit.platform.suite.api;version="[1.14.0,2.0.0)",
  org.opentest4j

--- a/tests/org.eclipse.e4.ui.tests/src/org/eclipse/e4/ui/tests/application/EModelServiceFindTest.java
+++ b/tests/org.eclipse.e4.ui.tests/src/org/eclipse/e4/ui/tests/application/EModelServiceFindTest.java
@@ -14,11 +14,11 @@
  ******************************************************************************/
 package org.eclipse.e4.ui.tests.application;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
-import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -259,26 +259,9 @@ public class EModelServiceFindTest {
 		EModelService modelService = application.getContext().get(EModelService.class);
 		assertNotNull(modelService);
 
-		try {
-			modelService.find("a", null);
-			fail("An exception should have prevented a null parameter to find(*)");
-		} catch (IllegalArgumentException e) {
-			// expected
-		}
-
-		try {
-			modelService.findElements(null, null, null);
-			fail("An exception should have prevented a null parameter to findElements(*)");
-		} catch (IllegalArgumentException e) {
-			// expected
-		}
-
-		try {
-			modelService.findElements(null, null, null, null, EModelService.ANYWHERE);
-			fail("An exception should have prevented a null parameter to findElements(*)");
-		} catch (IllegalArgumentException e) {
-			// expected
-		}
+		assertThrows(IllegalArgumentException.class, () -> modelService.find("a", null));
+		assertThrows(IllegalArgumentException.class, () -> modelService.findElements(null, null, null));
+		assertThrows(IllegalArgumentException.class, () -> modelService.findElements(null, null, null, null, EModelService.ANYWHERE));
 	}
 
 	@Test

--- a/tests/org.eclipse.e4.ui.tests/src/org/eclipse/e4/ui/tests/application/ModelRobustnessTest.java
+++ b/tests/org.eclipse.e4.ui.tests/src/org/eclipse/e4/ui/tests/application/ModelRobustnessTest.java
@@ -16,7 +16,7 @@ package org.eclipse.e4.ui.tests.application;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.List;
 import org.eclipse.e4.ui.internal.workbench.E4XMIResource;
@@ -41,12 +41,8 @@ public class ModelRobustnessTest {
 		ResourceSet set = new ResourceSetImpl();
 		Resource resource = null;
 
-		try {
-			resource = set.getResource(uri, true);
-			fail("This should have thrown an exception");
-		} catch (Exception e) {
-			resource = set.getResource(uri, false);
-		}
+		assertThrows(Exception.class, () -> set.getResource(uri, true));
+		resource = set.getResource(uri, false);
 
 		assertNotNull(resource);
 		assertEquals(E4XMIResource.class, resource.getClass());
@@ -75,17 +71,10 @@ public class ModelRobustnessTest {
 		MApplication app = MApplicationFactory.INSTANCE.createApplication();
 		List l = app.getChildren();
 		l.add(MBasicFactory.INSTANCE.createWindow());
-		try {
-			l.add(MBasicFactory.INSTANCE.createPart());
-			fail("The adding of this should have failed");
-		} catch (IllegalArgumentException | ArrayStoreException | ClassCastException e) {
-			// EList.add says this is the expected exception, although testing
-			// indicates its one of the two previous exceptions that is really
-			// thrown.
-			// See bug 407539
-		} catch (Exception e) {
-			throw new RuntimeException(e);
-		}
+		// EList.add says IllegalArgumentException is the expected exception, although
+		// testing indicates ArrayStoreException or ClassCastException may be thrown.
+		// See bug 407539
+		assertThrows(RuntimeException.class, () -> l.add(MBasicFactory.INSTANCE.createPart()));
 
 		l.add(MBasicFactory.INSTANCE.createWindow());
 		assertEquals(2, l.size());

--- a/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/dialogs/DialogSettingsTest.java
+++ b/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/dialogs/DialogSettingsTest.java
@@ -19,8 +19,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.IOException;
 import java.io.StringReader;
@@ -455,14 +455,9 @@ public class DialogSettingsTest {
 	}
 
 	@Test
-	@SuppressWarnings("resource")
 	public void testSaveWithIOException() {
 		final DialogSettings settings = new DialogSettings("test");
-		try {
-			settings.save(new BrokenWriter());
-			fail("IOException expected");
-		} catch (IOException e) {
-		}
+		assertThrows(IOException.class, () -> settings.save(new BrokenWriter()));
 	}
 
 	private static class BrokenWriter extends Writer {

--- a/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/labelProviders/DecoratingStyledCellLabelProviderTest.java
+++ b/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/labelProviders/DecoratingStyledCellLabelProviderTest.java
@@ -19,8 +19,8 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
 
 import org.eclipse.core.runtime.AssertionFailedException;
 import org.eclipse.jface.resource.JFaceResources;
@@ -238,12 +238,7 @@ public class DecoratingStyledCellLabelProviderTest extends ViewerTestCase {
 
 	@Test
 	public void testSetDecorationContext() {
-		try {
-			getDecoratingStyledLabelProvider().setDecorationContext(null);
-			fail("DecoratingStyledCellLabelProvider.setDecorationContext did not throw an exception when passed null");
-		} catch (AssertionFailedException e) {
-			// A Good Thing.
-		}
+		assertThrows(AssertionFailedException.class, () -> getDecoratingStyledLabelProvider().setDecorationContext(null));
 	}
 
 	@Test

--- a/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/labelProviders/IDecorationContextTest.java
+++ b/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/labelProviders/IDecorationContextTest.java
@@ -15,7 +15,7 @@
 package org.eclipse.jface.tests.labelProviders;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.eclipse.core.runtime.AssertionFailedException;
 import org.eclipse.jface.viewers.DecoratingStyledCellLabelProvider;
@@ -141,12 +141,7 @@ public class IDecorationContextTest {
 	@Test
 	public void testSetDecorationContextNull() {
 		DecoratingStyledCellLabelProvider label = getDecoratingStyledCellLabelProvider(false);
-		try {
-			label.setDecorationContext(null);
-			fail("DecoratingStyledCellLabelProvider.setDecorationContext did not throw an exception when passed null");
-		} catch (AssertionFailedException e) {
-			// A Good Thing.
-		}
+		assertThrows(AssertionFailedException.class, () -> label.setDecorationContext(null));
 	}
 
 }

--- a/tests/org.eclipse.jface.text.tests/src/org/eclipse/jface/text/tests/TextPresentationTest.java
+++ b/tests/org.eclipse.jface.text.tests/src/org/eclipse/jface/text/tests/TextPresentationTest.java
@@ -15,8 +15,8 @@ package org.eclipse.jface.text.tests;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -1256,23 +1256,17 @@ public class TextPresentationTest {
 	public void testIterator() {
 		// Test read over iterator end
 		Iterator<StyleRange> e= fTextPresentation.getAllStyleRangeIterator();
-		try {
+		assertThrows(NoSuchElementException.class, () -> {
 			for (int i= 0; i < 1000; i++) {
 				e.next();
 			}
-			fail("Iterator has no end.");
-		} catch (NoSuchElementException ex) {
-			// expected
-		}
-		e= fTextPresentation.getNonDefaultStyleRangeIterator();
-		try {
+		});
+		Iterator<StyleRange> e2= fTextPresentation.getNonDefaultStyleRangeIterator();
+		assertThrows(NoSuchElementException.class, () -> {
 			for (int i= 0; i < 1000; i++) {
-				e.next();
+				e2.next();
 			}
-			fail("Iterator has no end.");
-		} catch (NoSuchElementException ex) {
-			// expected
-		}
+		});
 	}
 
 	// helper method required as long as TextPresentation methods manipulate given arguments

--- a/tests/org.eclipse.text.tests/src/org/eclipse/text/tests/LineTrackerTest3.java
+++ b/tests/org.eclipse.text.tests/src/org/eclipse/text/tests/LineTrackerTest3.java
@@ -17,8 +17,8 @@ package org.eclipse.text.tests;
 
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -335,17 +335,10 @@ public class LineTrackerTest3 extends AbstractLineTrackerTest {
 			assertEquals(lengths[i], line.getLength(), "line: " + i);
 			assertEquals(offsets[i], line.getOffset(), "line: " + i);
 		}
-		try {
-			fTracker.getLineInformation(lengths.length);
-			fail();
-		} catch (Exception e) {
-		}
-
-		try {
-			fTracker.getLineInformationOfOffset(offsets[offsets.length] + 1);
-			fail();
-		} catch (Exception e) {
-		}
+		int numLines1= lengths.length;
+		int outOfRange1= offsets[offsets.length - 1] + lengths[lengths.length - 1] + 1;
+		assertThrows(Exception.class, () -> fTracker.getLineInformation(numLines1));
+		assertThrows(Exception.class, () -> fTracker.getLineInformationOfOffset(outOfRange1));
 
 
 		/* phantom last line when the last line is not empty */
@@ -369,18 +362,10 @@ public class LineTrackerTest3 extends AbstractLineTrackerTest {
 			assertEquals(len, line.getLength(), "length of line: " + i);
 			assertEquals(offset, line.getOffset(), "offset of line: " + i);
 		}
-
-		try {
-			fTracker.getLineInformation(lengths.length);
-			fail();
-		} catch (Exception e) {
-		}
-
-		try {
-			fTracker.getLineInformationOfOffset(offsets[offsets.length] + 1);
-			fail();
-		} catch (Exception e) {
-		}
+		int numLines2= lengths.length;
+		int outOfRange2= offsets[offsets.length - 1] + lengths[lengths.length - 1] + 1;
+		assertThrows(Exception.class, () -> fTracker.getLineInformation(numLines2));
+		assertThrows(Exception.class, () -> fTracker.getLineInformationOfOffset(outOfRange2));
 
 	}
 
@@ -409,17 +394,10 @@ public class LineTrackerTest3 extends AbstractLineTrackerTest {
 			assertEquals(lengths[i], line.getLength(), "line: " + i);
 			assertEquals(offsets[i], line.getOffset(), "line: " + i);
 		}
-		try {
-			fTracker.getLineInformation(lengths.length);
-			fail();
-		} catch (Exception e) {
-		}
-
-		try {
-			fTracker.getLineInformationOfOffset(offsets[offsets.length] + 1);
-			fail();
-		} catch (Exception e) {
-		}
+		int numLines3= lengths.length;
+		int outOfRange3= offsets[offsets.length - 1] + lengths[lengths.length - 1] + 1;
+		assertThrows(Exception.class, () -> fTracker.getLineInformation(numLines3));
+		assertThrows(Exception.class, () -> fTracker.getLineInformationOfOffset(outOfRange3));
 
 
 		/* phantom last line when the last line is not empty */
@@ -444,109 +422,40 @@ public class LineTrackerTest3 extends AbstractLineTrackerTest {
 			assertEquals(offset, line.getOffset(), "offset of line: " + i);
 		}
 
-		try {
-			fTracker.getLineInformation(lengths.length);
-			fail();
-		} catch (Exception e) {
-		}
-
-		try {
-			fTracker.getLineInformationOfOffset(offsets[offsets.length] + 1);
-			fail();
-		} catch (Exception e) {
-		}
+		int numLines4= lengths.length;
+		int outOfRange4= offsets[offsets.length - 1] + lengths[lengths.length - 1] + 1;
+		assertThrows(Exception.class, () -> fTracker.getLineInformation(numLines4));
+		assertThrows(Exception.class, () -> fTracker.getLineInformationOfOffset(outOfRange4));
 
 	}
 
 	@Test
 	public void testNegativeOffset() throws Exception {
-		try {
-			assertEquals(-1, fTracker.getLineNumberOfOffset(-1));
-			fail();
-		} catch (BadLocationException e) {
-		}
-		try {
-			fTracker.getLineInformationOfOffset(-1);
-			fail();
-		} catch (BadLocationException e) {
-		}
+		assertThrows(BadLocationException.class, () -> fTracker.getLineNumberOfOffset(-1));
+		assertThrows(BadLocationException.class, () -> fTracker.getLineInformationOfOffset(-1));
 
-		try {
-			assertEquals(-1, fTracker.getLineNumberOfOffset(-1000));
-			fail();
-		} catch (BadLocationException e) {
-		}
-		try {
-			fTracker.getLineInformationOfOffset(-1000);
-			fail();
-		} catch (BadLocationException e) {
-		}
+		assertThrows(BadLocationException.class, () -> fTracker.getLineNumberOfOffset(-1000));
+		assertThrows(BadLocationException.class, () -> fTracker.getLineInformationOfOffset(-1000));
 
-		try {
-			fTracker.getLineInformationOfOffset(1000);
-			fail();
-		} catch (BadLocationException e) {
-		}
-		try {
-			fTracker.getLineNumberOfOffset(1000);
-			fail();
-		} catch (BadLocationException e) {
-		}
-		try {
-			fTracker.getLineOffset(-1000);
-			fail();
-		} catch (BadLocationException e) {
-		}
-		try {
-			fTracker.getLineInformation(-1000);
-			fail();
-		} catch (BadLocationException e) {
-		}
+		assertThrows(BadLocationException.class, () -> fTracker.getLineInformationOfOffset(1000));
+		assertThrows(BadLocationException.class, () -> fTracker.getLineNumberOfOffset(1000));
+		assertThrows(BadLocationException.class, () -> fTracker.getLineOffset(-1000));
+		assertThrows(BadLocationException.class, () -> fTracker.getLineInformation(-1000));
 	}
+
+	@Test
 	public void testNegativeOffset2() throws Exception {
 		replace(0, 0, "x");
-		try {
-			assertEquals(-1, fTracker.getLineNumberOfOffset(-1));
-			fail();
-		} catch (BadLocationException e) {
-		}
-		try {
-			fTracker.getLineInformationOfOffset(-1);
-			fail();
-		} catch (BadLocationException e) {
-		}
+		assertThrows(BadLocationException.class, () -> fTracker.getLineNumberOfOffset(-1));
+		assertThrows(BadLocationException.class, () -> fTracker.getLineInformationOfOffset(-1));
 
-		try {
-			assertEquals(-1, fTracker.getLineNumberOfOffset(-1000));
-			fail();
-		} catch (BadLocationException e) {
-		}
-		try {
-			fTracker.getLineInformationOfOffset(-1000);
-			fail();
-		} catch (BadLocationException e) {
-		}
+		assertThrows(BadLocationException.class, () -> fTracker.getLineNumberOfOffset(-1000));
+		assertThrows(BadLocationException.class, () -> fTracker.getLineInformationOfOffset(-1000));
 
-		try {
-			fTracker.getLineInformationOfOffset(1000);
-			fail();
-		} catch (BadLocationException e) {
-		}
-		try {
-			fTracker.getLineNumberOfOffset(1000);
-			fail();
-		} catch (BadLocationException e) {
-		}
-		try {
-			fTracker.getLineOffset(-1000);
-			fail();
-		} catch (BadLocationException e) {
-		}
-		try {
-			fTracker.getLineInformation(-1000);
-			fail();
-		} catch (BadLocationException e) {
-		}
+		assertThrows(BadLocationException.class, () -> fTracker.getLineInformationOfOffset(1000));
+		assertThrows(BadLocationException.class, () -> fTracker.getLineNumberOfOffset(1000));
+		assertThrows(BadLocationException.class, () -> fTracker.getLineOffset(-1000));
+		assertThrows(BadLocationException.class, () -> fTracker.getLineInformation(-1000));
 	}
 
 	/**
@@ -561,36 +470,11 @@ public class LineTrackerTest3 extends AbstractLineTrackerTest {
 		set(null);
 		assertEquals(1, fTracker.getNumberOfLines(), "Tracker not empty.");
 		assertEquals(0, fTracker.getLineLength(0), "Tracker not empty.");
-		try {
-			fTracker.getLineInformationOfOffset(5);
-			fail("No exception for bad location.");
-		} catch (BadLocationException e) {
-			// expected
-		}
-		try {
-			fTracker.getLineInformationOfOffset(initialContentLength);
-			fail("No exception for bad location.");
-		} catch (BadLocationException e) {
-			// expected
-		}
-		try {
-			fTracker.getLineNumberOfOffset(5);
-			fail("No exception for bad location.");
-		} catch (BadLocationException e) {
-			// expected
-		}
-		try {
-			fTracker.getLineNumberOfOffset(initialContentLength);
-			fail("No exception for bad location.");
-		} catch (BadLocationException e) {
-			// expected
-		}
-		try {
-			fTracker.getNumberOfLines(5, 3);
-			fail("No exception for bad location.");
-		} catch (BadLocationException e) {
-			// expected
-		}
+		assertThrows(BadLocationException.class, () -> fTracker.getLineInformationOfOffset(5));
+		assertThrows(BadLocationException.class, () -> fTracker.getLineInformationOfOffset(initialContentLength));
+		assertThrows(BadLocationException.class, () -> fTracker.getLineNumberOfOffset(5));
+		assertThrows(BadLocationException.class, () -> fTracker.getLineNumberOfOffset(initialContentLength));
+		assertThrows(BadLocationException.class, () -> fTracker.getNumberOfLines(5, 3));
 	}
 
 	/**

--- a/tests/org.eclipse.text.tests/src/org/eclipse/text/tests/TextStoreTest.java
+++ b/tests/org.eclipse.text.tests/src/org/eclipse/text/tests/TextStoreTest.java
@@ -16,8 +16,8 @@ package org.eclipse.text.tests;
 
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -120,11 +120,7 @@ public abstract class TextStoreTest {
 		for (int i= 0; i < fTextStore.getLength(); i++)
 			assertEquals(expected.charAt(i), fTextStore.get(i));
 
-		try {
-			fTextStore.get(fTextStore.getLength());
-			fail();
-		} catch (IndexOutOfBoundsException e) {
-		}
+		assertThrows(IndexOutOfBoundsException.class, () -> fTextStore.get(fTextStore.getLength()));
 	}
 
 	@Test
@@ -399,19 +395,10 @@ public abstract class TextStoreTest {
 			assertEquals(lengths[i], line.getLength(), "line: " + i);
 			assertEquals(offsets[i], line.getOffset(), "line: " + i);
 		}
-		try {
-			fTracker.getLineInformation(lengths.length);
-			fail();
-		} catch (Exception e) {
-		}
-
-		try {
-			fTracker.getLineInformationOfOffset(offsets[offsets.length] + 1);
-			fail();
-		} catch (Exception e) {
-		}
-
-		/* phantom last line when the last line is not empty */
+		int numLines1= lengths.length;
+		int outOfRange1= offsets[offsets.length - 1] + lengths[lengths.length - 1] + 1;
+		assertThrows(Exception.class, () -> fTracker.getLineInformation(numLines1));
+		assertThrows(Exception.class, () -> fTracker.getLineInformationOfOffset(outOfRange1));
 		set("x\nx");
 		assertTextStoreContents("x\nx");
 		offsets= new int[]{0, 2, 3};
@@ -434,17 +421,10 @@ public abstract class TextStoreTest {
 			assertEquals(offset, line.getOffset(), "offset of line: " + i);
 		}
 
-		try {
-			fTracker.getLineInformation(lengths.length);
-			fail();
-		} catch (Exception e) {
-		}
-
-		try {
-			fTracker.getLineInformationOfOffset(offsets[offsets.length] + 1);
-			fail();
-		} catch (Exception e) {
-		}
+		int numLines2= lengths.length;
+		int outOfRange2= offsets[offsets.length - 1] + lengths[lengths.length - 1] + 1;
+		assertThrows(Exception.class, () -> fTracker.getLineInformation(numLines2));
+		assertThrows(Exception.class, () -> fTracker.getLineInformationOfOffset(outOfRange2));
 
 	}
 

--- a/tests/org.eclipse.text.tests/src/org/eclipse/text/tests/TextUtilitiesTest.java
+++ b/tests/org.eclipse.text.tests/src/org/eclipse/text/tests/TextUtilitiesTest.java
@@ -16,6 +16,7 @@ package org.eclipse.text.tests;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.fail;
 
 import java.util.ArrayList;
@@ -318,26 +319,9 @@ public class TextUtilitiesTest {
 		assertEquals(-1, result[0]);
 		assertEquals(-1, result[1]);
 
-		try {
-			TextUtilities.indexOf(null, "foobarabcd", 0);
-			fail("Exception not thrown");
-		} catch (NullPointerException ex) {
-			// expected
-		}
-
-		try {
-			TextUtilities.indexOf(new String[] { "abc", null }, "foobarabcd", 0);
-			fail("Exception not thrown");
-		} catch (NullPointerException ex) {
-			// expected
-		}
-
-		try {
-			TextUtilities.indexOf(new String[] { "abc" }, null, 0);
-			fail("Exception not thrown");
-		} catch (NullPointerException ex) {
-			// expected
-		}
+		assertThrows(NullPointerException.class, () -> TextUtilities.indexOf(null, "foobarabcd", 0));
+		assertThrows(NullPointerException.class, () -> TextUtilities.indexOf(new String[] { "abc", null }, "foobarabcd", 0));
+		assertThrows(NullPointerException.class, () -> TextUtilities.indexOf(new String[] { "abc" }, null, 0));
 	}
 
 	@Test

--- a/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/workbench/texteditor/tests/HippieCompletionTest.java
+++ b/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/workbench/texteditor/tests/HippieCompletionTest.java
@@ -16,8 +16,8 @@ package org.eclipse.ui.workbench.texteditor.tests;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -447,11 +447,7 @@ public class HippieCompletionTest {
 		ArrayList<String> list= new ArrayList<>();
 		Accessor state= null;
 
-		try {
-			state= createAccessor(list.iterator(), 0);
-			fail("Having no items is not valid (at least the empty completion must be there)");
-		} catch (AssertionFailedException ex) {
-		}
+		assertThrows(AssertionFailedException.class, () -> createAccessor(list.iterator(), 0));
 
 		list.add("");
 		state= createAccessor(list.iterator(), 0);

--- a/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/workbench/texteditor/tests/revisions/ChangeRegionTest.java
+++ b/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/workbench/texteditor/tests/revisions/ChangeRegionTest.java
@@ -14,8 +14,8 @@
 package org.eclipse.ui.workbench.texteditor.tests.revisions;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
 
 import java.util.Date;
 import java.util.List;
@@ -69,26 +69,9 @@ public class ChangeRegionTest {
 
 	@Test
 	public void testCreation() throws Exception {
-		try {
-			@SuppressWarnings("unused")
-			ChangeRegion changeRegion= new ChangeRegion(fRevision, null);
-			fail();
-		} catch (Exception e) {
-		}
-
-		try {
-			@SuppressWarnings("unused")
-			ChangeRegion changeRegion= new ChangeRegion(null, new LineRange(12, 3));
-			fail();
-		} catch (Exception e) {
-		}
-
-		try {
-			@SuppressWarnings("unused")
-			ChangeRegion changeRegion= new ChangeRegion(null, null);
-			fail();
-		} catch (Exception e) {
-		}
+		assertThrows(Exception.class, () -> new ChangeRegion(fRevision, null));
+		assertThrows(Exception.class, () -> new ChangeRegion(null, new LineRange(12, 3)));
+		assertThrows(Exception.class, () -> new ChangeRegion(null, null));
 
 		ChangeRegion r= new ChangeRegion(fRevision, new LineRange(12, 3));
 		assertEquals(fRevision, r.getRevision());

--- a/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/workbench/texteditor/tests/rulers/DAGTest.java
+++ b/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/workbench/texteditor/tests/rulers/DAGTest.java
@@ -15,8 +15,8 @@ package org.eclipse.ui.workbench.texteditor.tests.rulers;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -53,28 +53,12 @@ public class DAGTest {
 	}
 
 	@Test
-	public void testIllegal() throws Exception {
+	public void testIllegal() {
 		assertFalse(fDag.addEdge(A, A));
-		try {
-			fDag.addEdge(A, null);
-			fail();
-		} catch (RuntimeException x) {
-		}
-		try {
-			fDag.addEdge(null, A);
-			fail();
-		} catch (RuntimeException x) {
-		}
-		try {
-			fDag.addEdge(null, null);
-			fail();
-		} catch (RuntimeException x) {
-		}
-		try {
-			fDag.addVertex(null);
-			fail();
-		} catch (RuntimeException x) {
-		}
+		assertThrows(RuntimeException.class, () -> fDag.addEdge(A, null));
+		assertThrows(RuntimeException.class, () -> fDag.addEdge(null, A));
+		assertThrows(RuntimeException.class, () -> fDag.addEdge(null, null));
+		assertThrows(RuntimeException.class, () -> fDag.addVertex(null));
 	}
 
 	@Test


### PR DESCRIPTION
Replace legacy `try { ...; fail(...); } catch (XException e) {}` patterns with JUnit 5 `assertThrows()`.

Also fixes a latent test bug in `TextStoreTest` and `LineTrackerTest3`: `offsets[offsets.length]` always threw `ArrayIndexOutOfBoundsException` before `getLineInformationOfOffset` was called; replaced with a properly computed out-of-bounds offset.