### PR TITLE
Avoid access to default scope on read of configuration scope preference

### DIFF
--- a/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/Workbench.java
+++ b/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/Workbench.java
@@ -254,7 +254,6 @@ import org.eclipse.ui.keys.IBindingService;
 import org.eclipse.ui.menus.IMenuService;
 import org.eclipse.ui.model.IContributionService;
 import org.eclipse.ui.operations.IWorkbenchOperationSupport;
-import org.eclipse.ui.preferences.ScopedPreferenceStore;
 import org.eclipse.ui.progress.IProgressService;
 import org.eclipse.ui.progress.WorkbenchJob;
 import org.eclipse.ui.services.IDisposable;
@@ -3748,8 +3747,8 @@ public final class Workbench extends EventManager implements IWorkbench, org.ecl
 						+ " is configured (e.g., via the INI), but the according preference should be preferred instead." //$NON-NLS-1$
 				));
 			} else {
-				boolean rescaleAtRuntime = new ScopedPreferenceStore(ConfigurationScope.INSTANCE,
-						WorkbenchPlugin.PI_WORKBENCH).getBoolean(IWorkbenchPreferenceConstants.RESCALING_AT_RUNTIME);
+				boolean rescaleAtRuntime = ConfigurationScope.INSTANCE.getNode(WorkbenchPlugin.PI_WORKBENCH)
+						.getBoolean(IWorkbenchPreferenceConstants.RESCALING_AT_RUNTIME, true);
 				System.setProperty(SWT_RESCALE_AT_RUNTIME_PROPERTY, Boolean.toString(rescaleAtRuntime));
 			}
 


### PR DESCRIPTION
The configuration scope preference for monitor-specific scaling is read at a point in time where the workspace location may not have been defined, so that the instance scope preferences cannot be accessed yet. Since some defaults initializers require access to the instance scope, the access to the configuration scope preference must avoid access to the default scope in case no explicit value is set for that preference yet.

This change adapts the access to the monitor-specific scaling configuration scope preference to not access the default scope. Since there may be further preference defaults initializers out of our control that access instance scope preferences, just adapting those in the Platform would not be a sufficient solution alternative.

Fixes https://github.com/eclipse-platform/eclipse.platform.ui/issues/4085