### PR TITLE
Apply Quick Access results by request state instead of last job

### DIFF
--- a/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/quickaccess/QuickAccessContents.java
+++ b/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/quickaccess/QuickAccessContents.java
@@ -147,9 +147,12 @@ public abstract class QuickAccessContents {
 	/**
 	 * Refreshes the contents of the quick access shell
 	 *
-	 * @param filter The filter text to apply to results
+	 * @param filterInput The filter text to apply to results
 	 */
-	public void updateProposals(String filter) {
+	public void updateProposals(String filterInput) {
+		// Lower-case once so all callers share one filter string; the matcher and
+		// previous-pick lookup also require a lower-cased filter.
+		final String filter = filterInput == null ? "" : filterInput.toLowerCase(); //$NON-NLS-1$
 		if (Policy.DEBUG_QUICK_ACCESS) {
 			trace("Updating proposals with filter: \"" + filter + "\""); //$NON-NLS-1$ //$NON-NLS-2$
 		}
@@ -168,6 +171,8 @@ public abstract class QuickAccessContents {
 		String computingMessage = NLS.bind(QuickAccessMessages.QuickaAcessContents_computeMatchingEntries, filter);
 		int maxNumberOfItemsInTable = computeNumberOfItems();
 		lastComputedItemCount = maxNumberOfItemsInTable;
+		// Captured to detect a show-all toggle while this compute runs.
+		final boolean requestShowAllMatches = showAllMatches;
 		AtomicReference<List<QuickAccessEntry>[]> entries = new AtomicReference<>();
 		final Job currentComputeEntriesJob = Job.create(computingMessage, theMonitor -> {
 			entries.set(
@@ -203,12 +208,20 @@ public abstract class QuickAccessContents {
 							", entries: " + toIds(entries)); //$NON-NLS-1$
 				}
 				computingFeedbackJob.cancel();
-				if (computeProposalsJob == currentComputeEntriesJob && event.getResult().isOK()
-						&& !table.isDisposed()) {
-					if (Policy.DEBUG_QUICK_ACCESS) {
-						trace("Setting quick access contents: " + toIds(entries)); //$NON-NLS-1$
-					}
+				if (event.getResult().isOK() && !table.isDisposed()) {
 					display.asyncExec(() -> {
+						if (table.isDisposed() || filterText == null || filterText.isDisposed()) {
+							return;
+						}
+						// Apply if the results still match the current filter and show-all,
+						// not only when this is the last scheduled job.
+						if (!filter.equals(filterText.getText().toLowerCase())
+								|| requestShowAllMatches != showAllMatches) {
+							return;
+						}
+						if (Policy.DEBUG_QUICK_ACCESS) {
+							trace("Setting quick access contents: " + toIds(entries)); //$NON-NLS-1$
+						}
 						computingFeedbackJob.cancel();
 						refreshTable(perfectMatch, entries.get(), filter);
 					});


### PR DESCRIPTION
The Quick Access dialog intermittently came up empty (issue #4009, mainly on macOS but also Windows): the compute job produced the right results but they were thrown away because result application keyed off whether the job was the last one scheduled, and a resize-triggered recompute right afterwards made it no longer the last. This applies a finished job's results whenever they still match the current filter and show-all state instead, so valid results are no longer discarded, while results for a filter the user has since changed are still rejected.

It also normalizes the filter to lower case in one place so the modify and resize listeners stop creating competing differently-cased jobs (the matcher requires lower case), which also fixes previous-pick perfect-match lookup whose keys are stored lower-cased. The earlier resize-coalescing change narrowed this window but did not close it.

Opening as draft to let the multi-OS CI matrix exercise the timing, since the flake does not reproduce locally. QuickAccessDialogTest passes locally against the patched bundle.