### PR TITLE
Query Quick Access UI providers in a single UI-thread pass

### DIFF
--- a/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/quickaccess/QuickAccessContents.java
+++ b/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/quickaccess/QuickAccessContents.java
@@ -391,6 +391,45 @@ public abstract class QuickAccessContents {
 	}
 
 	/**
+	 * Queries every provider that requires UI access in a single UI-thread pass and
+	 * returns their sorted elements keyed by provider. Batching the queries avoids a
+	 * blocking worker-to-UI round-trip per provider on each keystroke.
+	 */
+	private Map<QuickAccessProvider, List<QuickAccessElement>> computeUiProviderElements(String filter, String category,
+			IProgressMonitor monitor) {
+		List<QuickAccessProvider> uiProviders = new ArrayList<>();
+		for (QuickAccessProvider provider : providers) {
+			if (!provider.requiresUiAccess()) {
+				continue;
+			}
+			boolean isPreviousPickProvider = provider instanceof PreviousPicksProvider;
+			if (category != null && !category.equalsIgnoreCase(provider.getName()) && !isPreviousPickProvider) {
+				continue;
+			}
+			if (!filter.isEmpty() || isPreviousPickProvider || showAllMatches) {
+				uiProviders.add(provider);
+			}
+		}
+		if (uiProviders.isEmpty() || monitor.isCanceled() || table == null || table.isDisposed()) {
+			return Collections.emptyMap();
+		}
+		Map<QuickAccessProvider, List<QuickAccessElement>> result = new HashMap<>();
+		table.getDisplay().syncExec(() -> {
+			for (QuickAccessProvider provider : uiProviders) {
+				if (monitor.isCanceled()) {
+					return;
+				}
+				try {
+					result.put(provider, Arrays.asList(provider.getElementsSorted(filter, monitor)));
+				} catch (RuntimeException e) {
+					WorkbenchPlugin.log(e);
+				}
+			}
+		});
+		return result;
+	}
+
+	/**
 	 * Returns a list per provider containing matching {@link QuickAccessEntry} that
 	 * should be displayed in the table given a text filter and a perfect match
 	 * entry that should be given priority. The number of items returned is affected
@@ -417,6 +456,11 @@ public abstract class QuickAccessContents {
 		}
 		final String finalFilter = filter;
 
+		// Query providers that must run on the UI thread once, in a single UI pass,
+		// rather than a separate blocking worker-to-UI round-trip per provider.
+		Map<QuickAccessProvider, List<QuickAccessElement>> uiProviderElements = computeUiProviderElements(finalFilter,
+				category, aMonitor);
+
 		// collect matching elements
 		LinkedHashMap<QuickAccessProvider, List<QuickAccessElement>> elementsForProviders = new LinkedHashMap<>(
 				providers.length);
@@ -430,28 +474,12 @@ public abstract class QuickAccessContents {
 				continue;
 			}
 			if (!filter.isEmpty() || isPreviousPickProvider || showAllMatches) {
-				AtomicReference<List<QuickAccessElement>> sortedElementRef = new AtomicReference<>();
+				List<QuickAccessElement> sortedElements;
 				if (provider.requiresUiAccess()) {
-					UIJob job = new UIJob(
-							NLS.bind(QuickAccessMessages.QuickAccessContents_processingProviderInUI,
-									provider.getName())) {
-						@Override
-						public IStatus runInUIThread(IProgressMonitor monitor) {
-							sortedElementRef.set(Arrays.asList(provider.getElementsSorted(finalFilter, monitor)));
-							return Status.OK_STATUS;
-						}
-					};
-					job.setPriority(Job.INTERACTIVE);
-					job.schedule();
-					try {
-						job.join(0, new NullProgressMonitor());
-					} catch (Exception e) {
-						WorkbenchPlugin.log(e);
-					}
+					sortedElements = uiProviderElements.get(provider);
 				} else {
-					sortedElementRef.set(Arrays.asList(provider.getElementsSorted(filter, aMonitor)));
+					sortedElements = Arrays.asList(provider.getElementsSorted(filter, aMonitor));
 				}
-				List<QuickAccessElement> sortedElements = sortedElementRef.get();
 				if (sortedElements == null) {
 					sortedElements = Collections.emptyList();
 				}

--- a/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/quickaccess/QuickAccessMessages.java
+++ b/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/quickaccess/QuickAccessMessages.java
@@ -45,7 +45,6 @@ public class QuickAccessMessages extends NLS {
 	public static String QuickAccessContents_activate;
 	public static String QuickAccessContents_computeMatchingEntries_displayFeedback_jobName;
 	public static String QuickaAcessContents_computeMatchingEntries;
-	public static String QuickAccessContents_processingProviderInUI;
 
 	static {
 		// initialize resource bundle

--- a/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/quickaccess/messages.properties
+++ b/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/quickaccess/messages.properties
@@ -35,4 +35,3 @@ QuickAccessContents_HelpCategory=Help
 QuickAccessContents_activate=Activate bundle for ''{0}'' proposals
 QuickAccessContents_computeMatchingEntries_displayFeedback_jobName=May show feedback when computing quick access
 QuickaAcessContents_computeMatchingEntries=\u23F3 Computing proposals for ''{0}''
-QuickAccessContents_processingProviderInUI=Processing ''{0}'' in UI Thread


### PR DESCRIPTION
Quick Access computes proposals on a background job, but for every provider that requires UI access it scheduled a separate UIJob and blocked the worker on `join(0)`. With around seven UI-access providers (editors, parts, perspectives, commands, actions, preferences, properties) that meant seven serialized worker-to-UI round-trips per keystroke, so the time to fill the table scaled with UI-thread scheduling latency.

This queries all UI-access providers together in one UIJob and looks the results up per provider when assembling the table; non-UI providers still run directly on the worker. Result ordering and behavior are unchanged, only the number of thread hops drops from one-per-provider to one. This should also reduce the intermittent macOS timeout in QuickAccessDialogTest.testCommandEnableContext, where the repeated round-trips occasionally pushed the compute past the test's wait.