### PR TITLE
Refactor CommandContributionItemParameter initialization to use supported constructor API

### DIFF
--- a/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/ide/WorkbenchActionBuilder.java
+++ b/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/ide/WorkbenchActionBuilder.java
@@ -1535,11 +1535,13 @@ public class WorkbenchActionBuilder extends ActionBarAdvisor {
 				.getService(IActionCommandMappingService.class);
 		acms.map(actionId, commandId);
 
-		CommandContributionItemParameter commandParm = new CommandContributionItemParameter(
-				getWindow(), actionId, commandId, null, sharedImages
-						.getImageDescriptor(image), sharedImages
-						.getImageDescriptor(disabledImage), null, label, null,
-				tooltip, CommandContributionItem.STYLE_PUSH, null, false);
+		CommandContributionItemParameter commandParm = new CommandContributionItemParameter(getWindow(), actionId,
+				commandId, CommandContributionItem.STYLE_PUSH);
+
+		commandParm.icon = sharedImages.getImageDescriptor(image);
+		commandParm.disabledIcon = sharedImages.getImageDescriptor(disabledImage);
+		commandParm.label = label;
+		commandParm.tooltip = tooltip;
 		return new CommandContributionItem(commandParm);
 	}
 }


### PR DESCRIPTION
**Summary**
Updated the WorkbenchActionBuilder#getItem(...) implementation to replace usage of the deprecated/internal CommandContributionItemParameter constructor with the currently supported constructor pattern.

**Changes**
Replaced the constructor invocation that accepted multiple UI-related parameters (icon, disabledIcon, label, tooltip, etc.).

Switched to using the supported constructor:

new CommandContributionItemParameter(
    getWindow(),
    actionId,
    commandId,
    CommandContributionItem.STYLE_PUSH
);
Populated UI attributes (icon, disabledIcon, label, and tooltip) through the parameter object's fields after construction.
Preserved existing functionality and behavior of the contributed command item.

**Reason for Change**
The previous implementation triggered an API tooling error:
"WorkbenchActionBuilder illegally references constructor CommandContributionItemParameter(IServiceLocator, String, String, Map, ImageDescriptor, ImageDescriptor, ImageDescriptor, String, String, String, int, String, boolean)"

The existing implementation triggered an Eclipse API tooling error because of the constructor used to create CommandContributionItemParameter. This update adopts a constructor pattern that complies with API tooling validation and initializes presentation-related properties separately. The resulting command contribution behaves the same as before while eliminating the validation issue.

**Impact**
- No functional changes.
- Resolves API tooling/build validation issues.
- Improves compatibility with newer Eclipse platform versions and supported API guidelines.


Created this as a separate change as suggested via https://github.com/eclipse-platform/eclipse.platform.ui/pull/4061#pullrequestreview-4442387401