### PR TITLE
Make unsaved changes indicator the default on tabs

### DIFF
--- a/bundles/org.eclipse.e4.ui.workbench.renderers.swt/src/org/eclipse/e4/ui/workbench/renderers/swt/CTabRendering.java
+++ b/bundles/org.eclipse.e4.ui.workbench.renderers.swt/src/org/eclipse/e4/ui/workbench/renderers/swt/CTabRendering.java
@@ -80,8 +80,8 @@ public class CTabRendering extends CTabFolderRenderer implements ICTabRendering,
 	 * A named preference for setting CTabFolder's to be rendered with dirty
 	 * indicator overlay on close button
 	 * <p>
-	 * The default value for this preference is: <code>false</code> (do not show
-	 * dirty indicator)
+	 * The default value for this preference is: <code>true</code> (show dirty
+	 * indicator)
 	 * </p>
 	 */
 	public static final String SHOW_DIRTY_INDICATOR_ON_TABS = "SHOW_DIRTY_INDICATOR_ON_TABS"; //$NON-NLS-1$
@@ -89,7 +89,7 @@ public class CTabRendering extends CTabFolderRenderer implements ICTabRendering,
 	/**
 	 * Default value for "dirty indicator" preference for tabs
 	 */
-	public static final boolean SHOW_DIRTY_INDICATOR_ON_TABS_DEFAULT = false;
+	public static final boolean SHOW_DIRTY_INDICATOR_ON_TABS_DEFAULT = true;
 
 	private static int MIN_VIEW_CHARS = 1;
 	private static int MAX_VIEW_CHARS = Integer.MAX_VALUE;

--- a/tests/org.eclipse.e4.ui.tests/src/org/eclipse/e4/ui/tests/workbench/MPartTest.java
+++ b/tests/org.eclipse.e4.ui.tests/src/org/eclipse/e4/ui/tests/workbench/MPartTest.java
@@ -21,6 +21,8 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
 import jakarta.inject.Inject;
+import org.eclipse.core.runtime.preferences.IEclipsePreferences;
+import org.eclipse.core.runtime.preferences.InstanceScope;
 import org.eclipse.e4.core.contexts.IEclipseContext;
 import org.eclipse.e4.ui.model.application.MApplication;
 import org.eclipse.e4.ui.model.application.ui.basic.MPart;
@@ -30,6 +32,7 @@ import org.eclipse.e4.ui.model.application.ui.basic.MWindow;
 import org.eclipse.e4.ui.tests.rules.WorkbenchContextExtension;
 import org.eclipse.e4.ui.workbench.IPresentationEngine;
 import org.eclipse.e4.ui.workbench.modeling.EModelService;
+import org.eclipse.e4.ui.workbench.renderers.swt.CTabRendering;
 import org.eclipse.swt.custom.CTabFolder;
 import org.eclipse.swt.custom.CTabItem;
 import org.junit.jupiter.api.Test;
@@ -191,34 +194,45 @@ public class MPartTest {
 
 	@Test
 	public void testMPartBug369866() {
-		final MWindow window = createWindowWithOneView("Part");
+		// This test verifies the textual '*' dirty prefix, which is only used
+		// when the graphical dirty indicator is disabled.
+		IEclipsePreferences prefs = InstanceScope.INSTANCE
+				.getNode(CTabRendering.PREF_QUALIFIER_ECLIPSE_E4_UI_WORKBENCH_RENDERERS_SWT);
+		boolean previous = prefs.getBoolean(CTabRendering.SHOW_DIRTY_INDICATOR_ON_TABS,
+				CTabRendering.SHOW_DIRTY_INDICATOR_ON_TABS_DEFAULT);
+		prefs.putBoolean(CTabRendering.SHOW_DIRTY_INDICATOR_ON_TABS, false);
+		try {
+			final MWindow window = createWindowWithOneView("Part");
 
-		application.getChildren().add(window);
-		contextRule.createAndRunWorkbench(window);
+			application.getChildren().add(window);
+			contextRule.createAndRunWorkbench(window);
 
-		MPartSashContainer container = (MPartSashContainer) window.getChildren().get(0);
-		MPartStack stack = (MPartStack) container.getChildren().get(0);
-		MPart part = (MPart) stack.getChildren().get(0);
+			MPartSashContainer container = (MPartSashContainer) window.getChildren().get(0);
+			MPartStack stack = (MPartStack) container.getChildren().get(0);
+			MPart part = (MPart) stack.getChildren().get(0);
 
-		CTabFolder folder = (CTabFolder) stack.getWidget();
-		CTabItem item = folder.getItem(0);
+			CTabFolder folder = (CTabFolder) stack.getWidget();
+			CTabItem item = folder.getItem(0);
 
-		// bug 369866 has a StringIOOBE from toggling the dirty flag with an
-		// empty part name
-		assertFalse(part.isDirty());
-		assertEquals("Part", item.getText());
+			// bug 369866 has a StringIOOBE from toggling the dirty flag with an
+			// empty part name
+			assertFalse(part.isDirty());
+			assertEquals("Part", item.getText());
 
-		part.setDirty(true);
-		assertEquals("*Part", item.getText());
+			part.setDirty(true);
+			assertEquals("*Part", item.getText());
 
-		part.setLabel("");
-		assertEquals("*", item.getText());
+			part.setLabel("");
+			assertEquals("*", item.getText());
 
-		part.setDirty(false);
-		assertEquals("", item.getText());
+			part.setDirty(false);
+			assertEquals("", item.getText());
 
-		part.setDirty(true);
-		assertEquals("*", item.getText());
+			part.setDirty(true);
+			assertEquals("*", item.getText());
+		} finally {
+			prefs.putBoolean(CTabRendering.SHOW_DIRTY_INDICATOR_ON_TABS, previous);
+		}
 	}
 
 	private MWindow createWindowWithOneView(String partName) {

--- a/tests/org.eclipse.e4.ui.tests/src/org/eclipse/e4/ui/tests/workbench/MSaveablePartTest.java
+++ b/tests/org.eclipse.e4.ui.tests/src/org/eclipse/e4/ui/tests/workbench/MSaveablePartTest.java
@@ -19,6 +19,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 
 import jakarta.inject.Inject;
+import org.eclipse.core.runtime.preferences.IEclipsePreferences;
+import org.eclipse.core.runtime.preferences.InstanceScope;
 import org.eclipse.e4.ui.model.application.MApplication;
 import org.eclipse.e4.ui.model.application.ui.basic.MPart;
 import org.eclipse.e4.ui.model.application.ui.basic.MPartSashContainer;
@@ -26,6 +28,7 @@ import org.eclipse.e4.ui.model.application.ui.basic.MPartStack;
 import org.eclipse.e4.ui.model.application.ui.basic.MWindow;
 import org.eclipse.e4.ui.tests.rules.WorkbenchContextExtension;
 import org.eclipse.e4.ui.workbench.modeling.EModelService;
+import org.eclipse.e4.ui.workbench.renderers.swt.CTabRendering;
 import org.eclipse.swt.custom.CTabFolder;
 import org.eclipse.swt.custom.CTabItem;
 import org.junit.jupiter.api.Test;
@@ -44,27 +47,38 @@ public class MSaveablePartTest {
 
 	@Test
 	public void testCreateView() {
-		final MWindow window = createWindowWithOneView("Part Name");
+		// This test verifies the textual '*' dirty prefix, which is only used
+		// when the graphical dirty indicator is disabled.
+		IEclipsePreferences prefs = InstanceScope.INSTANCE
+				.getNode(CTabRendering.PREF_QUALIFIER_ECLIPSE_E4_UI_WORKBENCH_RENDERERS_SWT);
+		boolean previous = prefs.getBoolean(CTabRendering.SHOW_DIRTY_INDICATOR_ON_TABS,
+				CTabRendering.SHOW_DIRTY_INDICATOR_ON_TABS_DEFAULT);
+		prefs.putBoolean(CTabRendering.SHOW_DIRTY_INDICATOR_ON_TABS, false);
+		try {
+			final MWindow window = createWindowWithOneView("Part Name");
 
-		application.getChildren().add(window);
-		contextRule.createAndRunWorkbench(window);
+			application.getChildren().add(window);
+			contextRule.createAndRunWorkbench(window);
 
-		MPartSashContainer container = (MPartSashContainer) window
-				.getChildren().get(0);
-		MPartStack stack = (MPartStack) container.getChildren().get(0);
-		MPart part = (MPart) stack.getChildren().get(0);
+			MPartSashContainer container = (MPartSashContainer) window
+					.getChildren().get(0);
+			MPartStack stack = (MPartStack) container.getChildren().get(0);
+			MPart part = (MPart) stack.getChildren().get(0);
 
-		CTabFolder folder = (CTabFolder) stack.getWidget();
-		CTabItem item = folder.getItem(0);
-		assertEquals("Part Name", item.getText());
+			CTabFolder folder = (CTabFolder) stack.getWidget();
+			CTabItem item = folder.getItem(0);
+			assertEquals("Part Name", item.getText());
 
-		assertFalse(part.isDirty());
+			assertFalse(part.isDirty());
 
-		part.setDirty(true);
-		assertEquals("*Part Name", item.getText());
+			part.setDirty(true);
+			assertEquals("*Part Name", item.getText());
 
-		part.setDirty(false);
-		assertEquals("Part Name", item.getText());
+			part.setDirty(false);
+			assertEquals("Part Name", item.getText());
+		} finally {
+			prefs.putBoolean(CTabRendering.SHOW_DIRTY_INDICATOR_ON_TABS, previous);
+		}
 	}
 
 	private MWindow createWindowWithOneView(String partName) {

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/multieditor/MultiEditorTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/multieditor/MultiEditorTest.java
@@ -35,6 +35,9 @@ import org.eclipse.core.runtime.FileLocator;
 import org.eclipse.core.runtime.ILog;
 import org.eclipse.core.runtime.ILogListener;
 import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.preferences.IEclipsePreferences;
+import org.eclipse.core.runtime.preferences.InstanceScope;
+import org.eclipse.e4.ui.workbench.renderers.swt.CTabRendering;
 import org.eclipse.jface.action.IContributionItem;
 import org.eclipse.jface.action.ToolBarContributionItem;
 import org.eclipse.jface.action.ToolBarManager;
@@ -233,6 +236,14 @@ public class MultiEditorTest {
 		MockEditorPart editorA = (MockEditorPart) innerEditors[0];
 		MockEditorPart editorB = (MockEditorPart) innerEditors[0];
 
+		// This test verifies the textual '*' dirty prefix, which is only used
+		// when the graphical dirty indicator is disabled.
+		IEclipsePreferences prefs = InstanceScope.INSTANCE
+				.getNode(CTabRendering.PREF_QUALIFIER_ECLIPSE_E4_UI_WORKBENCH_RENDERERS_SWT);
+		boolean previous = prefs.getBoolean(CTabRendering.SHOW_DIRTY_INDICATOR_ON_TABS,
+				CTabRendering.SHOW_DIRTY_INDICATOR_ON_TABS_DEFAULT);
+		prefs.putBoolean(CTabRendering.SHOW_DIRTY_INDICATOR_ON_TABS, false);
+
 		char firstChar = item.getText().charAt(0);
 		assertFalse(firstChar == '*');
 
@@ -249,6 +260,7 @@ public class MultiEditorTest {
 			editorB.setDirty(false);
 			assertEquals(firstChar, item.getText().charAt(0));
 		} finally {
+			prefs.putBoolean(CTabRendering.SHOW_DIRTY_INDICATOR_ON_TABS, previous);
 			page.closeAllEditors(false);
 		}
 	}


### PR DESCRIPTION
This makes the new unsaved-changes (dirty) indicator on view and editor tabs the default by flipping `SHOW_DIRTY_INDICATOR_ON_TABS_DEFAULT` to `true`.
The indicator was introduced as opt-in in 4.40 and was generally well received.
Making it opt-out during this development cycle means developers and users exercise it by default and can give feedback, while anyone who prefers the old close-button behavior can still disable it on the Appearance preference page.
If it does not prove mature enough we can easily revert to opt-in before release.

Implements https://github.com/eclipse-platform/eclipse.platform.ui/issues/4045