### PR TITLE
Fix selection not updating when checking a tree item on Import window

### DIFF
--- a/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/ide/dialogs/ResourceTreeAndListGroup.java
+++ b/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/ide/dialogs/ResourceTreeAndListGroup.java
@@ -73,6 +73,15 @@ public class ResourceTreeAndListGroup extends EventManager {
 			BusyIndicator.showWhile(treeViewer.getControl().getDisplay(),
 					() -> {
 						if (event.getCheckable().equals(treeViewer)) {
+							/*
+							 * On Windows, checking an item does not automatically update the tree selection
+							 * like on Linux environment. Force the checked element to become the current
+							 * selection so SelectionListener and CheckListener stay in sync together
+							 */
+							Object currentSelection = treeViewer.getStructuredSelection().getFirstElement();
+							if (!Objects.equals(currentSelection, event.getElement())) {
+								treeViewer.setSelection(new StructuredSelection(event.getElement()), true);
+							}
 							treeItemChecked(event.getElement(), event
 									.getChecked());
 						} else {

--- a/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/ide/dialogs/ResourceTreeAndListGroup.java
+++ b/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/ide/dialogs/ResourceTreeAndListGroup.java
@@ -23,6 +23,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Objects;
 import java.util.Set;
 
 import org.eclipse.core.commands.common.EventManager;


### PR DESCRIPTION
I have found the issue when testing the Trace Compass in the Windows environment:
**Preproduce steps:**
1. Open the trace compass (My version is Version: 11.1.0) and try to import the archived trace package through **Trace Import** window:
2. I select the trace folder that contains the trace file in the trace package:

**Expected behaviour:**
It shows the trace file in the trace folder:
<img width="765" height="959" alt="image" src="https://github.com/user-attachments/assets/64f53043-42cd-40f0-89cf-fe79333516cc" />


**Actual behaviour**
It does not show the trace file in the trace folder, and it also selects the wrong item:
<img width="752" height="960" alt="image" src="https://github.com/user-attachments/assets/c263cdd8-8c70-410f-8e85-3a0b6ae5d9df" />

