### PR TITLE
Wait for the expected item count in QuickAccessDialogTest.testShowAll

### DIFF
--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/quickaccess/QuickAccessDialogTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/quickaccess/QuickAccessDialogTest.java
@@ -243,14 +243,14 @@ public class QuickAccessDialogTest {
 				.getService(IHandlerService.class);
 		// Run the handler to turn on show all
 		handlerService.executeCommand("org.eclipse.ui.window.quickAccess", null); //$NON-NLS-1$
-		processEventsUntil(() -> table.getItemCount() != defaultCount, TIMEOUT);
+		processEventsUntil(() -> table.getItemCount() > defaultCount, TIMEOUT);
 		final int allCount = table.getItemCount();
 		assertTrue(allCount > defaultCount, "Turning on show all should display more items");
 		assertEquals(oldFirstItemText, table.getItem(0).getText(1), "Turning on show all should not change the top item");
 
 		// Run the handler to turn off show all
 		handlerService.executeCommand("org.eclipse.ui.window.quickAccess", null); //$NON-NLS-1$
-		processEventsUntil(() -> table.getItemCount() != allCount, TIMEOUT);
+		processEventsUntil(() -> table.getItemCount() < allCount, TIMEOUT);
 		// Note: The table count may one off from the old count because of shell resizing (scroll bars being added then removed)
 		assertTrue(table.getItemCount() < allCount, "Turning off show all should limit items shown");
 		assertEquals(oldFirstItemText, table.getItem(0).getText(1), "Turning off show all should not change the top item");


### PR DESCRIPTION
`testShowAll` toggled show-all (and back) but only waited for the table item count to *differ* from the previous count, while asserting a direction: more items when showing all, fewer when limiting again. The visible row count can shift by one as scroll bars appear and disappear during layout, so the "differs" wait could end early on that incidental change and capture a count that was not yet the expanded (or limited) one. That made the assertion fail intermittently on macOS (Linux and Windows were unaffected).

The waits now poll for the actual asserted condition (count greater than the limited count when showing all, less than the full count when limiting again), so an incidental one-off change no longer ends the wait before the real recompute lands.