### PR TITLE
Remove contents of IPageLayout that are deprecated for removal

### DIFF
--- a/bundles/org.eclipse.ui.workbench/.settings/.api_filters
+++ b/bundles/org.eclipse.ui.workbench/.settings/.api_filters
@@ -1,5 +1,25 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <component id="org.eclipse.ui.workbench" version="2">
+    <resource path="eclipseui/org/eclipse/ui/IPageLayout.java" type="org.eclipse.ui.IPageLayout">
+        <filter id="405864542">
+            <message_arguments>
+                <message_argument value="org.eclipse.ui.IPageLayout"/>
+                <message_argument value="DEFAULT_FASTVIEW_RATIO"/>
+            </message_arguments>
+        </filter>
+        <filter id="405901410">
+            <message_arguments>
+                <message_argument value="org.eclipse.ui.IPageLayout"/>
+                <message_argument value="getEditorReuseThreshold()"/>
+            </message_arguments>
+        </filter>
+        <filter id="405901410">
+            <message_arguments>
+                <message_argument value="org.eclipse.ui.IPageLayout"/>
+                <message_argument value="setEditorReuseThreshold(int)"/>
+            </message_arguments>
+        </filter>
+    </resource>
     <resource path="eclipseui/org/eclipse/ui/ISharedImages.java" type="org.eclipse.ui.ISharedImages">
         <filter id="405864542">
             <message_arguments>

--- a/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/IPageLayout.java
+++ b/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/IPageLayout.java
@@ -177,15 +177,6 @@ public interface IPageLayout {
 	float RATIO_MAX = 0.95f;
 
 	/**
-	 * The default fast view ratio width.
-	 *
-	 * @since 2.0
-	 * @deprecated discontinued support for fast views
-	 */
-	@Deprecated(forRemoval = true, since = "2023-12")
-	float DEFAULT_FASTVIEW_RATIO = 0.3f;
-
-	/**
 	 * The default view ratio width for regular (non-fast) views.
 	 *
 	 * @since 2.0
@@ -395,29 +386,6 @@ public interface IPageLayout {
 	 *                       <code>false</code> to hide the editor area
 	 */
 	void setEditorAreaVisible(boolean showEditorArea);
-
-	/**
-	 * Returns the number of open editors before reusing editors or -1 if the
-	 * preference settings should be used instead.
-	 *
-	 * @return the number of open editors before reusing editors or -1 if the
-	 *         preference settings should be used instead.
-	 *
-	 * @deprecated this always returns -1 as of Eclipse 2.1
-	 */
-	@Deprecated(forRemoval = true, since = "2023-12")
-	int getEditorReuseThreshold();
-
-	/**
-	 * Sets the number of open editors before reusing editors. If &lt; 0 the user
-	 * preference settings will be used.
-	 *
-	 * @param openEditors the number of open editors
-	 *
-	 * @deprecated this method has no effect, as of Eclipse 2.1
-	 */
-	@Deprecated(forRemoval = true, since = "2023-12")
-	void setEditorReuseThreshold(int openEditors);
 
 	/**
 	 * Sets whether this layout is fixed. In a fixed layout, layout parts cannot be

--- a/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/e4/compatibility/ModeledPageLayout.java
+++ b/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/e4/compatibility/ModeledPageLayout.java
@@ -310,11 +310,6 @@ public class ModeledPageLayout implements IPageLayout {
 	}
 
 	@Override
-	public int getEditorReuseThreshold() {
-		return -1;
-	}
-
-	@Override
 	public IPlaceholderFolderLayout getFolderForView(String id) {
 		MPart view = findPart(perspModel, id);
 		if (view == null) {
@@ -357,11 +352,6 @@ public class ModeledPageLayout implements IPageLayout {
 	@Override
 	public void setEditorAreaVisible(boolean showEditorArea) {
 		eaRef.setToBeRendered(showEditorArea);
-	}
-
-	@Override
-	public void setEditorReuseThreshold(int openEditors) {
-		// ignored, no-op, same as 3.x implementation
 	}
 
 	@Override


### PR DESCRIPTION
A fastview constant and two methods of IPageLayout have been deprecated for removal for almost 3 years. This change finally removes those contents.