### PR TITLE
Remove redundant export from org.eclipse.e4.ui.css.core package

### DIFF
--- a/bundles/org.eclipse.e4.ui.css.core/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.e4.ui.css.core/META-INF/MANIFEST.MF
@@ -5,8 +5,7 @@ Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Bundle-Version: 0.14.800.qualifier
-Export-Package: org.eclipse.e4.ui.css.core;x-internal:=true,
- org.eclipse.e4.ui.css.core.css2;x-friends:="org.eclipse.e4.ui.css.swt.theme,org.eclipse.e4.ui.css.swt,org.eclipse.e4.ui.css.jface",
+Export-Package: org.eclipse.e4.ui.css.core.css2;x-friends:="org.eclipse.e4.ui.css.swt.theme,org.eclipse.e4.ui.css.swt,org.eclipse.e4.ui.css.jface",
  org.eclipse.e4.ui.css.core.dom;x-friends:="org.eclipse.e4.ui.css.swt,org.eclipse.ui.views.properties.tabbed,org.eclipse.ui.forms",
  org.eclipse.e4.ui.css.core.dom.properties;
   x-friends:="org.eclipse.e4.ui.css.swt,


### PR DESCRIPTION
Remove redundant export from org.eclipse.e4.ui.css.core package