### PR TITLE
Fix configuration of the unsaved tab dirty indicator

### DIFF
--- a/bundles/org.eclipse.e4.ui.workbench.renderers.swt/src/org/eclipse/e4/ui/workbench/renderers/swt/StackRenderer.java
+++ b/bundles/org.eclipse.e4.ui.workbench.renderers.swt/src/org/eclipse/e4/ui/workbench/renderers/swt/StackRenderer.java
@@ -34,6 +34,7 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Stream;
+import org.eclipse.core.runtime.Platform;
 import org.eclipse.core.runtime.preferences.IEclipsePreferences;
 import org.eclipse.e4.core.contexts.IEclipseContext;
 import org.eclipse.e4.core.di.annotations.Optional;
@@ -941,8 +942,10 @@ public class StackRenderer extends LazyStackRenderer {
 	}
 
 	private boolean getShowDirtyIndicatorForTabsFromPreferences() {
-		return preferences.getBoolean(CTabRendering.SHOW_DIRTY_INDICATOR_ON_TABS,
-				CTabRendering.SHOW_DIRTY_INDICATOR_ON_TABS_DEFAULT);
+		// Use the preferences service so product customization (default scope) is honored
+		return Platform.getPreferencesService().getBoolean(
+				CTabRendering.PREF_QUALIFIER_ECLIPSE_E4_UI_WORKBENCH_RENDERERS_SWT,
+				CTabRendering.SHOW_DIRTY_INDICATOR_ON_TABS, CTabRendering.SHOW_DIRTY_INDICATOR_ON_TABS_DEFAULT, null);
 	}
 
 	private void updateMRUValue(CTabFolder tabFolder) {

--- a/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/dialogs/ViewsPreferencePage.java
+++ b/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/dialogs/ViewsPreferencePage.java
@@ -203,8 +203,6 @@ public class ViewsPreferencePage extends PreferencePage implements IWorkbenchPre
 		createHideIconsForViewTabs(comp);
 		createDependency(showFullTextForViewTabs, hideIconsForViewTabs);
 
-		createShowDirtyIndicatorForTabs(comp);
-
 		createRescaleAtRuntimeCheckButton(comp);
 
 		if (currentTheme != null) {
@@ -259,6 +257,7 @@ public class ViewsPreferencePage extends PreferencePage implements IWorkbenchPre
 	private void createThemeIndependentComposits(Composite comp) {
 		createColoredLabelsPref(comp);
 		createEnableMruPref(comp);
+		createShowDirtyIndicatorForTabs(comp);
 	}
 
 	protected void createShowFullTextForViewTabs(Composite composite) {
@@ -471,8 +470,10 @@ public class ViewsPreferencePage extends PreferencePage implements IWorkbenchPre
 			}
 			prefs.putBoolean(CTabRendering.HIDE_ICONS_FOR_VIEW_TABS, hideIconsForViewTabs.getSelection());
 			prefs.putBoolean(CTabRendering.SHOW_FULL_TEXT_FOR_VIEW_TABS, showFullTextForViewTabs.getSelection());
-			prefs.putBoolean(CTabRendering.SHOW_DIRTY_INDICATOR_ON_TABS, showDirtyIndicatorForTabs.getSelection());
 		}
+
+		// Dirty indicator is independent of CSS theming, so always store it
+		prefs.putBoolean(CTabRendering.SHOW_DIRTY_INDICATOR_ON_TABS, showDirtyIndicatorForTabs.getSelection());
 
 		IPreferenceStore apiStore = PrefUtil.getAPIPreferenceStore();
 		apiStore.setValue(IWorkbenchPreferenceConstants.USE_COLORED_LABELS, useColoredLabels.getSelection());
@@ -624,9 +625,9 @@ public class ViewsPreferencePage extends PreferencePage implements IWorkbenchPre
 			showFullTextForViewTabs.setSelection(defaultPrefs.getBoolean(CTabRendering.SHOW_FULL_TEXT_FOR_VIEW_TABS,
 					CTabRendering.SHOW_FULL_TEXT_FOR_VIEW_TABS_DEFAULT));
 			showFullTextForViewTabs.notifyListeners(SWT.Selection, null);
-			showDirtyIndicatorForTabs.setSelection(defaultPrefs.getBoolean(CTabRendering.SHOW_DIRTY_INDICATOR_ON_TABS,
-					CTabRendering.SHOW_DIRTY_INDICATOR_ON_TABS_DEFAULT));
 		}
+		showDirtyIndicatorForTabs.setSelection(defaultPrefs.getBoolean(CTabRendering.SHOW_DIRTY_INDICATOR_ON_TABS,
+				CTabRendering.SHOW_DIRTY_INDICATOR_ON_TABS_DEFAULT));
 		IPreferenceStore apiStore = PrefUtil.getAPIPreferenceStore();
 		useColoredLabels.setSelection(apiStore.getDefaultBoolean(IWorkbenchPreferenceConstants.USE_COLORED_LABELS));
 


### PR DESCRIPTION
The dirty indicator preference was only shown and stored while CSS theming was active, so it could not be turned off when Eclipse was started with `-cssTheme none` or in high-contrast mode. It is now created, stored and reset next to the "Show most recently used tabs" option and is therefore always available.

The renderer also read the value from the instance scope only, which ignored a default contributed through product customization (`SHOW_DIRTY_INDICATOR_ON_TABS` in `plugin_customization.ini`). It now reads via the preferences service so the default scope is honored, allowing products to restore the old asterisk behavior.

Fixes https://github.com/eclipse-platform/eclipse.platform.ui/issues/4130