### PR TITLE
Update Show In MRU when triggered from Open Resource dialog

### DIFF
--- a/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/ide/dialogs/OpenResourceDialog.java
+++ b/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/ide/dialogs/OpenResourceDialog.java
@@ -126,7 +126,11 @@ public class OpenResourceDialog extends FilteredResourcesSelectionDialog {
 					try {
 						view = page.showView(targetId);
 						IShowInTarget target = getShowInTarget(view);
-						if (!(target != null && target.show(getContext(null)))) {
+						if (target != null && target.show(getContext(null))) {
+							if (page instanceof WorkbenchPage workbenchPage) {
+								workbenchPage.performedShowIn(targetId);
+							}
+						} else {
 							page.getWorkbenchWindow().getShell().getDisplay().beep();
 						}
 					} catch (PartInitException e) {
@@ -355,6 +359,8 @@ public class OpenResourceDialog extends FilteredResourcesSelectionDialog {
 			IShowInTarget target = Adapters.adapt(view, IShowInTarget.class);
 			if (target == null || !target.show(new ShowInContext(null, selection))) {
 				activePage.getWorkbenchWindow().getShell().getDisplay().beep();
+			} else {
+				workbenchPage.performedShowIn(descriptor.getId());
 			}
 		} catch (PartInitException e) {
 			StatusManager.getManager().handle(new Status(IStatus.ERROR, IDEWorkbenchPlugin.IDE_WORKBENCH,


### PR DESCRIPTION
The Open Resource dialog drives Show In through its own actions (both the dropdown and the implicit action on a non-file selection), calling showView and IShowInTarget.show directly rather than the Navigate > Show In command. As a result WorkbenchPage.performedShowIn was never called and the most-recently-used order of Show In targets was left untouched, unlike the regular Show In popup.

This promotes the used target via performedShowIn after a successful show, so launching Show In from Open Resource feeds the same MRU list as the standard command.

Fixes #4058