### PR TITLE
Add method for providing disabled image descriptors

### DIFF
--- a/bundles/org.eclipse.e4.ui.workbench.renderers.swt/src/org/eclipse/e4/ui/workbench/renderers/swt/AbstractContributionItem.java
+++ b/bundles/org.eclipse.e4.ui.workbench.renderers.swt/src/org/eclipse/e4/ui/workbench/renderers/swt/AbstractContributionItem.java
@@ -158,7 +158,7 @@ public abstract class AbstractContributionItem extends ContributionItem {
 		if (iconURI != null && iconURI.length() > 0) {
 			ImageDescriptor iconDescriptor = resUtils.imageDescriptorFromURI(URI.createURI(iconURI));
 			if (disabled) {
-				iconDescriptor = ImageDescriptor.createWithFlags(iconDescriptor, SWT.IMAGE_DISABLE);
+				iconDescriptor = iconDescriptor.asDisabledDescriptor();
 			}
 			if (iconDescriptor != null) {
 				try {

--- a/bundles/org.eclipse.jface/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.jface/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.jface;singleton:=true
-Bundle-Version: 3.39.200.qualifier
+Bundle-Version: 3.40.0.qualifier
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Export-Package: org.eclipse.jface,

--- a/bundles/org.eclipse.jface/src/org/eclipse/jface/action/ActionContributionItem.java
+++ b/bundles/org.eclipse.jface/src/org/eclipse/jface/action/ActionContributionItem.java
@@ -1000,7 +1000,7 @@ public class ActionContributionItem extends ContributionItem {
 			// If there is no disabled image, but there is a regular image generate a
 			// disabled one
 			if (disabledImage == null && image != null) {
-				disabledImage = ImageDescriptor.createWithFlags(image, SWT.IMAGE_DISABLE);
+				disabledImage = image.asDisabledDescriptor();
 			}
 			if (image != null && !USE_COLOR_ICONS) {
 				image = ImageDescriptor.createWithFlags(image, SWT.IMAGE_GRAY);

--- a/bundles/org.eclipse.jface/src/org/eclipse/jface/resource/DerivedImageDescriptor.java
+++ b/bundles/org.eclipse.jface/src/org/eclipse/jface/resource/DerivedImageDescriptor.java
@@ -92,4 +92,12 @@ final class DerivedImageDescriptor extends ImageDescriptor {
 		image.dispose();
 		return result;
 	}
+
+	@Override
+	public ImageDescriptor asDisabledDescriptor() {
+		if ((flags & SWT.IMAGE_DISABLE) != 0) {
+			return this;
+		}
+		return super.asDisabledDescriptor();
+	}
 }

--- a/bundles/org.eclipse.jface/src/org/eclipse/jface/resource/ImageDescriptor.java
+++ b/bundles/org.eclipse.jface/src/org/eclipse/jface/resource/ImageDescriptor.java
@@ -20,6 +20,7 @@ import java.util.function.Supplier;
 
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.jface.util.Policy;
+import org.eclipse.swt.SWT;
 import org.eclipse.swt.SWTException;
 import org.eclipse.swt.graphics.Device;
 import org.eclipse.swt.graphics.Image;
@@ -67,6 +68,8 @@ public abstract class ImageDescriptor extends DeviceResourceDescriptor<Image> {
 	 * A small red square used to warn that an image cannot be created.
 	 */
 	protected static final ImageData DEFAULT_IMAGE_DATA = new ImageData(6, 6, 1, new PaletteData(new RGB(255, 0, 0)));
+
+	private ImageDescriptor disabledImageDescriptor;
 
 	/**
 	 * Constructs an image descriptor.
@@ -150,13 +153,6 @@ public abstract class ImageDescriptor extends DeviceResourceDescriptor<Image> {
 	/**
 	 * Creates an ImageDescriptor based on the given original descriptor, but with additional
 	 * SWT flags.
-	 *
-	 * <p>
-	 * Note that this sort of ImageDescriptor is slower and consumes more resources than
-	 * a regular image descriptor. It will also never generate results that look as nice as
-	 * a hand-drawn image. Clients are encouraged to supply their own disabled/grayed/etc. images
-	 * rather than using a default image and transforming it.
-	 * </p>
 	 *
 	 * @param originalImage image to transform
 	 * @param swtFlags any flag that can be passed to the flags argument of Image#Image(Device, Image, int)
@@ -349,6 +345,25 @@ public abstract class ImageDescriptor extends DeviceResourceDescriptor<Image> {
 	 */
 	public Image createImage(Device device) {
 		return createImage(true, device);
+	}
+
+	/**
+	 * Returns an image descriptor representing a disabled version of the icon of
+	 * this descriptor. The descriptor is shared, i.e., calling this method multiple
+	 * times will return the same descriptor every time. In case the descriptor
+	 * already represents a disabled version of the icon (created using
+	 * {@link #createWithFlags(ImageDescriptor, int)} with the
+	 * {@code SWT.IMAGE_DISABLE} flag), this method returns <code>this</code>.
+	 *
+	 * @since 3.40
+	 * @return a shared image descriptor for a disabled version of the icon for this
+	 *         descriptor
+	 */
+	public ImageDescriptor asDisabledDescriptor() {
+		if (disabledImageDescriptor == null) {
+			disabledImageDescriptor = createWithFlags(this, SWT.IMAGE_DISABLE);
+		}
+		return disabledImageDescriptor;
 	}
 
 	/**

--- a/bundles/org.eclipse.ui.ide.application/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.ui.ide.application/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Plugin.name
 Bundle-SymbolicName: org.eclipse.ui.ide.application;singleton:=true
-Bundle-Version: 1.6.100.qualifier
+Bundle-Version: 1.6.200.qualifier
 Bundle-Vendor: %Plugin.providerName
 Bundle-Localization: plugin
 Require-Bundle: org.eclipse.ui.ide;bundle-version="[3.21.0,4.0.0)",

--- a/bundles/org.eclipse.ui.ide.application/src/org/eclipse/ui/internal/ide/application/IDEWorkbenchAdvisor.java
+++ b/bundles/org.eclipse.ui.ide.application/src/org/eclipse/ui/internal/ide/application/IDEWorkbenchAdvisor.java
@@ -855,7 +855,7 @@ public class IDEWorkbenchAdvisor extends WorkbenchAdvisor {
 		ImageDescriptor desc = ImageDescriptor.createFromURL(url);
 		getWorkbenchConfigurer().declareImage(symbolicName, desc, shared);
 		if (disabledSymbolicName != null) {
-			ImageDescriptor disabledDescriptor = ImageDescriptor.createWithFlags(desc, SWT.IMAGE_DISABLE);
+			ImageDescriptor disabledDescriptor = desc.asDisabledDescriptor();
 			getWorkbenchConfigurer().declareImage(disabledSymbolicName, disabledDescriptor, shared);
 		}
 	}

--- a/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/texteditor/templates/TemplatesPageImages.java
+++ b/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/texteditor/templates/TemplatesPageImages.java
@@ -17,7 +17,6 @@ import java.net.URL;
 
 import org.osgi.framework.Bundle;
 
-import org.eclipse.swt.SWT;
 import org.eclipse.swt.graphics.Image;
 
 import org.eclipse.core.runtime.FileLocator;
@@ -118,7 +117,7 @@ class TemplatesPageImages {
 		}
 		fgImageRegistry.put(key, desc);
 		if (disabledKey != null) {
-			ImageDescriptor disabledDescriptor = ImageDescriptor.createWithFlags(desc, SWT.IMAGE_DISABLE);
+			ImageDescriptor disabledDescriptor = desc.asDisabledDescriptor();
 			fgImageRegistry.put(disabledKey, disabledDescriptor);
 		}
 	}

--- a/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/WorkbenchImages.java
+++ b/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/WorkbenchImages.java
@@ -20,7 +20,6 @@ import java.util.Map;
 import org.eclipse.core.runtime.Assert;
 import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.jface.resource.ImageRegistry;
-import org.eclipse.swt.SWT;
 import org.eclipse.swt.graphics.Image;
 import org.eclipse.ui.ISharedImages;
 import org.eclipse.ui.PlatformUI;
@@ -106,7 +105,7 @@ public/* final */class WorkbenchImages {
 				() -> BundleUtility.find(PlatformUI.PLUGIN_ID, path));
 		declareImage(key, desc, shared);
 		if (disabledKey != null) {
-			ImageDescriptor disabledImageDescriptor = ImageDescriptor.createWithFlags(desc, SWT.IMAGE_DISABLE);
+			ImageDescriptor disabledImageDescriptor = desc.asDisabledDescriptor();
 			declareImage(disabledKey, disabledImageDescriptor, shared);
 		}
 	}

--- a/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/dialogs/cpd/GrayOutUnavailableLabelProvider.java
+++ b/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/dialogs/cpd/GrayOutUnavailableLabelProvider.java
@@ -73,7 +73,7 @@ class GrayOutUnavailableLabelProvider extends TreeManager.TreeItemLabelProvider 
 		if (element instanceof DisplayItem item && actual != null) {
 			if (!CustomizePerspectiveDialog.isEffectivelyAvailable(item, filter)) {
 				ImageDescriptor original = ImageDescriptor.createFromImage(actual);
-				ImageDescriptor disable = ImageDescriptor.createWithFlags(original, SWT.IMAGE_DISABLE);
+				ImageDescriptor disable = original.asDisabledDescriptor();
 				Image newImage = disable.createImage();
 				toDispose.add(newImage);
 				return newImage;

--- a/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/progress/ProgressInfoItem.java
+++ b/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/progress/ProgressInfoItem.java
@@ -155,8 +155,7 @@ public class ProgressInfoItem extends Composite {
 	static {
 		ImageDescriptor processStopDescriptor = WorkbenchImages.getWorkbenchImageDescriptor("elcl16/progress_stop.svg"); //$NON-NLS-1$
 		JFaceResources.getImageRegistry().put(STOP_IMAGE_KEY, processStopDescriptor);
-		ImageDescriptor disabledProcessStopDescriptor = ImageDescriptor.createWithFlags(processStopDescriptor,
-				SWT.IMAGE_DISABLE);
+		ImageDescriptor disabledProcessStopDescriptor = processStopDescriptor.asDisabledDescriptor();
 		JFaceResources.getImageRegistry().put(DISABLED_STOP_IMAGE_KEY, disabledProcessStopDescriptor);
 
 		JFaceResources.getImageRegistry().put(DEFAULT_JOB_KEY,


### PR DESCRIPTION
Image descriptors are often shared and used with a `ResourceManager` to share an image created from the same descriptor. To do this with the disabled version of the image of a descriptor, a descriptor for the disabled image has to be managed in addition to the descriptor for the ordinary image. This is what is also done in shared workbench images where an image descriptor for the original and the disabled image are managed independently.

This change adds a method to an image descriptor for providing a shared image descriptor for the disabled version of the same image. This allows to only manage the original image's descriptor while also sharing the disabled version of that image. The disabled image descriptor is created lazy upon first access.
It is applied as a replacement at all places which used the `createWithFlags()` operation of an image descriptor for creating an image descriptor for the disabled version of the image to ensure that a shared image descriptor is used there.

As a further follow-up task, remaining usages of independently managed image descriptors for disabled image versions can be exchanged with usage of the new API.

This also contributes to:
- https://github.com/eclipse-platform/eclipse.platform.ui/pull/3760

### Alternative Solutions

One alternative I have thought about is the extension of the `ResourceManager` to allow the creation and management of a disabled version of an image. But the `ResourceManager` interface is currently designed to just create/destroy/get a resource from a `DeviceResourceDescriptor` and all resource-type-specific methods (such as for creating images) are deprecated proposing the usage of the generic methods. The providing a disabled resource for a given ImageDescriptor would, however, require specific methods that allow to parameterize the request with the information about disablement. For that reason, I chose to not follow this approach but embed the functionality into the `ImageDescriptor` itself.

### Feedback

Like always, feedback is welcome, in particular since this will introduce new API at the `ImageDescriptor` class. In case you have other proposals for sharing the image descriptor for a disabled version of another image descriptor, please share it.