### PR TITLE
Enhance EditingSupport/*CellEditor assertions

### DIFF
--- a/bundles/org.eclipse.jface/src/org/eclipse/jface/viewers/CheckboxCellEditor.java
+++ b/bundles/org.eclipse.jface/src/org/eclipse/jface/viewers/CheckboxCellEditor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2014 IBM Corporation and others.
+ * Copyright (c) 2000, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -126,7 +126,9 @@ public class CheckboxCellEditor extends CellEditor {
 	 */
 	@Override
 	protected void doSetValue(Object value) {
-		Assert.isTrue(value instanceof Boolean);
+		String valueType = value == null ? "null" : value.getClass().getName(); //$NON-NLS-1$
+		Assert.isTrue(value instanceof Boolean,
+				"CheckboxCellEditor expects a Boolean value but got " + valueType); //$NON-NLS-1$
 		this.value = ((Boolean) value).booleanValue();
 	}
 

--- a/bundles/org.eclipse.jface/src/org/eclipse/jface/viewers/ComboBoxCellEditor.java
+++ b/bundles/org.eclipse.jface/src/org/eclipse/jface/viewers/ComboBoxCellEditor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corporation and others.
+ * Copyright (c) 2000, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -226,7 +226,10 @@ public class ComboBoxCellEditor extends AbstractComboBoxCellEditor {
 	 */
 	@Override
 	protected void doSetValue(Object value) {
-		Assert.isTrue(comboBox != null && (value instanceof Integer));
+		Assert.isTrue(comboBox != null);
+		String valueType = value == null ? "null" : value.getClass().getName(); //$NON-NLS-1$
+		Assert.isTrue(value instanceof Integer,
+				"ComboBoxCellEditor expects an Integer value but got " + valueType); //$NON-NLS-1$
 		selection = ((Integer) value).intValue();
 		comboBox.select(selection);
 	}

--- a/bundles/org.eclipse.jface/src/org/eclipse/jface/viewers/EditingSupport.java
+++ b/bundles/org.eclipse.jface/src/org/eclipse/jface/viewers/EditingSupport.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2006, 2015 IBM Corporation and others.
+ * Copyright (c) 2006, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -17,6 +17,7 @@
 package org.eclipse.jface.viewers;
 
 import org.eclipse.core.runtime.Assert;
+import org.eclipse.core.runtime.AssertionFailedException;
 
 /**
  * EditingSupport is the abstract superclass of the support for cell editing.
@@ -99,7 +100,18 @@ public abstract class EditingSupport {
 	 */
 	protected void initializeCellEditorValue(CellEditor cellEditor, ViewerCell cell) {
 		Object value = getValue(cell.getElement());
-		cellEditor.setValue(value);
+		try {
+			cellEditor.setValue(value);
+		} catch (AssertionFailedException e) {
+			String valueType = value == null ? "null" : value.getClass().getName(); //$NON-NLS-1$
+			Assert.isTrue(false, "Failed to initialize cell editor " + cellEditor.getClass().getName() //$NON-NLS-1$
+					+ " at column index " + cell.getColumnIndex() //$NON-NLS-1$
+					+ " for element " + cell.getElement() //$NON-NLS-1$
+					+ " with value of type " + valueType //$NON-NLS-1$
+					+ ". The value returned by getValue(Object) is incompatible with the cell editor;" //$NON-NLS-1$
+					+ " check that the EditingSupport and the CellEditor for this column match. Cause: " //$NON-NLS-1$
+					+ e.getMessage());
+		}
 	}
 
 	/**

--- a/bundles/org.eclipse.jface/src/org/eclipse/jface/viewers/TextCellEditor.java
+++ b/bundles/org.eclipse.jface/src/org/eclipse/jface/viewers/TextCellEditor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2015 IBM Corporation and others.
+ * Copyright (c) 2000, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -222,7 +222,9 @@ public class TextCellEditor extends CellEditor {
 	 */
 	@Override
 	protected void doSetValue(Object value) {
-		Assert.isTrue(text != null && (value instanceof String));
+		Assert.isTrue(text != null);
+		String valueType = value == null ? "null" : value.getClass().getName(); //$NON-NLS-1$
+		Assert.isTrue(value instanceof String, "TextCellEditor expects a String value but got " + valueType); //$NON-NLS-1$
 		text.removeModifyListener(getModifyListener());
 		text.setText((String) value);
 		text.addModifyListener(getModifyListener());

--- a/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/viewers/AllViewersTests.java
+++ b/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/viewers/AllViewersTests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corporation and others.
+ * Copyright (c) 2000, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -29,7 +29,8 @@ import org.junit.platform.suite.api.Suite;
 		ListViewerRefreshTest.class, Bug200558Test.class, Bug201002TableViewerTest.class, Bug201002TreeViewerTest.class,
 		Bug200337TableViewerTest.class, //
 		Bug205700TreeViewerTest.class, Bug180504TableViewerTest.class, Bug180504TreeViewerTest.class,
-		Bug256889TableViewerTest.class, Bug287765Test.class, Bug242231Test.class, StyledStringBuilderTest.class,
+		Bug256889TableViewerTest.class, Bug287765Test.class, Bug242231Test.class,
+		EditingSupportValueMismatchTest.class, StyledStringBuilderTest.class,
 		TreeViewerWithLimitTest.class, TreeViewerWithLimitCompatibilityTest.class, TableViewerWithLimitTest.class,
 		TableViewerWithLimitCompatibilityTest.class })
 public class AllViewersTests {

--- a/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/viewers/EditingSupportValueMismatchTest.java
+++ b/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/viewers/EditingSupportValueMismatchTest.java
@@ -1,0 +1,86 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Aleksandar Kurtakov and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.jface.tests.viewers;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.eclipse.core.runtime.AssertionFailedException;
+import org.eclipse.jface.viewers.CellEditor;
+import org.eclipse.jface.viewers.ColumnLabelProvider;
+import org.eclipse.jface.viewers.EditingSupport;
+import org.eclipse.jface.viewers.StructuredViewer;
+import org.eclipse.jface.viewers.TableViewer;
+import org.eclipse.jface.viewers.TableViewerColumn;
+import org.eclipse.jface.viewers.TextCellEditor;
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.widgets.Composite;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Verifies that when an {@link EditingSupport} {@code getValue(Object)} returns
+ * a value incompatible with the {@link CellEditor} attached to the column,
+ * there is enough context (column index, element, value type) to help finding
+ * the cause.
+ */
+public class EditingSupportValueMismatchTest extends ViewerTestCase {
+
+	private TableViewer tableViewer;
+
+	@Override
+	protected StructuredViewer createViewer(Composite parent) {
+		tableViewer = new TableViewer(parent, SWT.NONE);
+		tableViewer.setContentProvider(new TestModelContentProvider());
+
+		TableViewerColumn tableColumn = new TableViewerColumn(tableViewer, SWT.NONE);
+		tableColumn.setEditingSupport(new EditingSupport(tableViewer) {
+
+			@Override
+			protected void setValue(Object element, Object value) {
+				// not reached in this test
+			}
+
+			@Override
+			protected Object getValue(Object element) {
+				// Return a non-String value for TextCellEditor, which expects a String.
+				return Integer.valueOf(42);
+			}
+
+			@Override
+			protected CellEditor getCellEditor(Object element) {
+				return new TextCellEditor(tableViewer.getTable());
+			}
+
+			@Override
+			protected boolean canEdit(Object element) {
+				return true;
+			}
+		});
+		tableColumn.setLabelProvider(new ColumnLabelProvider());
+		return tableViewer;
+	}
+
+	@Test
+	public void testMismatchProducesDetailedException() {
+		TestElement testElement = fRootElement.getChildAt(0);
+
+		AssertionFailedException ex = assertThrows(AssertionFailedException.class,
+				() -> tableViewer.editElement(testElement, 0));
+
+		String message = ex.getMessage();
+		assertNotNull(message);
+		assertTrue(message.contains("TextCellEditor"), "Name the cell editor: " + message);
+		assertTrue(message.contains("column index 0"), "Report the column index: " + message);
+		assertTrue(message.contains(Integer.class.getName()), "Report the offending value type: " + message);
+		assertTrue(message.contains("Cause:"), "Original assertion message: " + message);
+	}
+}


### PR DESCRIPTION
When CellEditor used expects different object type, there is assertion message like:
```
org.eclipse.core.runtime.AssertionFailedException: assertion failed:
    at org.eclipse.core.runtime.Assert.isTrue(Assert.java:121)
    at org.eclipse.core.runtime.Assert.isTrue(Assert.java:106)
    at org.eclipse.jface.viewers.TextCellEditor.doSetValue(TextCellEditor.java:225)
    at org.eclipse.jface.viewers.CellEditor.setValue(CellEditor.java:853)
    at org.eclipse.jface.viewers.EditingSupport.initializeCellEditorValue(EditingSupport.java:102)
```

which is not really helpful in identifying the exact cause.
Enhance the assertions to give as much information as possible.