### PR TITLE
Run addons SWT tests via the AllTests suite in the Tycho build

### DIFF
--- a/tests/org.eclipse.e4.ui.workbench.addons.swt.test/build.properties
+++ b/tests/org.eclipse.e4.ui.workbench.addons.swt.test/build.properties
@@ -2,3 +2,6 @@ source.. = src/
 output.. = bin/
 bin.includes = META-INF/,\
                .
+
+# Maven properties, see https://github.com/eclipse/tycho/wiki/Tycho-Pomless
+pom.model.property.testClass = org.eclipse.e4.ui.workbench.addons.AllTests

--- a/tests/org.eclipse.e4.ui.workbench.addons.swt.test/src/org/eclipse/e4/ui/workbench/addons/AllTests.java
+++ b/tests/org.eclipse.e4.ui.workbench.addons.swt.test/src/org/eclipse/e4/ui/workbench/addons/AllTests.java
@@ -1,0 +1,34 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Vector Informatik GmbH and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Heiko Klare - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.e4.ui.workbench.addons;
+
+import org.eclipse.e4.ui.workbench.addons.cleanupaddon.CleanupAddonTest;
+import org.eclipse.e4.ui.workbench.addons.dndaddon.StackDropAgentTest;
+import org.eclipse.e4.ui.workbench.addons.minmax.MaximizableChildrenTagTest;
+import org.eclipse.e4.ui.workbench.addons.minmax.MaximizeBugTest;
+import org.eclipse.e4.ui.workbench.addons.minmax.MaximizePartSashContainerPlaceholderTest;
+import org.junit.platform.suite.api.SelectClasses;
+import org.junit.platform.suite.api.Suite;
+
+@Suite
+@SelectClasses({ //
+		StackDropAgentTest.class, //
+		MaximizeBugTest.class, //
+		MaximizePartSashContainerPlaceholderTest.class, //
+		MaximizableChildrenTagTest.class, //
+		CleanupAddonTest.class, //
+})
+public class AllTests {
+
+}


### PR DESCRIPTION
Instead of relying on
Tycho's class-name autodiscovery, use the standard Tycho approach via
build.properties.

Reintroduce the AllTests @Suite and point Tycho at it through the
pom.model.property.testClass build property. This disables the
additional
name-based scan, so each test class is executed exactly once via the
suite.

The restored suite also includes StackDropAgentTest, which the previous
AllTests suite had omitted, so every test class in the bundle is now
part
of the suite.