### PR TITLE
Show filter hint only as placeholder in filtered viewers

### DIFF
--- a/bundles/org.eclipse.e4.ui.dialogs/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.e4.ui.dialogs/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.e4.ui.dialogs
-Bundle-Version: 1.7.100.qualifier
+Bundle-Version: 1.7.200.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-21
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/bundles/org.eclipse.e4.ui.dialogs/src/org/eclipse/e4/ui/dialogs/filteredtree/FilteredTree.java
+++ b/bundles/org.eclipse.e4.ui.dialogs/src/org/eclipse/e4/ui/dialogs/filteredtree/FilteredTree.java
@@ -425,9 +425,7 @@ public class FilteredTree extends AbstractFilteredViewerComposite<PatternFilter>
 
 	@Override
 	protected void textChanged() {
-		narrowingDown = previousFilterText == null
-				|| previousFilterText.equals(E4DialogMessages.FilteredTree_FilterMessage)
-				|| getFilterString().startsWith(previousFilterText);
+		narrowingDown = previousFilterText == null || getFilterString().startsWith(previousFilterText);
 		previousFilterText = getFilterString();
 		// cancel currently running job first, to prevent unnecessary redraw
 		refreshJob.cancel();

--- a/bundles/org.eclipse.jface/src/org/eclipse/jface/viewers/AbstractFilteredViewerComposite.java
+++ b/bundles/org.eclipse.jface/src/org/eclipse/jface/viewers/AbstractFilteredViewerComposite.java
@@ -279,30 +279,16 @@ public abstract class AbstractFilteredViewerComposite<T extends ViewerFilter> ex
 	}
 
 	/**
-	 * Set the text that will be shown until the first focus. A default value is
-	 * provided, so this method only need be called if overriding the default
-	 * initial text is desired.
+	 * Sets the placeholder hint shown while the filter field is empty.
 	 *
-	 * @param text initial text to appear in text field
+	 * @param text the placeholder hint for the filter field
 	 */
 	public void setInitialText(String text) {
-		initialText = text;
-		if (filterText != null) {
-			filterText.setMessage(text);
-			if (filterText.isFocusControl()) {
-				setFilterText(initialText);
-				textChanged();
-			} else {
-				getDisplay().asyncExec(() -> {
-					if (!filterText.isDisposed() && filterText.isFocusControl()) {
-						setFilterText(initialText);
-						textChanged();
-					}
-				});
-			}
-		} else {
-			setFilterText(initialText);
-			textChanged();
+		initialText = text != null ? text : ""; //$NON-NLS-1$
+		if (filterText != null && !filterText.isDisposed()) {
+			// Show the hint as placeholder only, never as field value (which would
+			// need clear-on-focus handling and read as a value to screen readers).
+			filterText.setMessage(initialText);
 		}
 	}
 

--- a/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/dialogs/FilteredTree.java
+++ b/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/dialogs/FilteredTree.java
@@ -615,9 +615,7 @@ public class FilteredTree extends AbstractFilteredViewerComposite<PatternFilter>
 
 	@Override
 	protected void textChanged() {
-		narrowingDown = previousFilterText == null
-				|| previousFilterText.equals(WorkbenchMessages.FilteredTree_FilterMessage)
-				|| getFilterString().startsWith(previousFilterText);
+		narrowingDown = previousFilterText == null || getFilterString().startsWith(previousFilterText);
 		previousFilterText = getFilterString();
 		// cancel currently running job first, to prevent unnecessary redraw
 		refreshJob.cancel();


### PR DESCRIPTION
Filtered viewers used to write the hint text ("type filter text") into the filter field's value when the field had focus, which required clear-on-focus handling and could be read by screen readers as an actual filter value. This moves the shared `AbstractFilteredViewerComposite#setInitialText` to expose the hint solely as the field's placeholder via `Text#setMessage`.

Showing a hint inside the field value is a recognized UX anti-pattern (see https://www.nngroup.com/articles/form-design-placeholders/). The placeholder gives the same visible hint without those drawbacks, and the accessible name is unaffected.

The fix lives in the JFace base, so it applies to `FilteredTree`, the e4 `FilteredTree` and `FilteredTable` at once, aligning them with the approach already used by `FilteredPreferenceDialog` and `ChooseWorkspaceDialog`.