### PR TITLE
Keep OS high contrast colors instead of forcing the default theme

### DIFF
--- a/bundles/org.eclipse.e4.ui.css.swt.theme/src/org/eclipse/e4/ui/css/swt/internal/theme/ThemeEngine.java
+++ b/bundles/org.eclipse.e4.ui.css.swt.theme/src/org/eclipse/e4/ui/css/swt/internal/theme/ThemeEngine.java
@@ -430,7 +430,12 @@ public class ThemeEngine implements IThemeEngine {
 				return;
 			}
 		}
-		// Theme not found (e.g. it was uninstalled); fall back to default
+		// In OS high-contrast mode keep the native OS colors instead of forcing a theme
+		if (display != null && display.getHighContrast()) {
+			ILog.of(ThemeEngine.class)
+					.warn("Theme '" + themeId + "' not found; using OS high contrast colors."); //$NON-NLS-1$ //$NON-NLS-2$
+			return;
+		}
 		ILog.of(ThemeEngine.class)
 				.warn("Theme '" + themeId + "' not found; falling back to default theme."); //$NON-NLS-1$ //$NON-NLS-2$
 		if (!E4_DEFAULT_THEME_ID.equals(themeId)) {

--- a/bundles/org.eclipse.e4.ui.workbench.swt/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.e4.ui.workbench.swt/META-INF/MANIFEST.MF
@@ -1,7 +1,7 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-SymbolicName: org.eclipse.e4.ui.workbench.swt;singleton:=true
-Bundle-Version: 0.18.100.qualifier
+Bundle-Version: 0.18.200.qualifier
 Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/bundles/org.eclipse.e4.ui.workbench.swt/src/org/eclipse/e4/ui/internal/workbench/swt/E4Application.java
+++ b/bundles/org.eclipse.e4.ui.workbench.swt/src/org/eclipse/e4/ui/internal/workbench/swt/E4Application.java
@@ -324,8 +324,8 @@ public class E4Application implements IApplication {
 				context.set(E4Application.THEME_ID, DEFAULT_THEME_ID);
 			}
 		} else {
-			// Check if user has overridden the branding/command-line theme
-			String userThemeId = getProductScopedThemeId();
+			// Do not let a product/workspace default override the OS high-contrast theme
+			String userThemeId = highContrastMode ? null : getProductScopedThemeId();
 			if (userThemeId != null) {
 				context.set(E4Application.THEME_ID, userThemeId);
 			} else {


### PR DESCRIPTION
When the OS is in high contrast mode Eclipse requests the high-contrast theme, but that theme was removed in the 2025-09 release. Since #3854 the theme engine then forced the default light theme, and a product or workspace default could override the selection, so the native OS high-contrast colors were lost and the UI became mostly white and unusable. This keeps the OS colors when the requested theme is missing while the OS is in high contrast mode, and no longer lets a product or workspace default override the high-contrast theme. The fallback to the default theme stays unchanged outside high contrast mode.

Fixes #3095