### PR TITLE
Trace quick access table disposal

### DIFF
--- a/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/quickaccess/QuickAccessContents.java
+++ b/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/quickaccess/QuickAccessContents.java
@@ -18,6 +18,8 @@
  *******************************************************************************/
 package org.eclipse.ui.internal.quickaccess;
 
+import java.io.PrintWriter;
+import java.io.StringWriter;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -836,6 +838,14 @@ public abstract class QuickAccessContents {
 		});
 
 		table.addSelectionListener(SelectionListener.widgetDefaultSelectedAdapter(e -> handleSelection()));
+		if (Policy.DEBUG_QUICK_ACCESS) {
+			table.addDisposeListener(e -> {
+				StringWriter writer = new StringWriter();
+				new Exception("provide stack trace").printStackTrace(new PrintWriter(writer)); //$NON-NLS-1$
+				String stackTrace = writer.toString(); // stack trace as a string
+				trace("Table disposed" + System.lineSeparator() + stackTrace); //$NON-NLS-1$
+			});
+		}
 		return table;
 	}
 

--- a/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/quickaccess/QuickAccessContents.java
+++ b/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/quickaccess/QuickAccessContents.java
@@ -336,6 +336,10 @@ public abstract class QuickAccessContents {
 					item.setData(entry);
 					item.setText(0, entry.provider.getName());
 					item.setText(1, entry.element.getLabel());
+					if (Policy.DEBUG_QUICK_ACCESS) {
+						trace("Adding table row: name=" + entry.provider.getName() + ", label=" //$NON-NLS-1$ //$NON-NLS-2$
+								+ entry.element.getLabel());
+					}
 					if (Util.isWpf()) {
 						item.setImage(1, entry.getImage(entry.element, resourceManager));
 					}

--- a/tests/org.eclipse.ui.tests.harness/src/org/eclipse/ui/tests/harness/util/TestRunLogUtil.java
+++ b/tests/org.eclipse.ui.tests.harness/src/org/eclipse/ui/tests/harness/util/TestRunLogUtil.java
@@ -13,6 +13,9 @@
  *******************************************************************************/
 package org.eclipse.ui.tests.harness.util;
 
+import org.junit.jupiter.api.extension.AfterEachCallback;
+import org.junit.jupiter.api.extension.BeforeEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.rules.TestWatcher;
 import org.junit.runner.Description;
 
@@ -34,23 +37,7 @@ public final class TestRunLogUtil {
 	 *
 	 * Note: field must be public or JUnit4 will complain.
 	 */
-	public static TestWatcher LOG_TESTRUN = new TestWatcher() {
-		@Override
-		protected void starting(Description description) {
-			System.out.println(formatTestStartMessage(description.getMethodName()));
-		}
-
-		@Override
-		protected void failed(Throwable e, Description description) {
-			System.out.println(description.getMethodName() + " failed:");
-			e.printStackTrace(System.out);
-		}
-
-		@Override
-		protected void finished(Description description) {
-			System.out.println(formatTestFinishedMessage(description.getMethodName()));
-		}
-	};
+	public static TestWatcher LOG_TESTRUN = new LogTestWatcher();
 
 	/**
 	 * Create message used to log start of a test.
@@ -71,6 +58,34 @@ public final class TestRunLogUtil {
 	public static String formatTestFinishedMessage(String testName) {
 		return testName + ": tearDown...\n"; //$NON-NLS-1$
 	}
+
+	private static class LogTestWatcher extends TestWatcher implements BeforeEachCallback, AfterEachCallback {
+		@Override
+		protected void starting(Description description) {
+			System.out.println(formatTestStartMessage(description.getMethodName()));
+		}
+
+		@Override
+		protected void failed(Throwable e, Description description) {
+			System.out.println(description.getMethodName() + " failed:");
+			e.printStackTrace(System.out);
+		}
+
+		@Override
+		protected void finished(Description description) {
+			System.out.println(formatTestFinishedMessage(description.getMethodName()));
+		}
+
+		@Override
+		public void beforeEach(ExtensionContext context) throws Exception {
+			System.out.println(formatTestStartMessage(context.getDisplayName()));
+		}
+
+		@Override
+		public void afterEach(ExtensionContext context) throws Exception {
+			System.out.println(formatTestFinishedMessage(context.getDisplayName()));
+		}
+	};
 
 	private TestRunLogUtil() {
 	}

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/quickaccess/QuickAccessDialogTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/quickaccess/QuickAccessDialogTest.java
@@ -50,12 +50,14 @@ import org.eclipse.ui.internal.quickaccess.QuickAccessDialog;
 import org.eclipse.ui.internal.quickaccess.QuickAccessMessages;
 import org.eclipse.ui.tests.harness.util.CloseTestWindowsExtension;
 import org.eclipse.ui.tests.harness.util.DisplayHelper;
+import org.eclipse.ui.tests.harness.util.TestRunLogUtil;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 /**
  * Tests the quick access UI
@@ -91,6 +93,9 @@ public class QuickAccessDialogTest {
 			.equals(QuickAccessMessages.QuickAccessContents_QuickAccess);
 	private IDialogSettings dialogSettings;
 	private IWorkbenchWindow activeWorkbenchWindow;
+
+	@RegisterExtension
+	public final Object TEST_WATCHER = TestRunLogUtil.LOG_TESTRUN;
 
 	@BeforeAll
 	public static void enableDebugOutputs() {


### PR DESCRIPTION
Tracing for fail in `QuickAccessDialogTest` hints at a disposed table prior to updating entries in the table. This change adds tracing for table dispose to validate this.

See: https://github.com/eclipse-platform/eclipse.platform.ui/issues/4009