### PR TITLE
Stabilize QuickAccessDialogTest UI-responsiveness check

### DIFF
--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/quickaccess/QuickAccessDialogTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/quickaccess/QuickAccessDialogTest.java
@@ -216,18 +216,32 @@ public class QuickAccessDialogTest {
 		QuickAccessDialog secondDialog = new TestQuickAccessDialog(activeWorkbenchWindow, null);
 		secondDialog.open();
 		assertTrue(System.currentTimeMillis() - duration < TestLongRunningQuickAccessComputer.DELAY);
-		AtomicLong tick = new AtomicLong(System.currentTimeMillis());
+		// Probe UI responsiveness with a self-rescheduling timer: it keeps firing
+		// while the UI thread can dispatch, so only a real freeze yields a large gap.
+		// The waitForCondition tick cannot tell a freeze from an idle Display.sleep().
+		Display display = secondDialog.getShell().getDisplay();
+		AtomicLong lastTick = new AtomicLong(System.currentTimeMillis());
 		AtomicLong maxBlockedUIThread = new AtomicLong();
-		assertTrue(DisplayHelper.waitForCondition(
-				secondDialog.getShell().getDisplay(), TestLongRunningQuickAccessComputer.DELAY + TIMEOUT, () -> {
-							long currentTick = System.currentTimeMillis();
-							long previousTick = tick.getAndSet(currentTick);
-							long currentDelayInUIThread = currentTick - previousTick;
-							maxBlockedUIThread.set(Math.max(maxBlockedUIThread.get(), currentDelayInUIThread));
-							return dialogContains(secondDialog,
-									TestLongRunningQuickAccessComputer.THE_ELEMENT.getLabel());
-						}), "Missing contributed element as previous pick");
-		assertTrue(maxBlockedUIThread.get() < TestLongRunningQuickAccessComputer.DELAY);
+		boolean[] monitoring = { true };
+		Runnable[] responsivenessProbe = new Runnable[1];
+		responsivenessProbe[0] = () -> {
+			long now = System.currentTimeMillis();
+			maxBlockedUIThread.set(Math.max(maxBlockedUIThread.get(), now - lastTick.getAndSet(now)));
+			if (monitoring[0]) {
+				display.timerExec(50, responsivenessProbe[0]);
+			}
+		};
+		display.timerExec(50, responsivenessProbe[0]);
+		try {
+			assertTrue(DisplayHelper.waitForCondition(display, TestLongRunningQuickAccessComputer.DELAY + TIMEOUT,
+					() -> dialogContains(secondDialog, TestLongRunningQuickAccessComputer.THE_ELEMENT.getLabel())),
+					"Missing contributed element as previous pick");
+		} finally {
+			monitoring[0] = false;
+			display.timerExec(-1, responsivenessProbe[0]);
+		}
+		assertTrue(maxBlockedUIThread.get() < TestLongRunningQuickAccessComputer.DELAY,
+				"UI thread blocked for " + maxBlockedUIThread.get() + "ms while restoring a previous pick");
 	}
 
 	/**


### PR DESCRIPTION
testLongRunningComputerDoesntFreezeUI measured UI blocking through the DisplayHelper.waitForCondition tick, whose loop parks in Display.sleep() while idle. When the second dialog restored a previous pick on the worker thread the UI thread was idle rather than frozen, but that idle interval was counted as a block and intermittently crossed the 3s threshold on macOS, so the test failed without any real UI freeze.

This switches the measurement to a self-rescheduling Display.timerExec probe. The timer keeps firing as long as the UI thread can dispatch events, so idle waiting now registers as short gaps while a genuine freeze still produces a large gap and fails the assertion. Test-only change.