### PR TITLE
Remove the leftover SAC references after the value-record migration

### DIFF
--- a/bundles/org.eclipse.e4.ui.css.core/src/org/eclipse/e4/ui/css/core/impl/dom/CssValues.java
+++ b/bundles/org.eclipse.e4.ui.css.core/src/org/eclipse/e4/ui/css/core/impl/dom/CssValues.java
@@ -26,8 +26,7 @@ import org.w3c.dom.css.Rect;
 /**
  * The internal CSS value model produced by the parser. A small sealed hierarchy
  * of immutable values that replaces the former {@code Measure} / {@code
- * RGBColorImpl} / {@code CSSValueListImpl} wrappers and removes the last SAC
- * dependency ({@code LexicalUnit}).
+ * RGBColorImpl} / {@code CSSValueListImpl} wrappers.
  *
  * <p>
  * Consumers pattern-match on the record variants ({@link CssNumber},
@@ -258,7 +257,7 @@ public final class CssValues {
 
 	/**
 	 * A separator (currently only {@code ,}) carried inside a value list, kept
-	 * for parity with the former SAC behaviour where the comma was a list item.
+	 * for parity with the historical behaviour where the comma was a list item.
 	 */
 	public record CssOperator(String text) implements CssPrimitive {
 		@Override

--- a/bundles/org.eclipse.e4.ui.css.core/src/org/eclipse/e4/ui/css/core/impl/engine/CSSEngineImpl.java
+++ b/bundles/org.eclipse.e4.ui.css.core/src/org/eclipse/e4/ui/css/core/impl/engine/CSSEngineImpl.java
@@ -477,9 +477,9 @@ public abstract class CSSEngineImpl implements CSSEngine {
 	 * Returns {@code true} if {@code selector} carries a pseudo-class or
 	 * attribute selector (anywhere in a compound or descendant combinator)
 	 * whose target value equals {@code pseudoInstance}. Mirrors the legacy
-	 * SAC walker, which handled both {@code :selected} (a pseudo-class) and
-	 * {@code Shell[active='true']} (an attribute) through SAC's shared
-	 * {@code AttributeCondition} interface.
+	 * walker, which handled both {@code :selected} (a pseudo-class) and
+	 * {@code Shell[active='true']} (an attribute) through a shared
+	 * condition interface.
 	 */
 	private static boolean matchesPseudoInstanceAttribute(Selectors.Selector selector, String pseudoInstance) {
 		if (selector instanceof Selectors.PseudoClass pc) {

--- a/bundles/org.eclipse.e4.ui.css.core/src/org/eclipse/e4/ui/css/core/impl/engine/selector/SelectorMatcher.java
+++ b/bundles/org.eclipse.e4.ui.css.core/src/org/eclipse/e4/ui/css/core/impl/engine/selector/SelectorMatcher.java
@@ -36,14 +36,14 @@ import org.w3c.dom.Node;
  *
  * <p>
  * Every method is static; the matcher carries no state. Callers pass the
- * element being tested plus an optional pseudo-element string (the same
- * argument the SAC engine carried) so that pseudo-class matching can defer
- * to the existing {@link CSSStylableElement#isPseudoInstanceOf} contract.
+ * element being tested plus an optional pseudo-element string so that
+ * pseudo-class matching can defer to the existing
+ * {@link CSSStylableElement#isPseudoInstanceOf} contract.
  * </p>
  *
  * <p>
- * Tag-name comparison is case sensitive, matching the existing SAC matcher
- * (Phase 1 test {@code testTagNameCaseSensitivity} in {@code CSSEngineTest}
+ * Tag-name comparison is case sensitive, preserving the historical matcher
+ * behaviour (Phase 1 test {@code testTagNameCaseSensitivity} in {@code CSSEngineTest}
  * locks this in). Pseudo-class semantics also follow the existing engine:
  * the static-pseudo-instance carve-out from
  * {@code CSSPseudoClassConditionImpl} is preserved so cascade behaviour

--- a/bundles/org.eclipse.e4.ui.css.core/src/org/eclipse/e4/ui/css/core/impl/engine/selector/Selectors.java
+++ b/bundles/org.eclipse.e4.ui.css.core/src/org/eclipse/e4/ui/css/core/impl/engine/selector/Selectors.java
@@ -19,14 +19,10 @@ import java.util.List;
  * Internal CSS selector AST.
  *
  * <p>
- * The engine historically exposed W3C SAC selectors
- * ({@code org.w3c.css.sac.Selector} and friends) and matched against them
- * through a hierarchy of vendored Batik wrapper classes under
- * {@code impl/sac/*}. This package replaces both with a small set of records
- * that the engine owns end to end. The W3C SAC types stay only as long as
- * the parser still emits them; a translator turns the SAC selector tree
- * produced by the Batik SAC parser into one of these records before it
- * reaches the engine matcher.
+ * This package is the engine's own selector model: a small set of records
+ * the parser builds directly and the matcher consumes end to end. It
+ * replaced an earlier layer of vendored selector wrapper classes that the
+ * engine no longer depends on.
  * </p>
  *
  * <p>
@@ -312,12 +308,12 @@ public final class Selectors {
 			return alternatives;
 		}
 
-		/** Number of alternatives in the list. SAC-style accessor for callers iterating the list. */
+		/** Number of alternatives in the list. Indexed accessor for callers iterating the list. */
 		public int getLength() {
 			return alternatives.size();
 		}
 
-		/** {@code i}-th alternative. SAC-style accessor for callers iterating the list. */
+		/** {@code i}-th alternative. Indexed accessor for callers iterating the list. */
 		public Selector item(int i) {
 			return alternatives.get(i);
 		}

--- a/bundles/org.eclipse.e4.ui.css.core/src/org/eclipse/e4/ui/css/core/impl/parser/CssParseException.java
+++ b/bundles/org.eclipse.e4.ui.css.core/src/org/eclipse/e4/ui/css/core/impl/parser/CssParseException.java
@@ -15,8 +15,7 @@ package org.eclipse.e4.ui.css.core.impl.parser;
 
 /**
  * Thrown by the hand-written CSS parser when the input cannot be parsed.
- * Replaces {@code org.w3c.css.sac.CSSException} for the internal parser, which
- * like its SAC predecessor is unchecked.
+ * Unchecked so it can surface from the parser without checked-exception plumbing.
  */
 public class CssParseException extends RuntimeException {
 

--- a/bundles/org.eclipse.e4.ui.css.core/src/org/eclipse/e4/ui/css/core/impl/parser/CssParser.java
+++ b/bundles/org.eclipse.e4.ui.css.core/src/org/eclipse/e4/ui/css/core/impl/parser/CssParser.java
@@ -413,7 +413,7 @@ public final class CssParser {
 			case COLON:
 				advance();
 				if (peek().kind == Kind.COLON) {
-					advance(); // pseudo-element ::, modelled as a pseudo-class like the SAC path
+					advance(); // pseudo-element ::, modelled as a pseudo-class
 				}
 				conditions.add(new PseudoClass(expect(Kind.IDENT).text));
 				break;
@@ -430,8 +430,8 @@ public final class CssParser {
 		for (int i = conditions.size() - 2; i >= 0; i--) {
 			conditionTree = new And(conditions.get(i), conditionTree);
 		}
-		// A universal element before conditions is dropped, matching the SAC
-		// translator: '.foo' and '*[a]' carry no element-type contribution.
+		// A universal element before conditions is dropped: '.foo' and '*[a]'
+		// carry no element-type contribution.
 		return element instanceof ElementType ? new And(element, conditionTree) : conditionTree;
 	}
 

--- a/tests/org.eclipse.e4.ui.tests.css.core/src/org/eclipse/e4/ui/css/core/impl/engine/selector/SelectorMatcherTest.java
+++ b/tests/org.eclipse.e4.ui.tests.css.core/src/org/eclipse/e4/ui/css/core/impl/engine/selector/SelectorMatcherTest.java
@@ -38,9 +38,7 @@ import org.junit.jupiter.api.Test;
 
 /**
  * Unit tests for {@link SelectorMatcher}. The cases mirror those in the
- * Phase 1 {@code CSSEngineTest}, but go through the new internal selector
- * AST instead of SAC. When Phase 3 Step 1 wires the engine to use this
- * matcher, the SAC-based duplicate tests can be retired.
+ * Phase 1 {@code CSSEngineTest}, but go through the internal selector AST.
  */
 class SelectorMatcherTest {
 

--- a/tests/org.eclipse.e4.ui.tests.css.core/src/org/eclipse/e4/ui/tests/css/core/CSSEngineTest.java
+++ b/tests/org.eclipse.e4.ui.tests.css.core/src/org/eclipse/e4/ui/tests/css/core/CSSEngineTest.java
@@ -261,9 +261,9 @@ class CSSEngineTest {
 
 	@Test
 	void testTagNameCaseSensitivity() throws Exception {
-		// Locks in current case-sensitive matching of the SAC engine. If the
-		// parser swap moves to case-insensitive (closer to HTML semantics), this
-		// test must be updated together with that change.
+		// Locks in current case-sensitive matching. If the matching ever moves
+		// to case-insensitive (closer to HTML semantics), this test must be
+		// updated together with that change.
 		TestCSSEngine engine = new TestCSSEngine();
 		Selector capital = parse(engine, "Button");
 		Selector lower = parse(engine, "button");

--- a/tests/org.eclipse.e4.ui.tests.css.core/src/org/eclipse/e4/ui/tests/css/core/parser/CssParserTest.java
+++ b/tests/org.eclipse.e4.ui.tests.css.core/src/org/eclipse/e4/ui/tests/css/core/parser/CssParserTest.java
@@ -91,8 +91,7 @@ public class CssParserTest {
 
 	@Test
 	void testUniversalElementDroppedBeforeConditions() {
-		// '.foo' and '*[a]' carry no element-type contribution, matching the
-		// previous SAC translator.
+		// '.foo' and '*[a]' carry no element-type contribution.
 		assertInstanceOf(Selectors.ClassSelector.class, firstSelector(".foo"));
 		assertInstanceOf(Selectors.AttributeSelector.class, firstSelector("*[a]"));
 	}

--- a/tests/org.eclipse.e4.ui.tests.css.swt/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.e4.ui.tests.css.swt/META-INF/MANIFEST.MF
@@ -16,8 +16,7 @@ Import-Package: org.eclipse.core.runtime;version="3.5.0",
  org.junit.jupiter.api.function;version="[5.14.0,6.0.0)",
  org.junit.platform.suite.api;version="[1.14.0,2.0.0)",
  org.osgi.framework;version="[1.7.0,2.0.0)",
- org.osgi.service.event;version="[1.3.0,2.0.0)",
- org.w3c.css.sac;version="1.3.0"
+ org.osgi.service.event;version="[1.3.0,2.0.0)"
 Eclipse-BundleShape: dir
 Automatic-Module-Name: org.eclipse.e4.ui.tests.css.swt
 Bundle-Vendor: %Bundle-Vendor


### PR DESCRIPTION
Follow-up to #4139, which deleted the `tkuiTestsToRefactor` legacy tests but left two SAC traces behind: the `Import-Package: org.w3c.css.sac` in the `org.eclipse.e4.ui.tests.css.swt` manifest, and a handful of `SAC`/Batik mentions in CSS-core and test comments.

Nothing on the build path uses SAC anymore, so this drops the import and rewrites the comments (keeping the behavioral rationale, just without the SAC name). With this in, the repo has no remaining reference to `org.w3c.css.sac`, so the library can leave the target platform once no bundle outside this repo needs it.