### PR TITLE
Restore bounded wait in QuickAccessDialogTest to avoid bundle timeout

### DIFF
--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/quickaccess/QuickAccessDialogTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/quickaccess/QuickAccessDialogTest.java
@@ -321,7 +321,7 @@ public class QuickAccessDialogTest {
 		 * wait for the dialog initialization, to avoid race conditions later on in the test, see:
 		 * https://github.com/eclipse-platform/eclipse.platform.ui/issues/4009
 		 */
-		assertTrue(DisplayHelper.waitForCondition(text.getDisplay(), TIMEOUT * 1000,
+		assertTrue(DisplayHelper.waitForCondition(text.getDisplay(), TIMEOUT,
 				() -> dialog.infoText != null),
 				"Unexpected dialog info: " + dialog.infoText);
 		text.setText(TestQuickAccessComputer.TEST_QUICK_ACCESS_PROPOSAL_LABEL);


### PR DESCRIPTION
The dialog-initialization wait in `testPreviousChoicesAvailableForExtension` was set to `TIMEOUT * 1000`, roughly 83 minutes. When the dialog initialization stalls, which happens on the macOS CI runners, the wait blocks well past the 1200s tycho-surefire budget for the whole `org.eclipse.ui.tests` bundle, so the test runtime is killed with SIGTERM (exit code 143). Maven then reports a launch failure with no test results, which is why the macOS validation has been failing for every PR without pointing at a specific test.

Restoring the wait to `TIMEOUT` makes the test fail fast and locally when the dialog does not initialize, instead of hanging and taking the entire bundle down with it. The underlying race that leaves the proposals empty is addressed separately in #4090; this change only removes the accidental long wait so failures stay attributable and the bundle keeps reporting results. See #4009.