### PR TITLE
Find/replace overlay: fix wrong initialization of search state

### DIFF
--- a/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/overlay/FindReplaceOverlay.java
+++ b/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/overlay/FindReplaceOverlay.java
@@ -71,6 +71,7 @@ import org.eclipse.ui.internal.SearchDecoration;
 import org.eclipse.ui.internal.findandreplace.FindReplaceLogic;
 import org.eclipse.ui.internal.findandreplace.FindReplaceMessages;
 import org.eclipse.ui.internal.findandreplace.HistoryStore;
+import org.eclipse.ui.internal.findandreplace.IFindReplaceLogic;
 import org.eclipse.ui.internal.findandreplace.SearchOptions;
 import org.eclipse.ui.part.MultiPageEditorSite;
 
@@ -113,7 +114,7 @@ public class FindReplaceOverlay {
 	private static final String IDEAL_WIDTH_TEXT = "THIS TEXT HAS A REASONABLE LENGTH FOR SEARCHING"; //$NON-NLS-1$
 	private static final int HISTORY_SIZE = 15;
 
-	private FindReplaceLogic findReplaceLogic;
+	private final IFindReplaceLogic findReplaceLogic;
 	private final IWorkbenchPart targetPart;
 	private boolean replaceBarOpen;
 
@@ -296,7 +297,7 @@ public class FindReplaceOverlay {
 	public FindReplaceOverlay(Shell parent, IWorkbenchPart part, IFindReplaceTarget target) {
 		targetPart = part;
 		targetControl = getTargetControl(parent, part);
-		createFindReplaceLogic(target);
+		findReplaceLogic = createFindReplaceLogic(target);
 		createContainerAndSearchControls(targetControl);
 		containerControl.setVisible(false);
 		PlatformUI.getWorkbench().getHelpSystem().setHelp(containerControl,
@@ -315,17 +316,18 @@ public class FindReplaceOverlay {
 		return targetControl instanceof StyledText;
 	}
 
-	private void createFindReplaceLogic(IFindReplaceTarget target) {
-		findReplaceLogic = new FindReplaceLogic();
+	private IFindReplaceLogic createFindReplaceLogic(IFindReplaceTarget target) {
+		IFindReplaceLogic logic = new FindReplaceLogic();
 		boolean isTargetEditable = false;
 		if (target != null) {
 			isTargetEditable = target.isEditable();
 		}
-		findReplaceLogic.updateTarget(target, isTargetEditable);
-		findReplaceLogic.activate(SearchOptions.INCREMENTAL);
-		findReplaceLogic.activate(SearchOptions.GLOBAL);
-		findReplaceLogic.activate(SearchOptions.WRAP);
-		findReplaceLogic.activate(SearchOptions.FORWARD);
+		logic.updateTarget(target, isTargetEditable);
+		logic.activate(SearchOptions.INCREMENTAL);
+		logic.activate(SearchOptions.GLOBAL);
+		logic.activate(SearchOptions.WRAP);
+		logic.activate(SearchOptions.FORWARD);
+		return logic;
 	}
 
 	public Composite getContainerControl() {
@@ -613,7 +615,7 @@ public class FindReplaceOverlay {
 					updateIncrementalSearch();
 				})
 				.withShortcuts(KeyboardShortcuts.OPTION_SEARCH_IN_SELECTION).build();
-		searchInSelectionButton.setSelection(findReplaceLogic.isActive(SearchOptions.WHOLE_WORD));
+		searchInSelectionButton.setSelection(!findReplaceLogic.isActive(SearchOptions.GLOBAL));
 	}
 
 	private void createRegexSearchButton() {

--- a/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/internal/findandreplace/overlay/FindReplaceOverlayTest.java
+++ b/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/internal/findandreplace/overlay/FindReplaceOverlayTest.java
@@ -215,4 +215,21 @@ public class FindReplaceOverlayTest extends FindReplaceUITest<OverlayAccess> {
 		assertEquals("foo", dialog.getFindText());
 	}
 
+	@Test
+	public void testSearchInSelectionButtonIsInverseOfGlobalOption() {
+		// The searchInSelection button is the inverse of the GLOBAL option:
+		// it is NOT selected when searching globally, and IS selected when searching in selection.
+		initializeTextViewerWithFindReplaceUI("text");
+		OverlayAccess dialog= getDialog();
+
+		dialog.assertSelected(SearchOptions.GLOBAL);
+
+		dialog.unselect(SearchOptions.GLOBAL);
+		dialog.assertUnselected(SearchOptions.GLOBAL);
+
+		dialog.select(SearchOptions.GLOBAL);
+		dialog.assertSelected(SearchOptions.GLOBAL);
+	}
+
+
 }


### PR DESCRIPTION
The search-in-selection option was accidentally initialized in the UI with the state of the whole-word option in the underlying logic object. This had no visible negative effect because the values are initialized during overlay creation with a fitting initial state.

Still, this change corrects that semantic inconsistency. It also make the FindReplaceLogic of the overlay immutable as it will actually not be modified throughout the overlay's lifecycle. A test for the inverse behavior of the global search option is added.