### PR TITLE
Trigger Show In for typed selection in Open Resource dialog

### DIFF
--- a/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/ide/dialogs/OpenResourceDialog.java
+++ b/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/ide/dialogs/OpenResourceDialog.java
@@ -309,9 +309,7 @@ public class OpenResourceDialog extends FilteredResourcesSelectionDialog {
 	@Override
 	protected void okPressed() {
 		IStructuredSelection selected = getSelectedItems();
-		Button okButton = getOkButton();
-		if (selected.size() == 1 && !(selected.getFirstElement() instanceof IFile)
-				&& okButton != null && okButton.isEnabled()) {
+		if (selected.size() == 1 && !(selected.getFirstElement() instanceof IFile)) {
 			if (showSelectionInFirstShowInTarget(selected)) {
 				return;
 			}


### PR DESCRIPTION
In the Open Resource dialog, the Show In action for a non-file resource (for example a project) was gated on the OK button's enabled state. When the resource was reached by typing a pattern instead of clicking the row, that enabled state could lag behind the auto-selected first match, so pressing Enter or the Open button did nothing.

This acts on the selected item directly, the same way the dialog opens a typed file. A first-matched project now triggers Show In via Enter or the Open button, making the keyboard and mouse paths behave consistently.