### PR TITLE
Remove the org.eclipse.ui.r30 from the Colors and Fonts theme selection.

### DIFF
--- a/bundles/org.eclipse.ui/plugin.properties
+++ b/bundles/org.eclipse.ui/plugin.properties
@@ -379,8 +379,6 @@ Color.showKeysBackgroundDesc=Color for background of the control to visualize pr
 ThemeName.SystemDefault = Reduced Palette
 HighContrast.ThemeDescription = A theme that takes all of its values from the system settings.
 
-ThemeName.R30 = Classic Theme
-
 SettingsTransfer.WorkbenchLayout = Workbench L&ayout
 SettingsTransfer.WorkingSets = Working &Sets
 SettingsTransfer.Preferences = &Preferences

--- a/bundles/org.eclipse.ui/plugin.xml
+++ b/bundles/org.eclipse.ui/plugin.xml
@@ -1993,40 +1993,6 @@
                <parameter name="color" value="foreground"></parameter>
             </colorFactory>
       </colorDefinition>
-      <theme
-            id="org.eclipse.ui.r30"
-            name="%ThemeName.R30">
-             <colorOverride
-               id="org.eclipse.ui.workbench.ACTIVE_TAB_BG_START"
-               value="COLOR_TITLE_BACKGROUND">
-         </colorOverride>
-         <colorOverride
-               id="org.eclipse.ui.workbench.ACTIVE_TAB_BG_END">
-            <colorFactory
-                  class="org.eclipse.ui.themes.RGBBlendColorFactory"
-                  plugin="org.eclipse.ui">
-               <parameter
-                     name="color1"
-                     value="COLOR_TITLE_BACKGROUND_GRADIENT">
-               </parameter>
-               <parameter
-                     name="color2"
-                     value="COLOR_TITLE_BACKGROUND_GRADIENT">
-               </parameter>
-            </colorFactory>
-         </colorOverride>
-         <data
-               name="org.eclipse.ui.workbench.ACTIVE_TAB_PERCENT"
-               value="100">
-         </data>
-         <colorOverride
-               id="org.eclipse.ui.workbench.ACTIVE_TAB_TEXT_COLOR"
-               value="COLOR_TITLE_FOREGROUND">
-         </colorOverride>
-		 <data
-      		name="org.eclipse.ui.workbench.ACTIVE_TAB_HIGHLIGHT" value="false">
-		 </data>
-      </theme>
       <colorDefinition
             categoryId="org.eclipse.ui.workbenchMisc"
             id="org.eclipse.ui.showkeys.foregroundColor"


### PR DESCRIPTION

The `org.eclipse.ui.r30` theme seems to be an old eclipse 3.x workbench theme. Its contribution is now limited to a small set of active-tab styling overrides and it no longer provide a distinct visual experience from default theme. The theme is also unrelated to the former e4 Classic theme which was removed recently (`org.eclipse.e4.ui.css.theme.e4_classic`), although the shared "Classic" naming can make them appear connected. modern eclipse since relay on the e4 CSS theme framework for appearance, and the  `org.eclipse.ui.r30` overrides no longer result in a meaningful or distinguishable theme experience, thus could be removed imo.

Contributes to https://github.com/eclipse-platform/eclipse.platform/issues/2760