### PR TITLE
Inherit host control colors in content proposal popups

### DIFF
--- a/bundles/org.eclipse.jface/src/org/eclipse/jface/fieldassist/ContentProposalAdapter.java
+++ b/bundles/org.eclipse.jface/src/org/eclipse/jface/fieldassist/ContentProposalAdapter.java
@@ -594,14 +594,18 @@ public class ContentProposalAdapter {
 
 		@Override
 		protected Color getForeground() {
-			return JFaceResources.getColorRegistry().get(
+			Color foreground = JFaceResources.getColorRegistry().get(
 					JFacePreferences.CONTENT_ASSIST_FOREGROUND_COLOR);
+			// Fall back to the host control's color so the popup matches its
+			// surroundings when no content assist color is configured.
+			return foreground != null ? foreground : control.getForeground();
 		}
 
 		@Override
 		protected Color getBackground() {
-			return JFaceResources.getColorRegistry().get(
+			Color background = JFaceResources.getColorRegistry().get(
 					JFacePreferences.CONTENT_ASSIST_BACKGROUND_COLOR);
+			return background != null ? background : control.getBackground();
 		}
 
 		/*


### PR DESCRIPTION
Content proposal popups now fall back to the host control's colors when
the JFace `CONTENT_ASSIST_*` preferences are unset, instead of defaulting
to white.

RCP applications that style their controls via SWT API get matching
popups for free, and the white completion popup in the dark workspace
selection dialog is fixed.
