### PR TITLE
Stream Quick Access results per provider instead of one blocking pass

### DIFF
--- a/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/quickaccess/QuickAccessContents.java
+++ b/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/quickaccess/QuickAccessContents.java
@@ -31,6 +31,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -103,6 +104,12 @@ public abstract class QuickAccessContents {
 
 	/** Trailing-edge debounce window collapsing a burst of shell resizes. */
 	private static final int RESIZE_DEBOUNCE_MS = 100;
+
+	/**
+	 * Family of the background job that computes the matching entries. Lets tests
+	 * join on the streaming compute deterministically instead of polling the table.
+	 */
+	public static final Object COMPUTE_JOB_FAMILY = new Object();
 
 	protected Text filterText;
 
@@ -181,15 +188,49 @@ public abstract class QuickAccessContents {
 		lastComputedItemCount = maxNumberOfItemsInTable;
 		// Captured to detect a show-all toggle while this compute runs.
 		final boolean requestShowAllMatches = showAllMatches;
-		AtomicReference<List<QuickAccessEntry>[]> entries = new AtomicReference<>();
-		final Job currentComputeEntriesJob = Job.create(computingMessage, theMonitor -> {
-			entries.set(
-					computeMatchingEntries(filter, perfectMatch, maxNumberOfItemsInTable, theMonitor));
-			if (Policy.DEBUG_QUICK_ACCESS) {
-				trace("Computed entries: " + toIds(entries)); //$NON-NLS-1$
+		// Set once the first results are rendered, so the "computing" feedback never
+		// flashes over content that has already streamed in.
+		boolean[] rendered = { false };
+		AtomicReference<UIJob> feedbackJobRef = new AtomicReference<>();
+		final Job currentComputeEntriesJob = new Job(computingMessage) {
+			@Override
+			protected IStatus run(IProgressMonitor theMonitor) {
+				// Query providers one at a time and re-render as each returns, so a slow
+				// provider neither holds the UI thread for the whole batch nor delays the
+				// results that are already available.
+				computeMatchingEntries(filter, perfectMatch, maxNumberOfItemsInTable, theMonitor, entries -> {
+					if (table.isDisposed()) {
+						return;
+					}
+					display.asyncExec(() -> {
+						if (table.isDisposed() || filterText == null || filterText.isDisposed()) {
+							return;
+						}
+						// Apply only while the results still match the current filter and
+						// show-all state, and this compute has not been superseded.
+						if (theMonitor.isCanceled() || !filter.equals(filterText.getText().toLowerCase())
+								|| requestShowAllMatches != showAllMatches) {
+							return;
+						}
+						if (Policy.DEBUG_QUICK_ACCESS) {
+							trace("Setting quick access contents: " + toIds(entries)); //$NON-NLS-1$
+						}
+						rendered[0] = true;
+						UIJob feedbackJob = feedbackJobRef.get();
+						if (feedbackJob != null) {
+							feedbackJob.cancel();
+						}
+						refreshTable(perfectMatch, entries, filter);
+					});
+				});
+				return theMonitor.isCanceled() ? Status.CANCEL_STATUS : Status.OK_STATUS;
 			}
-			return theMonitor.isCanceled() ? Status.CANCEL_STATUS : Status.OK_STATUS;
-		});
+
+			@Override
+			public boolean belongsTo(Object family) {
+				return family == COMPUTE_JOB_FAMILY;
+			}
+		};
 		currentComputeEntriesJob.setPriority(Job.INTERACTIVE);
 		if (Policy.DEBUG_QUICK_ACCESS) {
 			trace("Will compute proposals with Job: " + currentComputeEntriesJob); //$NON-NLS-1$
@@ -199,41 +240,24 @@ public abstract class QuickAccessContents {
 		UIJob computingFeedbackJob = new UIJob(table.getDisplay(), QuickAccessMessages.QuickAccessContents_computeMatchingEntries_displayFeedback_jobName) {
 			@Override
 			public IStatus runInUIThread(IProgressMonitor monitor) {
-				if (currentComputeEntriesJob.getResult() == null && !monitor.isCanceled() && !table.isDisposed()) {
+				if (!rendered[0] && currentComputeEntriesJob.getResult() == null && !monitor.isCanceled()
+						&& !table.isDisposed()) {
 					showHintText(computingMessage, grayColor);
 					return Status.OK_STATUS;
 				}
 				return Status.CANCEL_STATUS;
 			}
 		};
+		feedbackJobRef.set(computingFeedbackJob);
 		currentComputeEntriesJob.addJobChangeListener(new JobChangeAdapter() {
 			@Override
 			public void done(IJobChangeEvent event) {
 				if (Policy.DEBUG_QUICK_ACCESS) {
 					trace("Compute entries Job result: " + event.getResult() + //$NON-NLS-1$
 							", Job: " + currentComputeEntriesJob + //$NON-NLS-1$
-							", last proposals Job: " + computeProposalsJob + //$NON-NLS-1$
-							", entries: " + toIds(entries)); //$NON-NLS-1$
+							", last proposals Job: " + computeProposalsJob); //$NON-NLS-1$
 				}
 				computingFeedbackJob.cancel();
-				if (event.getResult().isOK() && !table.isDisposed()) {
-					display.asyncExec(() -> {
-						if (table.isDisposed() || filterText == null || filterText.isDisposed()) {
-							return;
-						}
-						// Apply if the results still match the current filter and show-all,
-						// not only when this is the last scheduled job.
-						if (!filter.equals(filterText.getText().toLowerCase())
-								|| requestShowAllMatches != showAllMatches) {
-							return;
-						}
-						if (Policy.DEBUG_QUICK_ACCESS) {
-							trace("Setting quick access contents: " + toIds(entries)); //$NON-NLS-1$
-						}
-						computingFeedbackJob.cancel();
-						refreshTable(perfectMatch, entries.get(), filter);
-					});
-				}
 			}
 		});
 		this.computeProposalsJob = currentComputeEntriesJob;
@@ -399,59 +423,46 @@ public abstract class QuickAccessContents {
 	}
 
 	/**
-	 * Queries every provider that requires UI access in a single UI-thread pass and
-	 * returns their sorted elements keyed by provider. Batching the queries avoids a
-	 * blocking worker-to-UI round-trip per provider on each keystroke.
+	 * Collects one provider's matching elements. Providers that require UI access are
+	 * queried on the display thread one at a time, so the UI thread is released
+	 * between providers instead of being held for the whole batch.
 	 */
-	private Map<QuickAccessProvider, List<QuickAccessElement>> computeUiProviderElements(String filter, String category,
+	private List<QuickAccessElement> collectProviderElements(QuickAccessProvider provider, String filter,
 			IProgressMonitor monitor) {
-		List<QuickAccessProvider> uiProviders = new ArrayList<>();
-		for (QuickAccessProvider provider : providers) {
-			if (!provider.requiresUiAccess()) {
-				continue;
-			}
-			boolean isPreviousPickProvider = provider instanceof PreviousPicksProvider;
-			if (category != null && !category.equalsIgnoreCase(provider.getName()) && !isPreviousPickProvider) {
-				continue;
-			}
-			if (!filter.isEmpty() || isPreviousPickProvider || showAllMatches) {
-				uiProviders.add(provider);
-			}
+		if (!provider.requiresUiAccess()) {
+			return Arrays.asList(provider.getElementsSorted(filter, monitor));
 		}
-		if (uiProviders.isEmpty() || monitor.isCanceled() || table == null || table.isDisposed()) {
-			return Collections.emptyMap();
+		if (monitor.isCanceled() || table == null || table.isDisposed()) {
+			return Collections.emptyList();
 		}
-		Map<QuickAccessProvider, List<QuickAccessElement>> result = new HashMap<>();
+		AtomicReference<List<QuickAccessElement>> result = new AtomicReference<>(Collections.emptyList());
 		table.getDisplay().syncExec(() -> {
-			for (QuickAccessProvider provider : uiProviders) {
-				if (monitor.isCanceled()) {
-					return;
-				}
-				try {
-					result.put(provider, Arrays.asList(provider.getElementsSorted(filter, monitor)));
-				} catch (RuntimeException e) {
-					WorkbenchPlugin.log(e);
-				}
+			if (monitor.isCanceled() || table.isDisposed()) {
+				return;
+			}
+			try {
+				result.set(Arrays.asList(provider.getElementsSorted(filter, monitor)));
+			} catch (RuntimeException e) {
+				WorkbenchPlugin.log(e);
 			}
 		});
-		return result;
+		return result.get();
 	}
 
 	/**
-	 * Returns a list per provider containing matching {@link QuickAccessEntry} that
-	 * should be displayed in the table given a text filter and a perfect match
-	 * entry that should be given priority. The number of items returned is affected
-	 * by {@link #getShowAllMatches()} and the size of the table's composite.
+	 * Queries each provider in turn and streams the matching entries to {@code render}
+	 * after every provider that contributes, so results appear as they are computed
+	 * rather than only once the slowest provider has finished. The number of entries
+	 * is affected by {@link #getShowAllMatches()} and the size of the table's
+	 * composite.
 	 *
 	 * @param filter       the string text filter to apply, possibly empty
 	 * @param perfectMatch a quick access element that should be given priority or
 	 *                     <code>null</code>
-	 *
-	 * @return the array of lists (one per provider) contains the quick access
-	 *         entries that should be added to the table, possibly empty
+	 * @param render       receives one snapshot (a list per provider) per re-render
 	 */
-	private List<QuickAccessEntry>[] computeMatchingEntries(String filter, QuickAccessElement perfectMatch,
-			int maxNumberOfItemsInTable, IProgressMonitor aMonitor) {
+	private void computeMatchingEntries(String filter, QuickAccessElement perfectMatch, int maxNumberOfItemsInTable,
+			IProgressMonitor aMonitor, Consumer<List<QuickAccessEntry>[]> render) {
 		if (aMonitor == null) {
 			aMonitor = new NullProgressMonitor();
 		}
@@ -464,41 +475,58 @@ public abstract class QuickAccessContents {
 		}
 		final String finalFilter = filter;
 
-		// Query providers that must run on the UI thread once, in a single UI pass,
-		// rather than a separate blocking worker-to-UI round-trip per provider.
-		Map<QuickAccessProvider, List<QuickAccessElement>> uiProviderElements = computeUiProviderElements(finalFilter,
-				category, aMonitor);
-
-		// collect matching elements
+		// Collect elements provider by provider and re-render after each, so results
+		// stream into the table.
 		LinkedHashMap<QuickAccessProvider, List<QuickAccessElement>> elementsForProviders = new LinkedHashMap<>(
 				providers.length);
+		boolean anyRendered = false;
 		for (QuickAccessProvider provider : providers) {
 			if (aMonitor.isCanceled()) {
-				break;
+				return;
 			}
 			boolean isPreviousPickProvider = provider instanceof PreviousPicksProvider;
 			// skip if filter contains a category, and current provider isn't this category
 			if (category != null && !category.equalsIgnoreCase(provider.getName()) && !isPreviousPickProvider) {
 				continue;
 			}
-			if (!filter.isEmpty() || isPreviousPickProvider || showAllMatches) {
-				List<QuickAccessElement> sortedElements;
-				if (provider.requiresUiAccess()) {
-					sortedElements = uiProviderElements.get(provider);
-				} else {
-					sortedElements = Arrays.asList(provider.getElementsSorted(filter, aMonitor));
-				}
-				if (sortedElements == null) {
-					sortedElements = Collections.emptyList();
-				}
-				if (!(provider instanceof PreviousPicksProvider)) {
-					for (QuickAccessElement element : sortedElements) {
-						elementsToProviders.put(element, provider);
-					}
-				}
-				elementsForProviders.put(provider, new ArrayList<>(sortedElements));
+			if (finalFilter.isEmpty() && !isPreviousPickProvider && !showAllMatches) {
+				continue;
 			}
+			List<QuickAccessElement> sortedElements = collectProviderElements(provider, finalFilter, aMonitor);
+			if (sortedElements == null) {
+				sortedElements = Collections.emptyList();
+			}
+			if (!isPreviousPickProvider) {
+				for (QuickAccessElement element : sortedElements) {
+					elementsToProviders.put(element, provider);
+				}
+			}
+			elementsForProviders.put(provider, new ArrayList<>(sortedElements));
+			if (sortedElements.isEmpty()) {
+				continue;
+			}
+			render.accept(assembleEntries(elementsForProviders, finalFilter, perfectMatch, maxNumberOfItemsInTable,
+					aMonitor));
+			anyRendered = true;
 		}
+		// Nothing matched (or only a perfect match exists): render once so the table
+		// reflects the final result rather than stale content.
+		if (!anyRendered && !aMonitor.isCanceled()) {
+			render.accept(assembleEntries(elementsForProviders, finalFilter, perfectMatch, maxNumberOfItemsInTable,
+					aMonitor));
+		}
+	}
+
+	/**
+	 * Builds the table snapshot (one list per provider, perfect match first) from the
+	 * elements gathered so far. Pure computation, safe to call repeatedly as more
+	 * providers report.
+	 */
+	private List<QuickAccessEntry>[] assembleEntries(
+			LinkedHashMap<QuickAccessProvider, List<QuickAccessElement>> collected, String finalFilter,
+			QuickAccessElement perfectMatch, int maxNumberOfItemsInTable, IProgressMonitor aMonitor) {
+		LinkedHashMap<QuickAccessProvider, List<QuickAccessElement>> elementsForProviders = new LinkedHashMap<>(
+				collected);
 
 		// Sort out the Previous Pick
 		List<String> prevPickIds = new ArrayList<>();
@@ -967,8 +995,8 @@ public abstract class QuickAccessContents {
 		return table;
 	}
 
-	private static List<String> toIds(AtomicReference<List<QuickAccessEntry>[]> entries) {
-		return Stream.of(entries.get()).flatMap(List::stream).map(e -> e.element.getId()).toList();
+	private static List<String> toIds(List<QuickAccessEntry>[] entries) {
+		return Stream.of(entries).filter(Objects::nonNull).flatMap(List::stream).map(e -> e.element.getId()).toList();
 	}
 
 	private static void trace(String message) {

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/quickaccess/QuickAccessDialogTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/quickaccess/QuickAccessDialogTest.java
@@ -32,6 +32,7 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Predicate;
 
 import org.eclipse.core.commands.Command;
+import org.eclipse.core.runtime.jobs.Job;
 import org.eclipse.jface.dialogs.DialogSettings;
 import org.eclipse.jface.dialogs.IDialogSettings;
 import org.eclipse.swt.SWT;
@@ -46,6 +47,7 @@ import org.eclipse.ui.commands.ICommandService;
 import org.eclipse.ui.handlers.IHandlerService;
 import org.eclipse.ui.ide.IDE;
 import org.eclipse.ui.internal.misc.Policy;
+import org.eclipse.ui.internal.quickaccess.QuickAccessContents;
 import org.eclipse.ui.internal.quickaccess.QuickAccessDialog;
 import org.eclipse.ui.internal.quickaccess.QuickAccessMessages;
 import org.eclipse.ui.tests.harness.util.CloseTestWindowsExtension;
@@ -85,6 +87,9 @@ public class QuickAccessDialogTest {
 	}
 
 	private static final int TIMEOUT = 5000;
+	// Generous safety bound for joining the streaming compute job; only consumed if
+	// that job genuinely hangs, never on a healthy run.
+	private static final int COMPUTE_TIMEOUT = 30000;
 	// Generous bound for the one-time cold initialization of the lazy providers.
 	private static final int WARMUP_TIMEOUT = 60000;
 	// The lazy providers initialize once per JVM, so warm them only once.
@@ -165,16 +170,15 @@ public class QuickAccessDialogTest {
 		assertEquals(0, table.getItemCount(), "Quick access table should be empty");
 
 		text.setText("T");
-		processEventsUntil(() -> table.getItemCount() > 1, TIMEOUT);
+		waitForQuickAccessResults(table.getDisplay());
 		int oldCount = table.getItemCount();
 		assertTrue(oldCount > 3, "Not enough quick access items for simple filter");
 		assertTrue(oldCount < MAXIMUM_NUMBER_OF_ELEMENTS, "Too many quick access items for size of table");
 		final String oldFirstItemText = table.getItem(0).getText(1);
 
 		text.setText("B"); // The letter mustn't be part of the previous 1st proposal
-		assertTrue(DisplayHelper.waitForCondition(table.getDisplay(),
-				TIMEOUT,
-				() -> table.getItemCount() > 1 && !table.getItem(0).getText(1).equals(oldFirstItemText)),
+		waitForQuickAccessResults(table.getDisplay());
+		assertTrue(table.getItemCount() > 1 && !table.getItem(0).getText(1).equals(oldFirstItemText),
 				"The quick access items should have changed");
 		int newCount = table.getItemCount();
 		assertTrue(newCount > 3, "Not enough quick access items for simple filter");
@@ -191,10 +195,9 @@ public class QuickAccessDialogTest {
 		assertEquals(0, table.getItemCount(), "Quick access table should be empty");
 
 		text.setText(TestQuickAccessComputer.TEST_QUICK_ACCESS_PROPOSAL_LABEL);
-		assertTrue(DisplayHelper.waitForCondition(dialog.getShell().getDisplay(), TIMEOUT, () ->
-				dialogContains(dialog, TestQuickAccessComputer.TEST_QUICK_ACCESS_PROPOSAL_LABEL)),
-				"Missing contributed element"
-		);
+		waitForQuickAccessResults(dialog.getShell().getDisplay());
+		assertTrue(dialogContains(dialog, TestQuickAccessComputer.TEST_QUICK_ACCESS_PROPOSAL_LABEL),
+				"Missing contributed element");
 	}
 
 	@Test
@@ -260,7 +263,7 @@ public class QuickAccessDialogTest {
 
 		// Set a filter to get some items
 		text.setText("T");
-		processEventsUntil(() -> table.getItemCount() > 1, TIMEOUT);
+		waitForQuickAccessResults(table.getDisplay());
 		final int defaultCount = table.getItemCount();
 		assertTrue(defaultCount > 3, "Not enough quick access items for simple filter");
 		assertTrue(defaultCount < MAXIMUM_NUMBER_OF_ELEMENTS, "Too many quick access items for size of table");
@@ -270,21 +273,21 @@ public class QuickAccessDialogTest {
 				.getService(IHandlerService.class);
 		// Run the handler to turn on show all
 		handlerService.executeCommand("org.eclipse.ui.window.quickAccess", null); //$NON-NLS-1$
-		processEventsUntil(() -> table.getItemCount() > defaultCount, TIMEOUT);
+		waitForQuickAccessResults(table.getDisplay());
 		final int allCount = table.getItemCount();
 		assertTrue(allCount > defaultCount, "Turning on show all should display more items");
 		assertEquals(oldFirstItemText, table.getItem(0).getText(1), "Turning on show all should not change the top item");
 
 		// Run the handler to turn off show all
 		handlerService.executeCommand("org.eclipse.ui.window.quickAccess", null); //$NON-NLS-1$
-		processEventsUntil(() -> table.getItemCount() < allCount, TIMEOUT);
+		waitForQuickAccessResults(table.getDisplay());
 		// Note: The table count may one off from the old count because of shell resizing (scroll bars being added then removed)
 		assertTrue(table.getItemCount() < allCount, "Turning off show all should limit items shown");
 		assertEquals(oldFirstItemText, table.getItem(0).getText(1), "Turning off show all should not change the top item");
 
 		// Run the handler to turn on show all
 		handlerService.executeCommand("org.eclipse.ui.window.quickAccess", null); //$NON-NLS-1$
-		processEventsUntil(() -> table.getItemCount() == allCount, TIMEOUT);
+		waitForQuickAccessResults(table.getDisplay());
 		assertEquals(allCount, table.getItemCount(), "Turning on show all twice shouldn't change the items");
 		assertEquals(oldFirstItemText, table.getItem(0).getText(1), "Turning on show all twice shouldn't change the top item");
 
@@ -295,7 +298,7 @@ public class QuickAccessDialogTest {
 		text = dialog.getQuickAccessContents().getFilterText();
 		Table newTable = dialog.getQuickAccessContents().getTable();
 		text.setText("T");
-		processEventsUntil(() -> newTable.getItemCount() > 1, TIMEOUT);
+		waitForQuickAccessResults(newTable.getDisplay());
 		// Note: The table count may one off from the old count because of shell resizing (scroll bars being added then removed)
 		assertTrue(newTable.getItemCount() < allCount,
 				"Show all should be turned off when the shell is closed and reopened");
@@ -310,9 +313,8 @@ public class QuickAccessDialogTest {
 		Table firstTable = dialog.getQuickAccessContents().getTable();
 		String quickAccessElementText = "Project Explorer";
 		text.setText(quickAccessElementText);
-		assertTrue(DisplayHelper.waitForCondition(firstTable.getDisplay(),
-				TIMEOUT,
-				() -> dialogContains(dialog, quickAccessElementText)), "Missing entry");
+		waitForQuickAccessResults(firstTable.getDisplay());
+		assertTrue(dialogContains(dialog, quickAccessElementText), "Missing entry");
 		firstTable.select(0);
 		activateCurrentElement(dialog);
 		assertNotEquals(0, dialogSettings.getArray("orderedElements").length);
@@ -325,9 +327,8 @@ public class QuickAccessDialogTest {
 		// then try in a new SearchField
 		QuickAccessDialog secondDialog = new TestQuickAccessDialog(activeWorkbenchWindow, null);
 		secondDialog.open();
-		assertTrue(DisplayHelper.waitForCondition(secondDialog.getShell().getDisplay(), TIMEOUT,
-						() -> dialogContains(secondDialog, quickAccessElementText)),
-				"Missing entry in previous pick");
+		waitForQuickAccessResults(secondDialog.getShell().getDisplay());
+		assertTrue(dialogContains(secondDialog, quickAccessElementText), "Missing entry in previous pick");
 	}
 
 	private void activateCurrentElement(QuickAccessDialog dialog) {
@@ -353,17 +354,17 @@ public class QuickAccessDialogTest {
 				"Unexpected dialog info: " + dialog.infoText);
 		text.setText(TestQuickAccessComputer.TEST_QUICK_ACCESS_PROPOSAL_LABEL);
 		final Table firstTable = dialog.getQuickAccessContents().getTable();
-		assertTrue(DisplayHelper.waitForCondition(text.getDisplay(), TIMEOUT,
-				() -> dialogContains(dialog, TestQuickAccessComputer.TEST_QUICK_ACCESS_PROPOSAL_LABEL)),
-				"Unexpected dialog contents: " + getAllEntries(dialog.getQuickAccessContents().getTable()));
+		waitForQuickAccessResults(text.getDisplay());
+		assertTrue(dialogContains(dialog, TestQuickAccessComputer.TEST_QUICK_ACCESS_PROPOSAL_LABEL),
+				"Unexpected dialog contents: " + getAllEntries(firstTable));
 		firstTable.select(0);
 		activateCurrentElement(dialog);
 		// then try in a new SearchField
 		QuickAccessDialog secondDialog = new TestQuickAccessDialog(activeWorkbenchWindow, null);
 		secondDialog.open();
-		assertTrue(DisplayHelper.waitForCondition(secondDialog.getShell().getDisplay(), TIMEOUT,
-						() -> getAllEntries(secondDialog.getQuickAccessContents().getTable()).stream()
-								.anyMatch(TestQuickAccessComputer::isContributedItem)),
+		waitForQuickAccessResults(secondDialog.getShell().getDisplay());
+		assertTrue(getAllEntries(secondDialog.getQuickAccessContents().getTable()).stream()
+						.anyMatch(TestQuickAccessComputer::isContributedItem),
 				"Contributed item not found in previous choices");
 	}
 
@@ -374,20 +375,19 @@ public class QuickAccessDialogTest {
 		Text text = dialog.getQuickAccessContents().getFilterText();
 		text.setText(TestIncrementalQuickAccessComputer.ENABLEMENT_QUERY);
 		final Table firstTable = dialog.getQuickAccessContents().getTable();
-		assertTrue(DisplayHelper.waitForCondition(text.getDisplay(), //
-				TIMEOUT, //
-				() -> firstTable.getItemCount() > 0
-						&& TestIncrementalQuickAccessComputer.isContributedItem(getAllEntries(firstTable).get(0))
-		));
+		waitForQuickAccessResults(text.getDisplay());
+		assertTrue(firstTable.getItemCount() > 0
+				&& TestIncrementalQuickAccessComputer.isContributedItem(getAllEntries(firstTable).get(0)),
+				"Contributed item not first in results");
 		firstTable.select(0);
 		activateCurrentElement(dialog);
 		// then try in a new SearchField
 		dialog = new TestQuickAccessDialog(activeWorkbenchWindow, null);
 		dialog.open();
 		final Table secondTable = dialog.getQuickAccessContents().getTable();
-		assertTrue(DisplayHelper.waitForCondition(secondTable.getDisplay(), TIMEOUT, //
-						() -> getAllEntries(secondTable).stream()
-								.anyMatch(TestIncrementalQuickAccessComputer::isContributedItem)),
+		waitForQuickAccessResults(secondTable.getDisplay());
+		assertTrue(getAllEntries(secondTable).stream()
+						.anyMatch(TestIncrementalQuickAccessComputer::isContributedItem),
 				"Contributed item not found in previous choices");
 	}
 
@@ -398,8 +398,8 @@ public class QuickAccessDialogTest {
 		Text text = dialog.getQuickAccessContents().getFilterText();
 		Table table = dialog.getQuickAccessContents().getTable();
 		text.setText("P");
-		assertTrue(DisplayHelper.waitForCondition(table.getDisplay(), TIMEOUT, () -> table.getItemCount() > 3),
-				"Not enough quick access items for simple filter");
+		waitForQuickAccessResults(table.getDisplay());
+		assertTrue(table.getItemCount() > 3, "Not enough quick access items for simple filter");
 		assertTrue(table.getItem(0).getText(1).toLowerCase().startsWith("p"), "Non-prefix match first");
 	}
 
@@ -419,8 +419,8 @@ public class QuickAccessDialogTest {
 		Text text = dialog.getQuickAccessContents().getFilterText();
 		Table table = dialog.getQuickAccessContents().getTable();
 		text.setText("Toggle Split");
-		assertTrue(DisplayHelper.waitForCondition(table.getDisplay(), TIMEOUT, () -> table.getItemCount() > 1),
-				"Not enough quick access items for simple filter");
+		waitForQuickAccessResults(table.getDisplay());
+		assertTrue(table.getItemCount() > 1, "Not enough quick access items for simple filter");
 		assertTrue(table.getItem(0).getText(1).toLowerCase().startsWith("toggle split"), "Non-prefix match first");
 	}
 
@@ -437,6 +437,21 @@ public class QuickAccessDialogTest {
 			}
 			return res.toString();
 		}).toList();
+	}
+
+	/**
+	 * Waits for the streaming Quick Access computation to finish and renders its
+	 * results, so assertions run against settled contents instead of racing a fixed
+	 * timeout. The compute job applies its results through {@code asyncExec}, so once
+	 * the job family is idle the pending render is drained before returning.
+	 */
+	private static void waitForQuickAccessResults(Display display) {
+		boolean computed = DisplayHelper.waitForCondition(display, COMPUTE_TIMEOUT,
+				() -> Job.getJobManager().find(QuickAccessContents.COMPUTE_JOB_FAMILY).length == 0);
+		assertTrue(computed, "Quick Access computation did not finish");
+		while (display.readAndDispatch()) {
+			// drain the asyncExec that renders the streamed results
+		}
 	}
 
 	private boolean dialogContains(QuickAccessDialog dialog, String substring) {


### PR DESCRIPTION
Quick Access computed every UI provider in a single Display.syncExec and rendered only once that whole batch and the ranking had finished, so a slow provider (or a previous-pick restore resolved through a slow provider) held the UI thread and delayed results that were already available. This change queries providers one at a time (UI providers each in their own syncExec, non-UI on the worker) and re-renders the table as each provider reports, so the UI thread is released between providers and the first results appear without waiting for the slowest. The assembled snapshot is unchanged: ranking, grouping, previous-pick dedup and the perfect match all behave as before, with the final render identical to the previous single pass.