### PR TITLE
Cancel Quick Access compute on dispose to stop orphaned jobs

### DIFF
--- a/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/quickaccess/QuickAccessContents.java
+++ b/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/quickaccess/QuickAccessContents.java
@@ -644,6 +644,12 @@ public abstract class QuickAccessContents {
 	}
 
 	private void doDispose() {
+		// Stop any in-flight compute so a closed dialog neither keeps querying providers
+		// nor leaves a job lingering in COMPUTE_JOB_FAMILY.
+		if (computeProposalsJob != null) {
+			computeProposalsJob.cancel();
+			computeProposalsJob = null;
+		}
 		if (textLayout != null && !textLayout.isDisposed()) {
 			textLayout.dispose();
 		}

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/quickaccess/QuickAccessDialogTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/quickaccess/QuickAccessDialogTest.java
@@ -124,7 +124,11 @@ public class QuickAccessDialogTest {
 			Text warmupText = warmupDialog.getQuickAccessContents().getFilterText();
 			Table warmupTable = warmupDialog.getQuickAccessContents().getTable();
 			warmupText.setText("t");
-			DisplayHelper.waitForCondition(warmupText.getDisplay(), WARMUP_TIMEOUT, () -> warmupTable.getItemCount() > 0);
+			// Wait for results AND for the compute job to drain, so the lazy providers'
+			// slow first query completes here rather than leaking into a test's timed wait.
+			DisplayHelper.waitForCondition(warmupText.getDisplay(), WARMUP_TIMEOUT,
+					() -> warmupTable.getItemCount() > 0
+							&& Job.getJobManager().find(QuickAccessContents.COMPUTE_JOB_FAMILY).length == 0);
 			providersWarmedUp = true;
 		}
 		warmupDialog.close();


### PR DESCRIPTION
`doDispose()` never cancelled the in-flight compute job, so a closed Quick Access dialog kept querying providers and lingered in the compute job family. The test warmup made this visible: it sets `"t"`, waits only for the first results, then closes the dialog while the lazy providers are still cold-initializing on the worker, leaving an orphaned job in the family. On a loaded macOS runner that orphan could outlive a test's 30 s wait for the family to drain, which is the `testPreviousChoicesAvailableForExtension` flake (#4009).

This cancels the compute job in `doDispose` so a closed dialog stops computing and leaves the family promptly, and makes the warmup wait for the compute to drain so the providers' slow first query finishes during setup instead of leaking into a test's timed wait. All ten `QuickAccessDialogTest` cases pass locally.