### PR TITLE
Remove OpenCloseTest from UiTestSuite

### DIFF
--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/UiTestSuite.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/UiTestSuite.java
@@ -54,7 +54,6 @@ import org.eclipse.ui.tests.quickaccess.QuickAccessTestSuite;
 import org.eclipse.ui.tests.releng.PluginActivationTests;
 import org.eclipse.ui.tests.services.ServicesTestSuite;
 import org.eclipse.ui.tests.statushandlers.StatusHandlingTestSuite;
-import org.eclipse.ui.tests.stress.OpenCloseTest;
 import org.eclipse.ui.tests.systeminplaceeditor.OpenSystemInPlaceEditorTest;
 import org.eclipse.ui.tests.themes.ThemesTestSuite;
 import org.eclipse.ui.tests.zoom.ZoomTestSuite;
@@ -108,7 +107,6 @@ import org.junit.platform.suite.api.Suite;
 	WorkbenchDatabindingTest.class,
 	ChooseWorkspaceDialogTests.class,
 	ViewerItemsLimitTest.class,
-	OpenCloseTest.class,
 	WorkspaceLockTest.class
 })
 public class UiTestSuite {


### PR DESCRIPTION
OpenCloseTest is a stress test that repeatedly opens and closes editors, views, perspectives, workbench windows and the intro part. On the macOS CI runners it is the single most expensive test (about 290s, roughly 29% of the org.eclipse.ui.tests suite) and it intermittently stalls in testOpenClosePerspective for 8 to 9 minutes, killing the forked test VM through the per-bundle timeout. The watchdog added earlier only turns that stall into a fast failure; it removes neither the cost nor the flakiness.

Why this is safe: the open/close cycles it exercises are already covered functionally and for leaks elsewhere, for example LeakTests (testSimpleEditorLeak, testSimpleViewLeak, testSimpleWindowLeak), IWorkbenchPageTest, the zoom ShowView and OpenEditor tests and the intro tests. Removing it from UiTestSuite therefore loses no real coverage while reclaiming a large, variable chunk of macOS validation time. The test class is kept so it can still be run manually for stress testing.

Fixes #4101