### PR TITLE
Fix commands being executed multiple times due to stale isEnabled() check

### DIFF
--- a/bundles/org.eclipse.e4.ui.bindings/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.e4.ui.bindings/META-INF/MANIFEST.MF
@@ -1,7 +1,7 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-SymbolicName: org.eclipse.e4.ui.bindings;singleton:=true
-Bundle-Version: 0.15.100.qualifier
+Bundle-Version: 0.15.200.qualifier
 Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/bundles/org.eclipse.e4.ui.bindings/src/org/eclipse/e4/ui/bindings/keys/KeyBindingDispatcher.java
+++ b/bundles/org.eclipse.e4.ui.bindings/src/org/eclipse/e4/ui/bindings/keys/KeyBindingDispatcher.java
@@ -304,7 +304,7 @@ public class KeyBindingDispatcher {
 		Object obj = HandlerServiceImpl.lookUpHandler(context, command.getId());
 		if (obj != null) {
 			if (obj instanceof IHandler handler) {
-				commandHandled = command.isEnabled() && handler.isHandled();
+				commandHandled = handler.isHandled();
 			} else {
 				commandHandled = true;
 			}
@@ -319,12 +319,12 @@ public class KeyBindingDispatcher {
 			getDisplay()
 					.asyncExec(() -> handleCommandExecution(parameterizedCommand, handlerService, trigger, obj));
 		} else {
-			handleCommandExecution(parameterizedCommand, handlerService, trigger, obj);
+			commandHandled &= handleCommandExecution(parameterizedCommand, handlerService, trigger, obj);
 		}
 		return (commandDefined && commandHandled);
 	}
 
-	private void handleCommandExecution(final ParameterizedCommand parameterizedCommand,
+	private boolean handleCommandExecution(final ParameterizedCommand parameterizedCommand,
 			final EHandlerService handlerService, final Event trigger, Object handler) {
 		final IEclipseContext staticContext = createContext(trigger);
 		try {
@@ -360,6 +360,7 @@ public class KeyBindingDispatcher {
 						}
 					}
 				}
+				return false;
 			}
 		} finally {
 			staticContext.dispose();
@@ -371,6 +372,7 @@ public class KeyBindingDispatcher {
 		if (keyAssistDialog != null) {
 			keyAssistDialog.clearRememberedState();
 		}
+		return true;
 	}
 
 	private boolean isTracingEnabled() {

--- a/tests/org.eclipse.e4.ui.bindings.tests/src/org/eclipse/e4/ui/bindings/tests/KeyDispatcherTest.java
+++ b/tests/org.eclipse.e4.ui.bindings.tests/src/org/eclipse/e4/ui/bindings/tests/KeyDispatcherTest.java
@@ -16,6 +16,8 @@
 package org.eclipse.e4.ui.bindings.tests;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
@@ -24,7 +26,11 @@ import org.junit.jupiter.api.Test;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.eclipse.core.commands.AbstractHandler;
 import org.eclipse.core.commands.Category;
+import org.eclipse.core.commands.Command;
+import org.eclipse.core.commands.ExecutionEvent;
+import org.eclipse.core.commands.ExecutionException;
 import org.eclipse.core.commands.ParameterizedCommand;
 import org.eclipse.core.commands.contexts.Context;
 import org.eclipse.core.commands.contexts.ContextManager;
@@ -195,6 +201,57 @@ public class KeyDispatcherTest {
 		shell.notifyListeners(SWT.KeyDown, event);
 
 		assertTrue(handler.q2);
+	}
+
+	/**
+	 * Regression test for https://github.com/eclipse-platform/eclipse.platform.ui/issues/4080
+	 * <p>
+	 * A handler's enabled state may be stale from a previous UI-refresh cycle and return
+	 * {@code false} even though the handler is capable of handling the command and would execute
+	 * it successfully. {@link KeyBindingDispatcher#executeCommand} must return {@code true}
+	 * whenever the handler is capable of handling the command, so that the caller consumes the key
+	 * event and prevents the OS from also processing it natively — which would cause the command to
+	 * execute twice.
+	 */
+	@Test
+	public void testExecuteCommandReturnsTrueWhenHandlerEnabledStateIsStale() throws Exception {
+		// Spy on an AbstractHandler (IHandler2) whose enabled state starts stale (false) but
+		// refreshes to true when Command.executeWithChecks() calls setEnabled(appContext).
+		AbstractHandler staleHandler = spy(new AbstractHandler() {
+			{
+				setBaseEnabled(false); // stale: disabled without an execution context
+			}
+
+			@Override
+			public void setEnabled(Object evaluationContext) {
+				setBaseEnabled(evaluationContext != null);
+			}
+
+			@Override
+			public Object execute(ExecutionEvent event) throws ExecutionException {
+				return null;
+			}
+		});
+
+		EHandlerService hs = workbenchContext.get(EHandlerService.class);
+		hs.activateHandler(TEST_ID1, staleHandler);
+
+		ECommandService cs = workbenchContext.get(ECommandService.class);
+		ParameterizedCommand paramCmd = cs.createCommand(TEST_ID1, null);
+		Command command = paramCmd.getCommand();
+		command.setHandler(staleHandler);
+
+		assertFalse(command.isEnabled(), "Precondition: command.isEnabled() must be false (stale state)");
+
+		Event event = new Event();
+		event.type = SWT.KeyDown;
+		event.stateMask = SWT.CTRL;
+		event.keyCode = 'A';
+
+		boolean result = dispatcher.executeCommand(paramCmd, event);
+
+		assertTrue(result, "executeCommand() must return true when the handler is capable of execution");
+		verify(staleHandler, times(1)).execute(any(ExecutionEvent.class));
 	}
 
 	@Test


### PR DESCRIPTION
## Problem

Since commit 35f5f09e ("Process KeyBinding Command Asyncly for Browser", fixes #3104), certain commands triggered via key bindings are executed twice. A prominent example is Paste (Ctrl+V) on a `Combo` widget, where text from the clipboard is inserted twice.

The duplicate execution follows two paths:
1. Via `KeyBindingDispatcher` → `HandlerService` → the registered handler (e.g. `WidgetMethodHandler`)
2. Via the OS native key event handler, which fires because Eclipse did not consume the key event

## Root Cause

### Change 1 — `command.isEnabled()` added to `commandHandled` evaluation

Commit 35f5f09e changed the `commandHandled` evaluation in `executeCommand()`:

```java
// before
commandHandled = ((IHandler) obj).isHandled();

// after (introduced by 35f5f09e)
commandHandled = command.isEnabled() && handler.isHandled();
```

`commandHandled` is what `executeCommand()` returns, and that return value determines whether `processKeyEvent()` sets `event.doit = false` to consume the key event.

`command.isEnabled()` delegates to `handler.isEnabled()`. For `IHandler2` implementations, this reflects the result of the last `setEnabled(evaluationContext)` call — made during menu/toolbar refresh cycles, not at the point of the key event. The enabled state is therefore **stale** and does not reflect the currently active widget context.

By contrast, inside `Command.executeWithChecks()` (called from `handlerService.executeHandler()`), the framework calls `setEnabled(event.getApplicationContext())` immediately before the same `isEnabled()` check, giving a **fresh** context-aware result. These two checks are not equivalent and do disagree for context-sensitive handlers like `WidgetMethodHandler`.

When `command.isEnabled()` incorrectly returns `false`:
- `commandHandled` is `false`
- `executeCommand()` returns `false`
- the key event is **not consumed** (`event.doit` remains `true`)
- the OS processes the keystroke natively, triggering a second execution

### Change 2 — `commandHandled = false` on `CommandException` was removed

The original code set `commandHandled = false` if execution produced a `CommandException` (e.g. a `NotEnabledException` thrown from `executeWithChecks()` after a fresh `setEnabled()` evaluation). This ensured the key was not eaten when execution genuinely failed. The commit removed this line, leaving no mechanism to correct `commandHandled` based on the actual execution outcome for the synchronous path.

## Solution

### Fix 1 (critical) — revert `commandHandled` to use only `handler.isHandled()`

```java
commandHandled = handler.isHandled();
```

`handler.isHandled()` answers the right question here: "is there a handler registered and capable of processing this command?" It does not depend on stale evaluation context. This is sufficient to decide whether Eclipse should claim ownership of the key event.

**Why this is sound for the synchronous (non-Browser) path:** execution happens immediately in the same call stack. If `isHandled()` is `true` but execution fails (see Fix 2), `commandHandled` is corrected before returning.

**Why this is sound for the async (Browser) path:** the key event must be consumed or not consumed synchronously, before the async execution runs. Basing that decision on `handler.isHandled()` is the right speculative choice — if we do not consume the key, the Browser's native handler will also process it, causing the exact duplicate-execution bug reported in #4080. The async path was introduced precisely to break a deadlock; eating the key speculatively is the correct trade-off.

### Fix 2 (secondary) — restore `commandHandled = false` on `CommandException` for the synchronous path

`handleCommandExecution()` is changed to return a `boolean` (`false` if a `CommandException` was recorded in the `staticContext` after execution, `true` otherwise). The synchronous branch of `executeCommand()` uses this return value to update `commandHandled` before returning:

```java
if (trigger != null && trigger.widget instanceof Browser) {
    getDisplay().asyncExec(() -> handleCommandExecution(...));
} else {
    commandHandled = handleCommandExecution(...) && commandHandled;
}
```

This restores the original correctness property: a handler that claims `isHandled()` but fails during execution (because `executeWithChecks()` finds it disabled after a fresh `setEnabled()` call) does not eat the key event.

The async Browser path remains `void` — a return value is not available before the caller returns, and the speculative eat-the-key decision based on `handler.isHandled()` is correct by the reasoning above.

Fixes #4080