### PR TITLE
Fix Ctrl+F7 view switcher showing same name for multi-instance views

### DIFF
--- a/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/ViewReference.java
+++ b/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/ViewReference.java
@@ -69,11 +69,6 @@ public class ViewReference extends WorkbenchPartReference implements IViewRefere
 	}
 
 	@Override
-	public String getPartName() {
-		return descriptor == null ? "" : descriptor.getLabel(); //$NON-NLS-1$
-	}
-
-	@Override
 	public String getSecondaryId() {
 		MPart part = getModel();
 


### PR DESCRIPTION
**Change made:** Removed the `getPartName()` override from `ViewReference.java`.

Views like Terminal call `setPartName("Terminal " + secondaryId)` which triggers `CompatibilityPart` to update the E4 model via `part.setLabel(computeLabel())`. The parent class `WorkbenchPartReference.getPartName()` returns `part.getLocalizedLabel()` which reflects this dynamic name (e.g. Terminal 1, Terminal 2 instead of Terminal Terminal).

The removed override was bypassing this by always returning the static plugin.xml descriptor label. Generic fix: Works for all multi-instance views (Terminal, Console, Search).

Fixes https://github.com/eclipse-platform/eclipse.platform/issues/2774