### PR TITLE
Attribute Quick Access perfect match to its actual provider

### DIFF
--- a/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/quickaccess/QuickAccessContents.java
+++ b/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/quickaccess/QuickAccessContents.java
@@ -519,12 +519,11 @@ public abstract class QuickAccessContents {
 		QuickAccessProvider perfectMatchProvider = null;
 		if (perfectMatch != null) {
 			for (Entry<QuickAccessProvider, List<QuickAccessElement>> entry : elementsForProviders.entrySet()) {
-				if (perfectMatchProvider != null) {
-					List<QuickAccessElement> filteredElements = new ArrayList<>(entry.getValue());
-					if (filteredElements.removeIf(element -> prevPickIds.contains(element.getId()))) {
-						entry.setValue(filteredElements);
-						perfectMatchProvider = entry.getKey();
-					}
+				List<QuickAccessElement> filteredElements = new ArrayList<>(entry.getValue());
+				if (filteredElements.removeIf(element -> element == perfectMatch)) {
+					entry.setValue(filteredElements);
+					perfectMatchProvider = entry.getKey();
+					break;
 				}
 			}
 		}


### PR DESCRIPTION
The loop that removes the perfect match from its provider before pinning it on top never executed: its body was guarded by a condition (perfectMatchProvider != null) that could never become true, and the removal predicate checked the previous-pick ids instead of the perfect match itself. As a result the pinned perfect match was always attributed to the first provider rather than the one it came from, and it was never removed from its provider's group, so it could appear twice in the show-all-matches view. This change finds the provider whose elements actually contain the perfect match, removes it by identity, and records that provider for the pinned entry.