### PR TITLE
Increase surefire timeout for the org.eclipse.ui.tests bundle

### DIFF
--- a/tests/org.eclipse.ui.tests/build.properties
+++ b/tests/org.eclipse.ui.tests/build.properties
@@ -31,3 +31,6 @@ src.includes = about.html
 # Maven properties, see https://github.com/eclipse/tycho/wiki/Tycho-Pomless
 pom.model.property.testClass = org.eclipse.ui.tests.UiTestSuite
 pom.model.property.defaultSigning-excludeInnerJars = true
+# This suite runs ~7 min on Linux but ~3x slower on the macOS CI runners, where it
+# exceeds the inherited 1200s surefire.timeout and the forked test VM is killed.
+pom.model.property.surefire.timeout = 1800


### PR DESCRIPTION
The org.eclipse.ui.tests suite runs in about 7 minutes on Linux but roughly three times slower on the GitHub macOS runners, where it exceeds the inherited 1200s surefire.timeout. The forked test VM is then killed (exit 143) while the suite is almost finished, which currently shows up as a recurring macOS CI failure on master unrelated to any individual test.

This raises surefire.timeout to 1800s for just this bundle via the Tycho pomless pom.model.property mechanism in build.properties, giving the slower macOS runner enough headroom to complete.