### PR TITLE
Stabilize QuickAccessDialogTest by warming lazy providers in setUp

### DIFF
--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/quickaccess/QuickAccessDialogTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/quickaccess/QuickAccessDialogTest.java
@@ -85,6 +85,10 @@ public class QuickAccessDialogTest {
 	}
 
 	private static final int TIMEOUT = 5000;
+	// Generous bound for the one-time cold initialization of the lazy providers.
+	private static final int WARMUP_TIMEOUT = 60000;
+	// The lazy providers initialize once per JVM, so warm them only once.
+	private static boolean providersWarmedUp;
 	// As defined in QuickAccessDialog and in SearchField
 	private static final int MAXIMUM_NUMBER_OF_ELEMENTS = 60;
 	private static final Predicate<Shell> isQuickAccessShell = shell -> shell.getText()
@@ -109,6 +113,15 @@ public class QuickAccessDialogTest {
 		activeWorkbenchWindow = openTestWindow();
 		QuickAccessDialog warmupDialog = new QuickAccessDialog(activeWorkbenchWindow, null);
 		warmupDialog.open();
+		if (!providersWarmedUp) {
+			// Warm the lazy providers once with a real filter so their slow first query
+			// runs here, not inside a test's timed wait. An empty filter skips them.
+			Text warmupText = warmupDialog.getQuickAccessContents().getFilterText();
+			Table warmupTable = warmupDialog.getQuickAccessContents().getTable();
+			warmupText.setText("t");
+			DisplayHelper.waitForCondition(warmupText.getDisplay(), WARMUP_TIMEOUT, () -> warmupTable.getItemCount() > 0);
+			providersWarmedUp = true;
+		}
 		warmupDialog.close();
 	}
 


### PR DESCRIPTION
The UI-requiring quick access providers are constructed and queried lazily on the first non-empty filter, and that first query runs them on the UI thread. On a cold workbench it can block for many seconds (about 28s on a slow macOS runner), and because the setUp warmup only used an empty filter (which skips those providers), that one-time cost landed inside whichever test typed the first filter and exceeded its timed wait, leaving the table empty.

This warms the providers with a real filter during setUp, so the slow first query runs outside any timed assertion and every test sees the warm, fast path. Test-only change; the lazy provider construction in production is unchanged.

Addresses https://github.com/eclipse-platform/eclipse.platform.ui/issues/4009