### PR TITLE
Replace CSSSWTTestCase inheritance with a JUnit 5 extension

### DIFF
--- a/tests/org.eclipse.e4.ui.tests.css.swt/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.e4.ui.tests.css.swt/META-INF/MANIFEST.MF
@@ -13,6 +13,7 @@ Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-21
 Import-Package: org.eclipse.core.runtime;version="3.5.0",
  org.junit.jupiter.api;version="[5.14.0,6.0.0)",
+ org.junit.jupiter.api.extension;version="[5.14.0,6.0.0)",
  org.junit.jupiter.api.function;version="[5.14.0,6.0.0)",
  org.junit.platform.suite.api;version="[1.14.0,2.0.0)",
  org.osgi.framework;version="[1.7.0,2.0.0)",

--- a/tests/org.eclipse.e4.ui.tests.css.swt/src/org/eclipse/e4/ui/tests/css/forms/ExpandableCompositeTest.java
+++ b/tests/org.eclipse.e4.ui.tests.css.swt/src/org/eclipse/e4/ui/tests/css/forms/ExpandableCompositeTest.java
@@ -17,24 +17,31 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
-import org.eclipse.e4.ui.tests.css.swt.CSSSWTTestCase;
+import org.eclipse.e4.ui.css.core.engine.CSSEngine;
+import org.eclipse.e4.ui.tests.css.swt.CssSwtEngine;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.graphics.RGB;
 import org.eclipse.swt.layout.FillLayout;
 import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Shell;
 import org.eclipse.ui.forms.widgets.ExpandableComposite;
 import org.eclipse.ui.forms.widgets.ToggleHyperlink;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
-public class ExpandableCompositeTest extends CSSSWTTestCase {
+public class ExpandableCompositeTest {
+
+	@RegisterExtension
+	CssSwtEngine css = new CssSwtEngine();
 
 	static final RGB RED = new RGB(255, 0, 0);
 	static final RGB GREEN = new RGB(0, 255, 0);
 	static final RGB BLUE = new RGB(0, 0, 255);
 
 	protected ExpandableComposite createTestExpandableComposite(String styleSheet) {
-		engine = createEngine(styleSheet, display);
+		Display display = css.getDisplay();
+		CSSEngine engine = css.createEngine(styleSheet);
 
 		// Create widgets
 		Shell shell = new Shell(display, SWT.SHELL_TRIM);
@@ -76,7 +83,7 @@ public class ExpandableCompositeTest extends CSSSWTTestCase {
 		assertNotNull(compositeToTest.getTitleBarForeground());
 		assertEquals(RED, compositeToTest.getTitleBarForeground().getRGB());
 
-		engine.reset();
+		css.getEngine().reset();
 
 		assertNull(compositeToTest.getTitleBarForeground());
 

--- a/tests/org.eclipse.e4.ui.tests.css.swt/src/org/eclipse/e4/ui/tests/css/forms/SectionTest.java
+++ b/tests/org.eclipse.e4.ui.tests.css.swt/src/org/eclipse/e4/ui/tests/css/forms/SectionTest.java
@@ -18,25 +18,32 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
-import org.eclipse.e4.ui.tests.css.swt.CSSSWTTestCase;
+import org.eclipse.e4.ui.css.core.engine.CSSEngine;
+import org.eclipse.e4.ui.tests.css.swt.CssSwtEngine;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.graphics.RGB;
 import org.eclipse.swt.layout.FillLayout;
 import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Shell;
 import org.eclipse.ui.forms.widgets.ExpandableComposite;
 import org.eclipse.ui.forms.widgets.Section;
 import org.eclipse.ui.forms.widgets.ToggleHyperlink;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
-public class SectionTest extends CSSSWTTestCase {
+public class SectionTest {
+
+	@RegisterExtension
+	CssSwtEngine css = new CssSwtEngine();
 
 	static final RGB RED = new RGB(255, 0, 0);
 	static final RGB GREEN = new RGB(0, 255, 0);
 	static final RGB BLUE = new RGB(0, 0, 255);
 
 	protected Section createTestSection(String styleSheet) {
-		engine = createEngine(styleSheet, display);
+		Display display = css.getDisplay();
+		CSSEngine engine = css.createEngine(styleSheet);
 
 		// Create widgets
 		Shell shell = new Shell(display, SWT.SHELL_TRIM);
@@ -91,7 +98,7 @@ public class SectionTest extends CSSSWTTestCase {
 					background-color-titlebar: #0000FF; \
 					border-color-titlebar: #00FF00}""");
 
-		engine.reset();
+		css.getEngine().reset();
 
 		assertNull(section.getTitleBarForeground());
 

--- a/tests/org.eclipse.e4.ui.tests.css.swt/src/org/eclipse/e4/ui/tests/css/properties/tabbed/TabbedPropertiesListTest.java
+++ b/tests/org.eclipse.e4.ui.tests.css.swt/src/org/eclipse/e4/ui/tests/css/properties/tabbed/TabbedPropertiesListTest.java
@@ -13,7 +13,8 @@ package org.eclipse.e4.ui.tests.css.properties.tabbed;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import org.eclipse.e4.ui.tests.css.swt.CSSSWTTestCase;
+import org.eclipse.e4.ui.css.core.engine.CSSEngine;
+import org.eclipse.e4.ui.tests.css.swt.CssSwtEngine;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.graphics.RGB;
 import org.eclipse.swt.layout.FillLayout;
@@ -22,12 +23,17 @@ import org.eclipse.swt.widgets.Shell;
 import org.eclipse.ui.internal.views.properties.tabbed.view.TabbedPropertyList;
 import org.eclipse.ui.views.properties.tabbed.TabbedPropertySheetWidgetFactory;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
-public class TabbedPropertiesListTest extends CSSSWTTestCase {
+public class TabbedPropertiesListTest {
+
+	@RegisterExtension
+	CssSwtEngine css = new CssSwtEngine();
 
 	static final RGB RED = new RGB(255, 0, 0);
 	private TabbedPropertySheetWidgetFactory factory;
 	private Shell shell;
+	private CSSEngine engine;
 
 
 	private TabbedPropertyList createTabbedPropertiesList(String stylesheet) {
@@ -37,9 +43,9 @@ public class TabbedPropertiesListTest extends CSSSWTTestCase {
 		} else {
 			s = stylesheet;
 		}
-		engine = createEngine(s, display);
+		engine = css.createEngine(s);
 
-		shell = new Shell(display, SWT.SHELL_TRIM);
+		shell = new Shell(css.getDisplay(), SWT.SHELL_TRIM);
 		FillLayout layout = new FillLayout();
 		shell.setLayout(layout);
 

--- a/tests/org.eclipse.e4.ui.tests.css.swt/src/org/eclipse/e4/ui/tests/css/properties/tabbed/TabbedPropertiesTitleTest.java
+++ b/tests/org.eclipse.e4.ui.tests.css.swt/src/org/eclipse/e4/ui/tests/css/properties/tabbed/TabbedPropertiesTitleTest.java
@@ -14,18 +14,23 @@ package org.eclipse.e4.ui.tests.css.properties.tabbed;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-import org.eclipse.e4.ui.tests.css.swt.CSSSWTTestCase;
+import org.eclipse.e4.ui.tests.css.swt.CssSwtEngine;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.graphics.RGB;
 import org.eclipse.swt.layout.FillLayout;
 import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Shell;
 import org.eclipse.ui.forms.IFormColors;
 import org.eclipse.ui.internal.views.properties.tabbed.view.TabbedPropertyTitle;
 import org.eclipse.ui.views.properties.tabbed.TabbedPropertySheetWidgetFactory;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
-public class TabbedPropertiesTitleTest extends CSSSWTTestCase {
+public class TabbedPropertiesTitleTest {
+
+	@RegisterExtension
+	CssSwtEngine css = new CssSwtEngine();
 
 	static final RGB RED = new RGB(255, 0, 0);
 	private TabbedPropertySheetWidgetFactory factory;
@@ -39,9 +44,8 @@ public class TabbedPropertiesTitleTest extends CSSSWTTestCase {
 		} else {
 			s = stylesheet;
 		}
-		engine = createEngine(
-				s,
-				display);
+		Display display = css.getDisplay();
+		css.createEngine(s);
 
 		shell = new Shell(display, SWT.SHELL_TRIM);
 		FillLayout layout = new FillLayout();
@@ -66,7 +70,7 @@ public class TabbedPropertiesTitleTest extends CSSSWTTestCase {
 	void titleBackgroundColorIsStyled() {
 		createTabbedPropertiesTitle(null);
 
-		engine.applyStyles(shell, true);
+		css.getEngine().applyStyles(shell, true);
 
 		assertColor(RED, IFormColors.H_GRADIENT_START);
 		assertColor(RED, IFormColors.H_GRADIENT_END);
@@ -83,8 +87,8 @@ public class TabbedPropertiesTitleTest extends CSSSWTTestCase {
 		RGB colorBottomKeylineOneBeforStyling = factory.getColors().getColor(IFormColors.H_BOTTOM_KEYLINE1).getRGB();
 		RGB colorBottomKeylineTwoBeforStyling = factory.getColors().getColor(IFormColors.H_BOTTOM_KEYLINE2).getRGB();
 
-		engine.applyStyles(shell, true);
-		engine.reset();
+		css.getEngine().applyStyles(shell, true);
+		css.getEngine().reset();
 		assertColor(colorGradStartBeforStyling, IFormColors.H_GRADIENT_START);
 		assertColor(colorGradEndBeforStyling, IFormColors.H_GRADIENT_END);
 		assertColor(colorBottomKeylineOneBeforStyling, IFormColors.H_BOTTOM_KEYLINE1);
@@ -101,7 +105,7 @@ public class TabbedPropertiesTitleTest extends CSSSWTTestCase {
 		RGB colorBottomKeylineOneBeforStyling = factory.getColors().getColor(IFormColors.H_BOTTOM_KEYLINE1).getRGB();
 		RGB colorBottomKeylineTwoBeforStyling = factory.getColors().getColor(IFormColors.H_BOTTOM_KEYLINE2).getRGB();
 
-		engine.applyStyles(shell, true);
+		css.getEngine().applyStyles(shell, true);
 		assertColor(colorGradStartBeforStyling, IFormColors.H_GRADIENT_START);
 		assertColor(colorGradEndBeforStyling, IFormColors.H_GRADIENT_END);
 		assertColor(colorBottomKeylineOneBeforStyling, IFormColors.H_BOTTOM_KEYLINE1);

--- a/tests/org.eclipse.e4.ui.tests.css.swt/src/org/eclipse/e4/ui/tests/css/swt/Bug419482Test.java
+++ b/tests/org.eclipse.e4.ui.tests.css.swt/src/org/eclipse/e4/ui/tests/css/swt/Bug419482Test.java
@@ -16,6 +16,7 @@ package org.eclipse.e4.ui.tests.css.swt;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import org.eclipse.e4.ui.css.core.engine.CSSEngine;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.graphics.RGB;
 import org.eclipse.swt.layout.RowLayout;
@@ -25,8 +26,12 @@ import org.eclipse.swt.widgets.Label;
 import org.eclipse.swt.widgets.Shell;
 import org.eclipse.swt.widgets.ToolBar;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
-public class Bug419482Test extends CSSSWTTestCase {
+public class Bug419482Test {
+
+	@RegisterExtension
+	CssSwtEngine css = new CssSwtEngine();
 
 	private static final RGB RGB_BLUE = new RGB(0, 0, 255);
 	private static final RGB RGB_RED = new RGB(255, 0, 0);
@@ -39,7 +44,7 @@ public class Bug419482Test extends CSSSWTTestCase {
 	void testTwoLevelsWildcard() {
 		String cssString = "Shell > * > * { color: red; } \n" + "Label { color: blue; }";
 
-		Label label = createTestLabel(cssString);
+		Label label = css.createTestLabel(cssString);
 
 		RGB rgb = label.getForeground().getRGB();
 		assertEquals(RGB_BLUE, rgb);
@@ -49,7 +54,7 @@ public class Bug419482Test extends CSSSWTTestCase {
 	void testOneLevelWildcardOneSpecific() {
 		String cssString = "Shell > * > Label { color: red; } \n" + "Label { color: blue; }";
 
-		Label label = createTestLabel(cssString);
+		Label label = css.createTestLabel(cssString);
 
 		RGB rgb = label.getForeground().getRGB();
 		assertEquals(RGB_RED, rgb);
@@ -59,7 +64,7 @@ public class Bug419482Test extends CSSSWTTestCase {
 	void testDescendentsWildcard() {
 		String cssString = "Shell * { color: red; } \n" + "Label { color: blue; }";
 
-		Label label = createTestLabel(cssString);
+		Label label = css.createTestLabel(cssString);
 
 		RGB rgb = label.getForeground().getRGB();
 		assertEquals(RGB_BLUE, rgb);
@@ -69,7 +74,7 @@ public class Bug419482Test extends CSSSWTTestCase {
 	void testDescendentsSpecific() {
 		String cssString = "Shell Label { color: red; } \n" + "Label { color: blue; }";
 
-		Label label = createTestLabel(cssString);
+		Label label = css.createTestLabel(cssString);
 
 		RGB rgb = label.getForeground().getRGB();
 		assertEquals(RGB_RED, rgb);
@@ -77,7 +82,7 @@ public class Bug419482Test extends CSSSWTTestCase {
 
 	@Test
 	void testOriginalBugReport() {
-		String css = """
+		String cssString = """
 			Shell, Shell > *, Shell > * > * {
 			    background-color: red;
 			}
@@ -85,9 +90,9 @@ public class Bug419482Test extends CSSSWTTestCase {
 			    background-color: blue;
 			}""";
 
-		engine = createEngine(css, display);
+		CSSEngine engine = css.createEngine(cssString);
 
-		Shell shell = createShellWithToolbars(display);
+		Shell shell = createShellWithToolbars(css.getDisplay());
 
 		// Apply styles
 		engine.applyStyles(shell, true);
@@ -99,7 +104,7 @@ public class Bug419482Test extends CSSSWTTestCase {
 
 	@Test
 	void testOriginalBugReportDifferentOrder() {
-		String css = """
+		String cssString = """
 			ToolBar {
 			    background-color: blue;
 			}\
@@ -108,10 +113,10 @@ public class Bug419482Test extends CSSSWTTestCase {
 			}
 			""";
 
-		engine = createEngine(css, display);
+		CSSEngine engine = css.createEngine(cssString);
 
 		// Create widgets
-		Shell shell = createShellWithToolbars(display);
+		Shell shell = createShellWithToolbars(css.getDisplay());
 
 		// Apply styles
 		engine.applyStyles(shell, true);

--- a/tests/org.eclipse.e4.ui.tests.css.swt/src/org/eclipse/e4/ui/tests/css/swt/Bug459961Test.java
+++ b/tests/org.eclipse.e4.ui.tests.css.swt/src/org/eclipse/e4/ui/tests/css/swt/Bug459961Test.java
@@ -20,14 +20,18 @@ import org.eclipse.swt.graphics.RGBA;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Label;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
-public class Bug459961Test extends CSSSWTTestCase {
+public class Bug459961Test {
+
+	@RegisterExtension
+	CssSwtEngine css = new CssSwtEngine();
 
 	@Test
 	void testRegularColorConstantReference() {
 		String cssString = "Label { background-color: COLOR-GREEN; }";
 
-		Label label = createTestLabel(cssString);
+		Label label = css.createTestLabel(cssString);
 
 		RGBA expected = Display.getDefault().getSystemColor(SWT.COLOR_GREEN).getRGBA();
 		RGBA actual = label.getBackground().getRGBA();
@@ -38,7 +42,7 @@ public class Bug459961Test extends CSSSWTTestCase {
 	void testTransparentColorConstantReference() {
 		String cssString = "Label { background-color: COLOR-TRANSPARENT; }";
 
-		Label label = createTestLabel(cssString);
+		Label label = css.createTestLabel(cssString);
 
 		RGBA expected = Display.getDefault().getSystemColor(SWT.COLOR_TRANSPARENT).getRGBA();
 		RGBA actual = label.getBackground().getRGBA();

--- a/tests/org.eclipse.e4.ui.tests.css.swt/src/org/eclipse/e4/ui/tests/css/swt/ButtonTest.java
+++ b/tests/org.eclipse.e4.ui.tests.css.swt/src/org/eclipse/e4/ui/tests/css/swt/ButtonTest.java
@@ -15,23 +15,32 @@
  *******************************************************************************/
 package org.eclipse.e4.ui.tests.css.swt;
 
+import static org.eclipse.e4.ui.tests.css.swt.CssSwtEngine.BLUE;
+import static org.eclipse.e4.ui.tests.css.swt.CssSwtEngine.RED;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
+import org.eclipse.e4.ui.css.core.engine.CSSEngine;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.graphics.FontData;
 import org.eclipse.swt.graphics.RGB;
 import org.eclipse.swt.layout.FillLayout;
 import org.eclipse.swt.widgets.Button;
 import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Shell;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
-public class ButtonTest extends CSSSWTTestCase {
+public class ButtonTest {
+
+	@RegisterExtension
+	CssSwtEngine css = new CssSwtEngine();
 
 	protected Button createTestButton(String styleSheet, int buttonStyle) {
-		engine = createEngine(styleSheet, display);
+		Display display = css.getDisplay();
+		CSSEngine engine = css.createEngine(styleSheet);
 
 		// Create widgets
 		Shell shell = new Shell(display, SWT.SHELL_TRIM);
@@ -102,7 +111,7 @@ public class ButtonTest extends CSSSWTTestCase {
 				SWT.CHECK);
 		assertEquals(RED, buttonToTest.getForeground().getRGB());
 		buttonToTest.setSelection(true);
-		engine.applyStyles(buttonToTest.getShell(), true);
+		css.getEngine().applyStyles(buttonToTest.getShell(), true);
 		assertEquals(BLUE, buttonToTest.getForeground().getRGB());
 	}
 

--- a/tests/org.eclipse.e4.ui.tests.css.swt/src/org/eclipse/e4/ui/tests/css/swt/CSSSWTWidgetTest.java
+++ b/tests/org.eclipse.e4.ui.tests.css.swt/src/org/eclipse/e4/ui/tests/css/swt/CSSSWTWidgetTest.java
@@ -29,8 +29,12 @@ import org.eclipse.e4.ui.css.swt.dom.html.SWTHTMLElement;
 import org.eclipse.swt.widgets.Widget;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
-public class CSSSWTWidgetTest extends CSSSWTTestCase {
+public class CSSSWTWidgetTest {
+
+	@RegisterExtension
+	CssSwtEngine css = new CssSwtEngine();
 
 	private static final class WidgetElementWithSupplierReturningNull extends WidgetElement {
 		private WidgetElementWithSupplierReturningNull(Widget widget, CSSEngine engine) {
@@ -61,14 +65,14 @@ public class CSSSWTWidgetTest extends CSSSWTTestCase {
 	@Disabled
 	@Test
 	void testEngineKey() {
-		Widget widget = createTestLabel("Label { font: Arial 12px; font-weight: bold }");
-		assertEquals(WidgetElement.getEngine(widget), engine);
+		Widget widget = css.createTestLabel("Label { font: Arial 12px; font-weight: bold }");
+		assertEquals(WidgetElement.getEngine(widget), css.getEngine());
 	}
 
 	@Test
 	void testIDKey() {
 		final String id = "some.test.id";
-		Widget widget = createTestLabel("Label { font: Arial 12px; font-weight: bold }");
+		Widget widget = css.createTestLabel("Label { font: Arial 12px; font-weight: bold }");
 		WidgetElement.setID(widget, id);
 		assertEquals(WidgetElement.getID(widget), id);
 	}
@@ -77,14 +81,15 @@ public class CSSSWTWidgetTest extends CSSSWTTestCase {
 	@Test
 	void testCSSClassKey() {
 		final String cssClass = "some.test.cssclassname";
-		Widget widget = createTestLabel("Label { font: Arial 12px; font-weight: bold }");
+		Widget widget = css.createTestLabel("Label { font: Arial 12px; font-weight: bold }");
 		WidgetElement.setCSSClass(widget, cssClass);
 		assertEquals(WidgetElement.getCSSClass(widget), cssClass);
 	}
 
 	@Test
 	void testHasAttribute() {
-		Widget widget = createTestLabel("Label { }");
+		Widget widget = css.createTestLabel("Label { }");
+		CSSEngine engine = css.getEngine();
 		String propertySetToEmptyStringKey = "empty-property";
 		widget.setData(propertySetToEmptyStringKey, "");
 		assertTrue(engine.getElement(widget).hasAttribute(propertySetToEmptyStringKey));
@@ -94,31 +99,34 @@ public class CSSSWTWidgetTest extends CSSSWTTestCase {
 
 	@Test
 	void testGetAttributeWithSwtStylesNull() {
-		Widget widget = createTestLabel("Label { }");
-		engine.setElementProvider((element, engine) -> new WidgetElementWithSwtStylesNull((Widget) element, engine));
+		Widget widget = css.createTestLabel("Label { }");
+		CSSEngine cssEngine = css.getEngine();
+		cssEngine.setElementProvider((element, engine) -> new WidgetElementWithSwtStylesNull((Widget) element, engine));
 
-		assertTrue(engine.getElement(widget).hasAttribute("style"));
-		assertEquals("", engine.getElement(widget).getAttribute("style"));
+		assertTrue(cssEngine.getElement(widget).hasAttribute("style"));
+		assertEquals("", cssEngine.getElement(widget).getAttribute("style"));
 	}
 
 	@Test
 	void testGetAttributeWithAttributeTypeNull() {
-		Widget widget = createTestLabel("Label { }");
-		engine.setElementProvider(
+		Widget widget = css.createTestLabel("Label { }");
+		CSSEngine cssEngine = css.getEngine();
+		cssEngine.setElementProvider(
 				(element, engine) -> new SWTHTMLElementWithAttributeTypeNull((Widget) element, engine));
 
-		assertTrue(engine.getElement(widget).hasAttribute("type"));
-		assertEquals("", engine.getElement(widget).getAttribute("type"));
+		assertTrue(cssEngine.getElement(widget).hasAttribute("type"));
+		assertEquals("", cssEngine.getElement(widget).getAttribute("type"));
 	}
 
 	@Test
 	void testGetAttributeWithAttributeSupplierReturningNull() {
-		Widget widget = createTestLabel("Label { }");
-		engine.setElementProvider(
+		Widget widget = css.createTestLabel("Label { }");
+		CSSEngine cssEngine = css.getEngine();
+		cssEngine.setElementProvider(
 				(element, engine) -> new WidgetElementWithSupplierReturningNull((Widget) element, engine));
 
 		// throws exception
-		assertThrows(AssertionFailedException.class, () -> engine.getElement(widget).getAttribute("style"));
+		assertThrows(AssertionFailedException.class, () -> cssEngine.getElement(widget).getAttribute("style"));
 
 	}
 }

--- a/tests/org.eclipse.e4.ui.tests.css.swt/src/org/eclipse/e4/ui/tests/css/swt/CTabFolderActiveClassTest.java
+++ b/tests/org.eclipse.e4.ui.tests.css.swt/src/org/eclipse/e4/ui/tests/css/swt/CTabFolderActiveClassTest.java
@@ -13,37 +13,43 @@
  *******************************************************************************/
 package org.eclipse.e4.ui.tests.css.swt;
 
+import static org.eclipse.e4.ui.tests.css.swt.CssSwtEngine.RED;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
+import org.eclipse.e4.ui.css.core.engine.CSSEngine;
 import org.eclipse.e4.ui.css.swt.dom.WidgetElement;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.custom.CTabFolder;
 import org.eclipse.swt.custom.CTabItem;
 import org.eclipse.swt.layout.FillLayout;
+import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Shell;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 /**
  * Locks in how {@code CTabFolder.active { ... }} rules are matched based on
  * the CSS class set via {@link WidgetElement#setCSSClass(org.eclipse.swt.widgets.Widget, String)}.
  */
-public class CTabFolderActiveClassTest extends CSSSWTTestCase {
+public class CTabFolderActiveClassTest {
+
+	@RegisterExtension
+	CssSwtEngine css = new CssSwtEngine();
 
 	private Shell shell;
 
-	@Override
 	@AfterEach
 	public void tearDown() {
 		if (shell != null && !shell.isDisposed()) {
 			shell.dispose();
 			shell = null;
 		}
-		super.tearDown();
 	}
 
 	private CTabFolder createFolder() {
+		Display display = css.getDisplay();
 		shell = new Shell(display, SWT.SHELL_TRIM);
 		shell.setLayout(new FillLayout());
 
@@ -59,7 +65,7 @@ public class CTabFolderActiveClassTest extends CSSSWTTestCase {
 		CTabFolder folder = createFolder();
 		WidgetElement.setCSSClass(folder, "active");
 
-		engine = createEngine("CTabFolder.active { background-color: #FF0000 }", display);
+		CSSEngine engine = css.createEngine("CTabFolder.active { background-color: #FF0000 }");
 		engine.applyStyles(shell, true);
 
 		assertEquals(RED, folder.getBackground().getRGB());
@@ -70,7 +76,7 @@ public class CTabFolderActiveClassTest extends CSSSWTTestCase {
 		CTabFolder folder = createFolder();
 		// no setCSSClass call
 
-		engine = createEngine("CTabFolder.active { background-color: #FF0000 }", display);
+		CSSEngine engine = css.createEngine("CTabFolder.active { background-color: #FF0000 }");
 		engine.applyStyles(shell, true);
 
 		assertNotEquals(RED, folder.getBackground().getRGB());
@@ -81,7 +87,7 @@ public class CTabFolderActiveClassTest extends CSSSWTTestCase {
 		CTabFolder folder = createFolder();
 		WidgetElement.setCSSClass(folder, "active");
 
-		engine = createEngine("CTabFolder.active { background-color: #FF0000 }", display);
+		CSSEngine engine = css.createEngine("CTabFolder.active { background-color: #FF0000 }");
 		engine.applyStyles(shell, true);
 		assertEquals(RED, folder.getBackground().getRGB());
 

--- a/tests/org.eclipse.e4.ui.tests.css.swt/src/org/eclipse/e4/ui/tests/css/swt/CTabFolderTest.java
+++ b/tests/org.eclipse.e4.ui.tests.css.swt/src/org/eclipse/e4/ui/tests/css/swt/CTabFolderTest.java
@@ -15,9 +15,14 @@
  *******************************************************************************/
 package org.eclipse.e4.ui.tests.css.swt;
 
+import static org.eclipse.e4.ui.tests.css.swt.CssSwtEngine.BLUE;
+import static org.eclipse.e4.ui.tests.css.swt.CssSwtEngine.GREEN;
+import static org.eclipse.e4.ui.tests.css.swt.CssSwtEngine.RED;
+import static org.eclipse.e4.ui.tests.css.swt.CssSwtEngine.WHITE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
 
+import org.eclipse.e4.ui.css.core.engine.CSSEngine;
 import org.eclipse.e4.ui.css.swt.dom.WidgetElement;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.custom.CTabFolder;
@@ -30,11 +35,16 @@ import org.eclipse.swt.widgets.Label;
 import org.eclipse.swt.widgets.Shell;
 import org.eclipse.swt.widgets.ToolBar;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
-public class CTabFolderTest extends CSSSWTTestCase {
+public class CTabFolderTest {
+
+	@RegisterExtension
+	CssSwtEngine css = new CssSwtEngine();
 
 	protected CTabFolder createTestCTabFolder(String styleSheet) {
-		engine = createEngine(styleSheet, display);
+		Display display = css.getDisplay();
+		CSSEngine engine = css.createEngine(styleSheet);
 
 		// Create widgets
 		Shell shell = new Shell(display, SWT.SHELL_TRIM);
@@ -55,7 +65,8 @@ public class CTabFolderTest extends CSSSWTTestCase {
 
 	protected ToolBar[] createTestToolBars(String styleSheet) {
 
-		engine = createEngine(styleSheet, display);
+		Display display = css.getDisplay();
+		CSSEngine engine = css.createEngine(styleSheet);
 
 		// Create widgets
 		Shell shell = new Shell(display, SWT.SHELL_TRIM);
@@ -84,8 +95,8 @@ public class CTabFolderTest extends CSSSWTTestCase {
 	}
 
 	protected Shell createShell(String styleSheet) {
-		Display display = Display.getDefault();
-		engine = createEngine(styleSheet, display);
+		Display display = css.getDisplay();
+		CSSEngine engine = css.createEngine(styleSheet);
 
 		// Create widgets
 		Shell shell = new Shell(display, SWT.NONE);
@@ -97,7 +108,8 @@ public class CTabFolderTest extends CSSSWTTestCase {
 	}
 
 	protected Label createLabelInCTabFolder(String styleSheet) {
-		engine = createEngine(styleSheet, display);
+		Display display = css.getDisplay();
+		CSSEngine engine = css.createEngine(styleSheet);
 
 		// Create widgets
 		Shell shell = new Shell(display, SWT.SHELL_TRIM);
@@ -172,64 +184,64 @@ public class CTabFolderTest extends CSSSWTTestCase {
 	void testBorderVisible() {
 		CTabFolder folderToTest = createTestCTabFolder("CTabFolder { border-visible: true}");
 		assertEquals(true, folderToTest.getBorderVisible());
-		assertEquals("true", engine.retrieveCSSProperty(folderToTest, "border-visible", null));
+		assertEquals("true", css.getEngine().retrieveCSSProperty(folderToTest, "border-visible", null));
 		folderToTest.getShell().close();
 		folderToTest = createTestCTabFolder("CTabFolder { border-visible: false}");
 		assertEquals(false, folderToTest.getBorderVisible());
-		assertEquals("false", engine.retrieveCSSProperty(folderToTest, "border-visible", null));
+		assertEquals("false", css.getEngine().retrieveCSSProperty(folderToTest, "border-visible", null));
 	}
 	@Test
 	void testSimple() {
 		CTabFolder folderToTest = createTestCTabFolder("CTabFolder { swt-simple: true}");
 		assertEquals(true, folderToTest.getSimple());
-		assertEquals("true", engine.retrieveCSSProperty(folderToTest, "swt-simple", null));
+		assertEquals("true", css.getEngine().retrieveCSSProperty(folderToTest, "swt-simple", null));
 		folderToTest.getShell().close();
 		folderToTest = createTestCTabFolder("CTabFolder { swt-simple: false}");
 		// Curved tabs are no longer supported, so getSimple() always returns true
 		assertEquals(true, folderToTest.getSimple());
-		assertEquals("true", engine.retrieveCSSProperty(folderToTest, "swt-simple", null));
+		assertEquals("true", css.getEngine().retrieveCSSProperty(folderToTest, "swt-simple", null));
 	}
 
 	@Test
 	void testMaximizeVisible() {
 		CTabFolder folderToTest = createTestCTabFolder("CTabFolder { swt-maximize-visible: true}");
 		assertEquals(true, folderToTest.getMaximizeVisible());
-		assertEquals("true", engine.retrieveCSSProperty(folderToTest, "swt-maximize-visible", null));
+		assertEquals("true", css.getEngine().retrieveCSSProperty(folderToTest, "swt-maximize-visible", null));
 		folderToTest.getShell().close();
 		folderToTest = createTestCTabFolder("CTabFolder { swt-maximize-visible: false}");
 		assertEquals(false, folderToTest.getMaximizeVisible());
-		assertEquals("false", engine.retrieveCSSProperty(folderToTest, "swt-maximize-visible", null));
+		assertEquals("false", css.getEngine().retrieveCSSProperty(folderToTest, "swt-maximize-visible", null));
 	}
 
 	@Test
 	void testMinimizeVisible() {
 		CTabFolder folderToTest = createTestCTabFolder("CTabFolder { swt-minimize-visible: true}");
 		assertEquals(true, folderToTest.getMinimizeVisible());
-		assertEquals("true", engine.retrieveCSSProperty(folderToTest, "swt-minimize-visible", null));
+		assertEquals("true", css.getEngine().retrieveCSSProperty(folderToTest, "swt-minimize-visible", null));
 		folderToTest.getShell().close();
 		folderToTest = createTestCTabFolder("CTabFolder { swt-minimize-visible: false}");
 		assertEquals(false, folderToTest.getMinimizeVisible());
-		assertEquals("false", engine.retrieveCSSProperty(folderToTest, "swt-minimize-visible", null));
+		assertEquals("false", css.getEngine().retrieveCSSProperty(folderToTest, "swt-minimize-visible", null));
 	}
 
 	@Test
 	void testMaximized() {
 		CTabFolder folderToTest = createTestCTabFolder("CTabFolder { swt-maximized: true}");
 		assertEquals(true, folderToTest.getMaximized());
-		assertEquals("true", engine.retrieveCSSProperty(folderToTest, "swt-maximized", null));
+		assertEquals("true", css.getEngine().retrieveCSSProperty(folderToTest, "swt-maximized", null));
 		folderToTest = createTestCTabFolder("CTabFolder { swt-maximized: false}");
 		assertEquals(false, folderToTest.getMaximized());
-		assertEquals("false", engine.retrieveCSSProperty(folderToTest, "swt-maximized", null));
+		assertEquals("false", css.getEngine().retrieveCSSProperty(folderToTest, "swt-maximized", null));
 	}
 
 	@Test
 	void testMinimized() {
 		CTabFolder folderToTest = createTestCTabFolder("CTabFolder { swt-minimized: true}");
 		assertEquals(true, folderToTest.getMinimized());
-		assertEquals("true", engine.retrieveCSSProperty(folderToTest, "swt-minimized", null));
+		assertEquals("true", css.getEngine().retrieveCSSProperty(folderToTest, "swt-minimized", null));
 		folderToTest = createTestCTabFolder("CTabFolder { swt-minimized: false}");
 		assertEquals(false, folderToTest.getMinimized());
-		assertEquals("false", engine.retrieveCSSProperty(folderToTest, "swt-minimized", null));
+		assertEquals("false", css.getEngine().retrieveCSSProperty(folderToTest, "swt-minimized", null));
 	}
 
 	@Test
@@ -254,43 +266,43 @@ public class CTabFolderTest extends CSSSWTTestCase {
 	void testSingle() {
 		CTabFolder folderToTest = createTestCTabFolder("CTabFolder { swt-single: true}");
 		assertEquals(true, folderToTest.getSingle());
-		assertEquals("true", engine.retrieveCSSProperty(folderToTest, "swt-single", null));
+		assertEquals("true", css.getEngine().retrieveCSSProperty(folderToTest, "swt-single", null));
 		folderToTest = createTestCTabFolder("CTabFolder { swt-single: false}");
 		assertEquals(false, folderToTest.getSingle());
-		assertEquals("false", engine.retrieveCSSProperty(folderToTest, "swt-single", null));
+		assertEquals("false", css.getEngine().retrieveCSSProperty(folderToTest, "swt-single", null));
 	}
 
 	@Test
 	void testUnselectedCloseVisible() {
 		CTabFolder folderToTest = createTestCTabFolder("CTabFolder { swt-unselected-close-visible: true}");
 		assertEquals(true, folderToTest.getUnselectedCloseVisible());
-		assertEquals("true", engine.retrieveCSSProperty(folderToTest, "swt-unselected-close-visible", null));
+		assertEquals("true", css.getEngine().retrieveCSSProperty(folderToTest, "swt-unselected-close-visible", null));
 		folderToTest = createTestCTabFolder("CTabFolder { swt-unselected-close-visible: false}");
 		assertEquals(false, folderToTest.getUnselectedCloseVisible());
-		assertEquals("false", engine.retrieveCSSProperty(folderToTest, "swt-unselected-close-visible", null));
+		assertEquals("false", css.getEngine().retrieveCSSProperty(folderToTest, "swt-unselected-close-visible", null));
 	}
 
 	@Test
 	void testUnselectedImageVisible() {
 		CTabFolder folderToTest = createTestCTabFolder("CTabFolder { swt-unselected-image-visible: true}");
 		assertEquals(true, folderToTest.getUnselectedImageVisible());
-		assertEquals("true", engine.retrieveCSSProperty(folderToTest, "swt-unselected-image-visible", null));
+		assertEquals("true", css.getEngine().retrieveCSSProperty(folderToTest, "swt-unselected-image-visible", null));
 		folderToTest = createTestCTabFolder("CTabFolder { swt-unselected-image-visible: false}");
 		assertEquals(false, folderToTest.getUnselectedImageVisible());
-		assertEquals("false", engine.retrieveCSSProperty(folderToTest, "swt-unselected-image-visible", null));
+		assertEquals("false", css.getEngine().retrieveCSSProperty(folderToTest, "swt-unselected-image-visible", null));
 	}
 
 	@Test
 	void testRetrievePropertyNull() {
 		Shell shell = createShell("Shell {color:red}");
-		assertEquals(null, engine.retrieveCSSProperty(shell, "border-visible", null));
-		assertEquals(null, engine.retrieveCSSProperty(shell, "swt-maximized", null));
-		assertEquals(null, engine.retrieveCSSProperty(shell, "swt-maximize-visible", null));
-		assertEquals(null, engine.retrieveCSSProperty(shell, "swt-minimize-visible", null));
-		assertEquals(null, engine.retrieveCSSProperty(shell, "swt-simple", null));
-		assertEquals(null, engine.retrieveCSSProperty(shell, "swt-single", null));
-		assertEquals(null, engine.retrieveCSSProperty(shell, "swt-unselected-close-visible", null));
-		assertEquals(null, engine.retrieveCSSProperty(shell, "swt-unselected-image-visible", null));
+		assertEquals(null, css.getEngine().retrieveCSSProperty(shell, "border-visible", null));
+		assertEquals(null, css.getEngine().retrieveCSSProperty(shell, "swt-maximized", null));
+		assertEquals(null, css.getEngine().retrieveCSSProperty(shell, "swt-maximize-visible", null));
+		assertEquals(null, css.getEngine().retrieveCSSProperty(shell, "swt-minimize-visible", null));
+		assertEquals(null, css.getEngine().retrieveCSSProperty(shell, "swt-simple", null));
+		assertEquals(null, css.getEngine().retrieveCSSProperty(shell, "swt-single", null));
+		assertEquals(null, css.getEngine().retrieveCSSProperty(shell, "swt-unselected-close-visible", null));
+		assertEquals(null, css.getEngine().retrieveCSSProperty(shell, "swt-unselected-image-visible", null));
 	}
 
 	@Test
@@ -307,14 +319,14 @@ public class CTabFolderTest extends CSSSWTTestCase {
 		ToolBar barC = toolBars[2];
 
 		WidgetElement.setCSSClass(barA.getParent(), "special");
-		engine.applyStyles(barA.getShell(), true);
+		css.getEngine().applyStyles(barA.getShell(), true);
 
 		assertEquals(RED, barA.getBackground().getRGB());
 		assertEquals(GREEN, barB.getBackground().getRGB());
 		assertEquals(BLUE, barC.getBackground().getRGB());
 
 		WidgetElement.setCSSClass(barA.getParent(), "extraordinary");
-		engine.applyStyles(barA.getShell(), true);
+		css.getEngine().applyStyles(barA.getShell(), true);
 
 		assertEquals(WHITE, barA.getBackground().getRGB());
 	}
@@ -329,19 +341,19 @@ public class CTabFolderTest extends CSSSWTTestCase {
 	void testSelectedImageVisible() {
 		CTabFolder folderToTest = createTestCTabFolder("CTabFolder { swt-selected-image-visible: true}");
 		assertEquals(true, folderToTest.getSelectedImageVisible());
-		assertEquals("true", engine.retrieveCSSProperty(folderToTest, "swt-selected-image-visible", null));
+		assertEquals("true", css.getEngine().retrieveCSSProperty(folderToTest, "swt-selected-image-visible", null));
 		folderToTest = createTestCTabFolder("CTabFolder { swt-selected-image-visible: false}");
 		assertEquals(false, folderToTest.getSelectedImageVisible());
-		assertEquals("false", engine.retrieveCSSProperty(folderToTest, "swt-selected-image-visible", null));
+		assertEquals("false", css.getEngine().retrieveCSSProperty(folderToTest, "swt-selected-image-visible", null));
 	}
 
 	@Test
 	void testMinimumCharacters() {
 		CTabFolder folderToTest = createTestCTabFolder("CTabFolder { swt-tab-text-minimum-characters: 1}");
 		assertEquals(1, folderToTest.getMinimumCharacters());
-		assertEquals("1", engine.retrieveCSSProperty(folderToTest, "swt-tab-text-minimum-characters", null));
+		assertEquals("1", css.getEngine().retrieveCSSProperty(folderToTest, "swt-tab-text-minimum-characters", null));
 		folderToTest = createTestCTabFolder("CTabFolder { swt-tab-text-minimum-characters: 1.2}");
 		assertEquals(1, folderToTest.getMinimumCharacters());
-		assertEquals("1", engine.retrieveCSSProperty(folderToTest, "swt-tab-text-minimum-characters", null));
+		assertEquals("1", css.getEngine().retrieveCSSProperty(folderToTest, "swt-tab-text-minimum-characters", null));
 	}
 }

--- a/tests/org.eclipse.e4.ui.tests.css.swt/src/org/eclipse/e4/ui/tests/css/swt/CTabItemSelectionTest.java
+++ b/tests/org.eclipse.e4.ui.tests.css.swt/src/org/eclipse/e4/ui/tests/css/swt/CTabItemSelectionTest.java
@@ -13,39 +13,45 @@
  *******************************************************************************/
 package org.eclipse.e4.ui.tests.css.swt;
 
+import static org.eclipse.e4.ui.tests.css.swt.CssSwtEngine.RED;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
+import org.eclipse.e4.ui.css.core.engine.CSSEngine;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.custom.CTabFolder;
 import org.eclipse.swt.custom.CTabItem;
 import org.eclipse.swt.graphics.RGB;
 import org.eclipse.swt.layout.FillLayout;
+import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Event;
 import org.eclipse.swt.widgets.Shell;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 /**
  * Pins {@code CTabItem:selected} pseudo behaviour and the
  * {@code CTabFolderElement} selection listener path.
  */
-public class CTabItemSelectionTest extends CSSSWTTestCase {
+public class CTabItemSelectionTest {
+
+	@RegisterExtension
+	CssSwtEngine css = new CssSwtEngine();
 
 	private Shell shell;
 
-	@Override
 	@AfterEach
 	public void tearDown() {
 		if (shell != null && !shell.isDisposed()) {
 			shell.dispose();
 			shell = null;
 		}
-		super.tearDown();
 	}
 
 	private void spinEventLoop() {
 		// Drain queued SWT events. Same pattern as CTabItemTest.
+		Display display = css.getDisplay();
 		for (int i = 0; i < 3; i++) {
 			while (display.readAndDispatch()) {
 			}
@@ -57,6 +63,7 @@ public class CTabItemSelectionTest extends CSSSWTTestCase {
 	}
 
 	private CTabFolder createFolderWithTwoItems(String styleSheet) {
+		Display display = css.getDisplay();
 		shell = new Shell(display, SWT.SHELL_TRIM);
 		shell.setLayout(new FillLayout());
 
@@ -67,7 +74,7 @@ public class CTabItemSelectionTest extends CSSSWTTestCase {
 		item1.setText("Item 1");
 		folder.setSelection(0);
 
-		engine = createEngine(styleSheet, display);
+		CSSEngine engine = css.createEngine(styleSheet);
 		engine.applyStyles(shell, true);
 		shell.open();
 		return folder;

--- a/tests/org.eclipse.e4.ui.tests.css.swt/src/org/eclipse/e4/ui/tests/css/swt/CTabItemTest.java
+++ b/tests/org.eclipse.e4.ui.tests.css.swt/src/org/eclipse/e4/ui/tests/css/swt/CTabItemTest.java
@@ -33,29 +33,32 @@ import org.eclipse.swt.layout.FillLayout;
 import org.eclipse.swt.widgets.Button;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;
+import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Shell;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
-public class CTabItemTest extends CSSSWTTestCase {
+public class CTabItemTest {
 
+	@RegisterExtension
+	CssSwtEngine css = new CssSwtEngine();
 
 	private Shell shell;
 
-	@Override
 	@AfterEach
 	public void tearDown() {
 		if (shell != null) {
 			shell.dispose();
 			shell = null;
 		}
-		super.tearDown();
 	}
 
 	private void spinEventLoop() {
 		// Workaround for https://bugs.eclipse.org/418101 and https://bugs.eclipse.org/403234 :
 		// Add some delay to allow asynchronous events to come in, but don't get trapped in an endless Display#sleep().
+		Display display = css.getDisplay();
 		for (int i = 0; i < 3; i++) {
 			while (display.readAndDispatch()) {
 			}
@@ -82,6 +85,7 @@ public class CTabItemTest extends CSSSWTTestCase {
 	private CTabFolder createTestTabFolder(boolean open) {
 
 		// Create widgets
+		Display display = css.getDisplay();
 		shell = new Shell(display, SWT.SHELL_TRIM);
 		FillLayout layout = new FillLayout();
 		shell.setLayout(layout);
@@ -101,7 +105,7 @@ public class CTabItemTest extends CSSSWTTestCase {
 	protected CTabFolder createTestTabFolder(String styleSheet, boolean open) {
 		CTabFolder folder = createTestTabFolder(open);
 
-		engine = createEngine(styleSheet, folder.getDisplay());
+		CSSEngine engine = css.createEngine(styleSheet);
 
 		// Apply styles
 		engine.applyStyles(folder.getShell(), true);
@@ -113,6 +117,7 @@ public class CTabItemTest extends CSSSWTTestCase {
 	void testFontRegular() {
 		CTabFolder folder = createTestTabFolder("Button { font-family: Verdana; font-size: 12 }\n"
 				+ "CTabItem { font-family: Verdana; font-size: 16 }");
+		CSSEngine engine = css.getEngine();
 		spinEventLoop();
 		folder.getItems();
 		assertEquals(0, folder.getSelectionIndex());
@@ -138,6 +143,7 @@ public class CTabItemTest extends CSSSWTTestCase {
 	void testFontBold() {
 		CTabFolder folder = createTestTabFolder("Button { font-weight: bold }\n"
 				+ "CTabItem { font-weight: bold }");
+		CSSEngine engine = css.getEngine();
 		spinEventLoop();
 
 		assertEquals(0, folder.getSelectionIndex());
@@ -158,6 +164,7 @@ public class CTabItemTest extends CSSSWTTestCase {
 	void testFontItalic() {
 		CTabFolder folder = createTestTabFolder("Button { font-weight: bold }\n"
 				+ "CTabItem { font-style: italic }");
+		CSSEngine engine = css.getEngine();
 		spinEventLoop();
 
 		assertEquals(0, folder.getSelectionIndex());
@@ -250,11 +257,11 @@ public class CTabItemTest extends CSSSWTTestCase {
 		CTabFolder folder2 = createFolder(folder.getShell());
 
 		WidgetElement.setCSSClass(folder2, "editorStack");
-		engine = createEngine("""
+		CSSEngine engine = css.createEngine("""
 			CTabItem { font-size: 10 }\
 			CTabItem:selected { font-size: 14; font-weight: bold }\
 			CTabFolder.editorStack CTabItem { font-size: 11; }\
-			CTabFolder.editorStack CTabItem:selected { font-size: 13; font-style: italic }""", folder.getDisplay());
+			CTabFolder.editorStack CTabItem:selected { font-size: 13; font-style: italic }""");
 		engine.applyStyles(folder.getShell(), true);
 
 		folder.getShell().open();
@@ -306,13 +313,12 @@ public class CTabItemTest extends CSSSWTTestCase {
 		CTabFolder folder2 = createFolder(folder.getShell());
 
 		WidgetElement.setCSSClass(folder2, "editorStack");
-		engine = createEngine(
+		CSSEngine engine = css.createEngine(
 				"""
 					CTabItem { font-size: 10 }\
 					CTabItem:selected { font-size: 14; font-weight: bold }\
 					CTabFolder.editorStack CTabItem { font-size: 11; }\
-					CTabFolder.editorStack CTabItem:selected { font-size: 13; font-weight: normal; font-style: italic }""",
-						folder.getDisplay());
+					CTabFolder.editorStack CTabItem:selected { font-size: 13; font-weight: normal; font-style: italic }""");
 		engine.applyStyles(folder.getShell(), true);
 
 		folder.getShell().open();
@@ -364,10 +370,10 @@ public class CTabItemTest extends CSSSWTTestCase {
 		CTabFolder folder2 = createFolder(folder.getShell());
 
 		WidgetElement.setCSSClass(folder2, "editorStack");
-		engine = createEngine("""
+		CSSEngine engine = css.createEngine("""
 			CTabItem { show-close: false }\
 			CTabItem:selected { show-close: true }\
-			CTabFolder.editorStack CTabItem { show-close: true }""", folder.getDisplay());
+			CTabFolder.editorStack CTabItem { show-close: true }""");
 		engine.applyStyles(folder.getShell(), true);
 
 		folder.getShell().open();
@@ -405,11 +411,11 @@ public class CTabItemTest extends CSSSWTTestCase {
 		CTabFolder folder2 = createFolder(folder.getShell());
 
 		WidgetElement.setCSSClass(folder2, "viewStack");
-		engine = createEngine("""
+		CSSEngine engine = css.createEngine("""
 			CTabItem { show-close: false }\
 			CTabItem:selected { show-close: true }\
 			CTabFolder.viewStack CTabItem { show-close: false }\
-			CTabFolder.viewStack CTabItem.selected { show-close: true }""", folder.getDisplay());
+			CTabFolder.viewStack CTabItem.selected { show-close: true }""");
 		engine.applyStyles(folder.getShell(), true);
 
 		folder.getShell().open();
@@ -448,6 +454,7 @@ public class CTabItemTest extends CSSSWTTestCase {
 	@Test
 	void testBackground() {
 		CTabFolder folder = createTestTabFolder("CTabItem { background-color: #0000ff }", false);
+		CSSEngine engine = css.getEngine();
 		assertEquals(new RGB(0, 0, 255), folder.getBackground().getRGB());
 
 		for (CTabItem item : folder.getItems()) {
@@ -469,7 +476,7 @@ public class CTabItemTest extends CSSSWTTestCase {
 			colour = "#00ff00";
 		}
 
-		CSSEngine engine = createEngine("CTabItem { background-color: " + colour + " }", folder.getDisplay());
+		CSSEngine engine = css.createEngine("CTabItem { background-color: " + colour + " }");
 		engine.applyStyles(folder, true);
 
 		assertEquals(rgb, folder.getBackground().getRGB());
@@ -484,6 +491,7 @@ public class CTabItemTest extends CSSSWTTestCase {
 	@Test
 	void testSelectionBackground() {
 		CTabFolder folder = createTestTabFolder("CTabItem:selected { background-color: #00ff00 }", false);
+		CSSEngine engine = css.getEngine();
 		assertEquals(new RGB(0, 255, 0), folder.getSelectionBackground().getRGB());
 
 		for (CTabItem item : folder.getItems()) {
@@ -494,6 +502,7 @@ public class CTabItemTest extends CSSSWTTestCase {
 	@Test
 	void testForeground() {
 		CTabFolder folder = createTestTabFolder("CTabItem { color: #0000ff }", false);
+		CSSEngine engine = css.getEngine();
 		assertEquals(new RGB(0, 0, 255), folder.getForeground().getRGB());
 
 		for (CTabItem item : folder.getItems()) {
@@ -516,7 +525,7 @@ public class CTabItemTest extends CSSSWTTestCase {
 			colour = "#00ff00";
 		}
 
-		CSSEngine engine = createEngine("CTabItem { color: " + colour + " }", folder.getDisplay());
+		CSSEngine engine = css.createEngine("CTabItem { color: " + colour + " }");
 		engine.applyStyles(folder, true);
 
 		assertEquals(rgb, folder.getForeground().getRGB());
@@ -531,6 +540,7 @@ public class CTabItemTest extends CSSSWTTestCase {
 	@Test
 	void testSelectionForeground() {
 		CTabFolder folder = createTestTabFolder("CTabItem:selected { color: #00ff00 }", false);
+		CSSEngine engine = css.getEngine();
 		assertEquals(new RGB(0, 255, 0), folder.getSelectionForeground().getRGB());
 
 		for (CTabItem item : folder.getItems()) {
@@ -541,6 +551,7 @@ public class CTabItemTest extends CSSSWTTestCase {
 	@Test
 	void testParent() {
 		CTabFolder folder = createTestTabFolder("CTabItem:selected { color: #00ff00 }", false);
+		CSSEngine engine = css.getEngine();
 		for (CTabItem item : folder.getItems()) {
 			CTabItemElement element = (CTabItemElement) engine.getElement(item);
 			assertNotNull(element.getParentNode());

--- a/tests/org.eclipse.e4.ui.tests.css.swt/src/org/eclipse/e4/ui/tests/css/swt/ColorDefinitionTest.java
+++ b/tests/org.eclipse.e4.ui.tests.css.swt/src/org/eclipse/e4/ui/tests/css/swt/ColorDefinitionTest.java
@@ -29,19 +29,23 @@ import org.eclipse.swt.SWT;
 import org.eclipse.swt.graphics.Color;
 import org.eclipse.swt.graphics.RGB;
 import org.eclipse.swt.widgets.Button;
+import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Label;
 import org.eclipse.swt.widgets.Shell;
 import org.eclipse.ui.internal.themes.ColorDefinition;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 import org.osgi.framework.FrameworkUtil;
 
-public class ColorDefinitionTest extends CSSSWTTestCase {
+public class ColorDefinitionTest {
 
+	@RegisterExtension
+	CssSwtEngine css = new CssSwtEngine();
 
 	@Test
 	void testColorDefinition() {
 		//given
-		CSSEngine engine = createEngine("ColorDefinition#ACTIVE_HYPERLINK_COLOR{color: green}", display);
+		CSSEngine engine = css.createEngine("ColorDefinition#ACTIVE_HYPERLINK_COLOR{color: green}");
 		ColorDefinition definition = colorDefinition("ACTIVE_HYPERLINK_COLOR", "name", "categoryId", "description");
 
 		assertEquals(new RGB(0, 0, 0), definition.getValue());
@@ -62,8 +66,8 @@ public class ColorDefinitionTest extends CSSSWTTestCase {
 	@Test
 	void testColorDefinitionWhenNameCategoryIdAndDescriptionOverridden() {
 		// given
-		CSSEngine engine = createEngine("ColorDefinition#ACTIVE_HYPERLINK_COLOR{color: green;" +
-				"label:'nameOverridden'; category:'#categoryIdOverridden'; description: 'descriptionOverridden'}", display);
+		CSSEngine engine = css.createEngine("ColorDefinition#ACTIVE_HYPERLINK_COLOR{color: green;" +
+				"label:'nameOverridden'; category:'#categoryIdOverridden'; description: 'descriptionOverridden'}");
 		ColorDefinition definition = colorDefinition("ACTIVE_HYPERLINK_COLOR","name", "categoryId", "description");
 
 		assertEquals(new RGB(0, 0, 0), definition.getValue());
@@ -84,7 +88,7 @@ public class ColorDefinitionTest extends CSSSWTTestCase {
 	@Test
 	void testColorDefinitionWhenDefinitionStylesheetNotFound() {
 		//given
-		CSSEngine engine = createEngine("ColorDefinition#ACTIVE_HYPERLINK_COLOR{color: green}", display);
+		CSSEngine engine = css.createEngine("ColorDefinition#ACTIVE_HYPERLINK_COLOR{color: green}");
 		ColorDefinition definition = colorDefinition("color definition uniqueId without matching stylesheet",
 				"name", "categoryId", "description");
 
@@ -105,7 +109,8 @@ public class ColorDefinitionTest extends CSSSWTTestCase {
 		//given
 		registerColorProviderWith("ACTIVE_HYPERLINK_COLOR", new RGB(255, 0, 0));
 
-		CSSEngine engine = createEngine("Label {background-color: '#ACTIVE_HYPERLINK_COLOR'}", display);
+		Display display = css.getDisplay();
+		CSSEngine engine = css.createEngine("Label {background-color: '#ACTIVE_HYPERLINK_COLOR'}");
 
 		Shell shell = new Shell(display, SWT.SHELL_TRIM);
 		Label label = new Label(shell, SWT.NONE);
@@ -123,7 +128,8 @@ public class ColorDefinitionTest extends CSSSWTTestCase {
 
 	@Test
 	void testUnset() {
-		CSSEngine engine = createEngine("Button {background-color: unset;}", display);
+		Display display = css.getDisplay();
+		CSSEngine engine = css.createEngine("Button {background-color: unset;}");
 
 		Shell shell = new Shell(display, SWT.SHELL_TRIM);
 		Button button = new Button(shell, SWT.NONE);
@@ -147,8 +153,8 @@ public class ColorDefinitionTest extends CSSSWTTestCase {
 	@Test
 	void testSetColorDefinitionWithSystemColor() {
 		// given
-		CSSEngine engine = createEngine("ColorDefinition#ACTIVE_HYPERLINK_COLOR{color: '#COLOR-LIST-SELECTION'}",
-				display);
+		Display display = css.getDisplay();
+		CSSEngine engine = css.createEngine("ColorDefinition#ACTIVE_HYPERLINK_COLOR{color: '#COLOR-LIST-SELECTION'}");
 		ColorDefinition definition = colorDefinition("ACTIVE_HYPERLINK_COLOR", "name", "categoryId", "description");
 
 		assertEquals(new RGB(0, 0, 0), definition.getValue());

--- a/tests/org.eclipse.e4.ui.tests.css.swt/src/org/eclipse/e4/ui/tests/css/swt/CompositeTest.java
+++ b/tests/org.eclipse.e4.ui.tests.css.swt/src/org/eclipse/e4/ui/tests/css/swt/CompositeTest.java
@@ -13,19 +13,27 @@
  *******************************************************************************/
 package org.eclipse.e4.ui.tests.css.swt;
 
+import static org.eclipse.e4.ui.tests.css.swt.CssSwtEngine.BLUE;
+import static org.eclipse.e4.ui.tests.css.swt.CssSwtEngine.RED;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import org.eclipse.e4.ui.css.core.engine.CSSEngine;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.layout.FillLayout;
 import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Shell;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
-public class CompositeTest extends CSSSWTTestCase {
+public class CompositeTest {
 
+	@RegisterExtension
+	CssSwtEngine css = new CssSwtEngine();
 
 	protected Composite createTestComposite(String styleSheet) {
-		engine = createEngine(styleSheet, display);
+		Display display = css.getDisplay();
+		CSSEngine engine = css.createEngine(styleSheet);
 
 		// Create widgets
 		Shell shell = new Shell(display, SWT.SHELL_TRIM);
@@ -43,7 +51,8 @@ public class CompositeTest extends CSSSWTTestCase {
 	}
 
 	protected Composite createTestCompositeAsInnerClass(String styleSheet) {
-		engine = createEngine(styleSheet, display);
+		Display display = css.getDisplay();
+		CSSEngine engine = css.createEngine(styleSheet);
 
 		// Create widgets
 		Shell shell = new Shell(display, SWT.SHELL_TRIM);

--- a/tests/org.eclipse.e4.ui.tests.css.swt/src/org/eclipse/e4/ui/tests/css/swt/CssSwtEngine.java
+++ b/tests/org.eclipse.e4.ui.tests.css.swt/src/org/eclipse/e4/ui/tests/css/swt/CssSwtEngine.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2016 IBM Corporation and others.
+ * Copyright (c) 2026 Lars Vogel and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -9,8 +9,7 @@
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
- *     IBM Corporation - initial API and implementation
- *     Thibault Le Ouay <thibaultleouay@gmail.com> - Bug 443094
+ *     Lars Vogel <Lars.Vogel@vogella.com> - initial API and implementation
  *******************************************************************************/
 package org.eclipse.e4.ui.tests.css.swt;
 
@@ -28,20 +27,32 @@ import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Label;
 import org.eclipse.swt.widgets.Shell;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.AfterEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
 
-public class CSSSWTTestCase {
+/**
+ * JUnit 5 extension that provides a shared {@link Display}, creates SWT CSS
+ * engines from a style sheet, offers small widget helpers, and disposes any
+ * open shells after each test.
+ */
+public class CssSwtEngine implements AfterEachCallback {
 	static final RGB RED = new RGB(255, 0, 0);
 	static final RGB GREEN = new RGB(0, 255, 0);
 	static final RGB BLUE = new RGB(0, 0, 255);
 	static final RGB WHITE = new RGB(255, 255, 255);
 
+	private final Display display = Display.getDefault();
+	private CSSEngine engine;
 
-	protected Display display;
-	protected CSSEngine engine;
+	public Display getDisplay() {
+		return display;
+	}
 
-	public CSSEngine createEngine(String styleSheet, Display display) {
+	public CSSEngine getEngine() {
+		return engine;
+	}
+
+	public CSSEngine createEngine(String styleSheet) {
 		engine = new CSSSWTEngineImpl(display);
 
 		engine.setErrorHandler(e -> fail(e.getMessage()));
@@ -52,27 +63,11 @@ public class CSSSWTTestCase {
 			fail(e.getMessage());
 		}
 		return engine;
-
 	}
 
-	@BeforeEach
-	public void setUp() {
-		display = Display.getDefault();
-	}
+	public Label createTestLabel(String styleSheet) {
+		engine = createEngine(styleSheet);
 
-	@AfterEach
-	public void tearDown() {
-		if (!display.isDisposed()) {
-			for (Shell shell : display.getShells()) {
-				shell.dispose();
-			}
-		}
-	}
-
-	protected Label createTestLabel(String styleSheet) {
-		engine = createEngine(styleSheet, display);
-
-		// Create widgets
 		Shell shell = new Shell(display, SWT.SHELL_TRIM);
 		FillLayout layout = new FillLayout();
 		shell.setLayout(layout);
@@ -83,10 +78,18 @@ public class CSSSWTTestCase {
 		Label labelToTest = new Label(panel, SWT.NONE);
 		labelToTest.setText("Some label text");
 
-		// Apply styles
 		engine.applyStyles(labelToTest, true);
 
 		shell.pack();
 		return labelToTest;
+	}
+
+	@Override
+	public void afterEach(ExtensionContext context) {
+		if (!display.isDisposed()) {
+			for (Shell shell : display.getShells()) {
+				shell.dispose();
+			}
+		}
 	}
 }

--- a/tests/org.eclipse.e4.ui.tests.css.swt/src/org/eclipse/e4/ui/tests/css/swt/DescendentTest.java
+++ b/tests/org.eclipse.e4.ui.tests.css.swt/src/org/eclipse/e4/ui/tests/css/swt/DescendentTest.java
@@ -16,16 +16,22 @@ package org.eclipse.e4.ui.tests.css.swt;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import org.eclipse.e4.ui.css.core.engine.CSSEngine;
 import org.eclipse.e4.ui.css.swt.dom.WidgetElement;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.graphics.RGB;
 import org.eclipse.swt.layout.FillLayout;
 import org.eclipse.swt.widgets.Button;
 import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Shell;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
-public class DescendentTest extends CSSSWTTestCase {
+public class DescendentTest {
+
+	@RegisterExtension
+	CssSwtEngine css = new CssSwtEngine();
 
 	static final RGB RED = new RGB(255, 0, 0);
 	static final RGB GREEN = new RGB(0, 255, 0);
@@ -35,7 +41,8 @@ public class DescendentTest extends CSSSWTTestCase {
 
 	protected Button[] createTestWidgets(String styleSheet) {
 
-		engine = createEngine(styleSheet, display);
+		Display display = css.getDisplay();
+		CSSEngine engine = css.createEngine(styleSheet);
 
 		// Create widgets
 		Shell shell = new Shell(display, SWT.SHELL_TRIM);
@@ -68,7 +75,7 @@ public class DescendentTest extends CSSSWTTestCase {
 		Button buttonC = buttons[2];
 
 		WidgetElement.setCSSClass(buttonA.getParent(), "special");
-		engine.applyStyles(buttonA.getShell(), true);
+		css.getEngine().applyStyles(buttonA.getShell(), true);
 
 		assertEquals(RED, buttonA.getBackground().getRGB());
 		assertEquals(GREEN, buttonB.getBackground().getRGB());
@@ -77,7 +84,7 @@ public class DescendentTest extends CSSSWTTestCase {
 		WidgetElement.setCSSClass(buttonA.getParent(), "extraordinary");
 		WidgetElement.setID(buttonB.getParent(), "parent");
 
-		engine.applyStyles(buttonA.getShell(), true);
+		css.getEngine().applyStyles(buttonA.getShell(), true);
 		assertEquals(WHITE, buttonA.getBackground().getRGB());
 		assertEquals(BLACK, buttonB.getBackground().getRGB());
 	}

--- a/tests/org.eclipse.e4.ui.tests.css.swt/src/org/eclipse/e4/ui/tests/css/swt/FontDefinitionTest.java
+++ b/tests/org.eclipse.e4.ui.tests.css.swt/src/org/eclipse/e4/ui/tests/css/swt/FontDefinitionTest.java
@@ -24,24 +24,29 @@ import static org.mockito.Mockito.mock;
 
 import java.util.Hashtable;
 
+import org.eclipse.e4.ui.css.core.engine.CSSEngine;
 import org.eclipse.e4.ui.internal.css.swt.definition.IColorAndFontProvider;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.graphics.Font;
 import org.eclipse.swt.graphics.FontData;
+import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Label;
 import org.eclipse.swt.widgets.Shell;
 import org.eclipse.ui.internal.themes.FontDefinition;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 import org.osgi.framework.FrameworkUtil;
 
-public class FontDefinitionTest extends CSSSWTTestCase {
+public class FontDefinitionTest {
+
+	@RegisterExtension
+	CssSwtEngine css = new CssSwtEngine();
 
 	@Test
 	void testFontDefinition() {
 		//given
-		engine = createEngine(
-				"FontDefinition#org-eclipse-jface-bannerfont {font-family: 'Times';font-size: 12;font-style: italic;font-weight: bold;}",
-				display);
+		CSSEngine engine = css.createEngine(
+				"FontDefinition#org-eclipse-jface-bannerfont {font-family: 'Times';font-size: 12;font-style: italic;font-weight: bold;}");
 		FontDefinition definition = fontDefinition("org.eclipse.jface.bannerfont", "name", "categoryId","description");
 
 		assertNull(definition.getValue());
@@ -64,10 +69,10 @@ public class FontDefinitionTest extends CSSSWTTestCase {
 	@Test
 	void testFontDefinitionWhenNameCategoryIdAndDescriptionOverridden() {
 		// given
-		engine = createEngine(
+		CSSEngine engine = css.createEngine(
 				"FontDefinition#org-eclipse-jface-bannerfont {font-family: 'Times';font-size: 12;font-style: italic; font-weight: bold;"
 						+
-						" label:'nameOverridden'; category: '#categoryIdOverridden'; description: 'descriptionOverridden'}", display);
+						" label:'nameOverridden'; category: '#categoryIdOverridden'; description: 'descriptionOverridden'}");
 		FontDefinition definition = fontDefinition("org.eclipse.jface.bannerfont", "name", "categoryId", "description");
 
 		assertNull(definition.getValue());
@@ -90,9 +95,8 @@ public class FontDefinitionTest extends CSSSWTTestCase {
 	@Test
 	void testFontDefinitionWhenDefinitionStylesheetNotFound() {
 		//given
-		engine = createEngine(
-				"FontDefinition#org-eclipse-jface-bannerfont {font-family: 'Times';font-size: 12;font-style: italic;}",
-				display);
+		CSSEngine engine = css.createEngine(
+				"FontDefinition#org-eclipse-jface-bannerfont {font-family: 'Times';font-size: 12;font-style: italic;}");
 		FontDefinition definition = fontDefinition("font definition uniqueId without matching stylesheet", "name", "categoryId", "description");
 
 		assertNull(definition.getValue());
@@ -111,7 +115,8 @@ public class FontDefinitionTest extends CSSSWTTestCase {
 		//given
 		registerFontProviderWith("org.eclipse.jface.bannerfont", new FontData("Times", 12, SWT.ITALIC));
 
-		engine = createEngine("Label {font-family: '#org-eclipse-jface-bannerfont'}", display);
+		Display display = css.getDisplay();
+		CSSEngine engine = css.createEngine("Label {font-family: '#org-eclipse-jface-bannerfont'}");
 
 		Shell shell = new Shell(display, SWT.SHELL_TRIM);
 		Label label = new Label(shell, SWT.NONE);

--- a/tests/org.eclipse.e4.ui.tests.css.swt/src/org/eclipse/e4/ui/tests/css/swt/GradientTest.java
+++ b/tests/org.eclipse.e4.ui.tests.css.swt/src/org/eclipse/e4/ui/tests/css/swt/GradientTest.java
@@ -19,6 +19,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.lang.reflect.Field;
 
+import org.eclipse.e4.ui.css.core.engine.CSSEngine;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.custom.CTabFolder;
 import org.eclipse.swt.custom.CTabItem;
@@ -26,8 +27,10 @@ import org.eclipse.swt.graphics.Color;
 import org.eclipse.swt.graphics.RGB;
 import org.eclipse.swt.layout.FillLayout;
 import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Shell;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 /**
  * Test gradient capabilities.
@@ -36,7 +39,10 @@ import org.junit.jupiter.api.Test;
  * to test it's doing the right thing.
  */
 
-public class GradientTest extends CSSSWTTestCase {
+public class GradientTest {
+
+	@RegisterExtension
+	CssSwtEngine css = new CssSwtEngine();
 
 	static final RGB RED = new RGB(255, 0, 0);
 	static final RGB GREEN = new RGB(0, 255, 0);
@@ -44,7 +50,8 @@ public class GradientTest extends CSSSWTTestCase {
 	static final RGB WHITE = new RGB(255, 255, 255);
 
 	protected CTabFolder createTestCTabFolder(String styleSheet) {
-		engine = createEngine(styleSheet, display);
+		Display display = css.getDisplay();
+		CSSEngine engine = css.createEngine(styleSheet);
 
 		// Create widgets
 		Shell shell = new Shell(display, SWT.SHELL_TRIM);

--- a/tests/org.eclipse.e4.ui.tests.css.swt/src/org/eclipse/e4/ui/tests/css/swt/IEclipsePreferencesPseudoKeyTest.java
+++ b/tests/org.eclipse.e4.ui.tests.css.swt/src/org/eclipse/e4/ui/tests/css/swt/IEclipsePreferencesPseudoKeyTest.java
@@ -17,24 +17,28 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.eclipse.core.internal.preferences.EclipsePreferences;
 import org.eclipse.core.runtime.preferences.IEclipsePreferences;
+import org.eclipse.e4.ui.css.core.engine.CSSEngine;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 /**
  * Locks in the {@code IEclipsePreferences#node:pseudo} selector form used by
  * shipped themes. See Bug 466075.
  */
-public class IEclipsePreferencesPseudoKeyTest extends CSSSWTTestCase {
+public class IEclipsePreferencesPseudoKeyTest {
+
+	@RegisterExtension
+	CssSwtEngine css = new CssSwtEngine();
 
 	@Test
 	void testPseudoSelectorMatchesAndWritesPreferenceValue() {
 		IEclipsePreferences preferences = new EclipsePreferences(null, "org.eclipse.jdt.ui") {};
 
-		engine = createEngine(
+		CSSEngine engine = css.createEngine(
 				"""
 					IEclipsePreferences#org-eclipse-jdt-ui:org-eclipse-ui-themes {\
 					preferences: 'semanticHighlighting.abstractClass.color=128,255,0'\
-					}""",
-				display);
+					}""");
 		engine.applyStyles(preferences, false);
 
 		// Bug 466075
@@ -47,15 +51,14 @@ public class IEclipsePreferencesPseudoKeyTest extends CSSSWTTestCase {
 		// contribute to the same preference node via different pseudo tags.
 		IEclipsePreferences preferences = new EclipsePreferences(null, "org.eclipse.ui.workbench") {};
 
-		engine = createEngine(
+		CSSEngine engine = css.createEngine(
 				"""
 					IEclipsePreferences#org-eclipse-ui-workbench:org-eclipse-ui-editors {\
 					preferences: 'org.eclipse.ui.editors.inlineAnnotationColor=155,155,155'\
 					}\
 					IEclipsePreferences#org-eclipse-ui-workbench:org-eclipse-ui-themes {\
 					preferences: 'ERROR_COLOR=247,68,117'\
-					}""",
-				display);
+					}""");
 		engine.applyStyles(preferences, false);
 
 		assertEquals("155,155,155", preferences.get("org.eclipse.ui.editors.inlineAnnotationColor", null));
@@ -71,15 +74,14 @@ public class IEclipsePreferencesPseudoKeyTest extends CSSSWTTestCase {
 		// rule wins. This matches standard CSS source-order tiebreak.
 		IEclipsePreferences preferences = new EclipsePreferences(null, "org.eclipse.jdt.ui") {};
 
-		engine = createEngine(
+		CSSEngine engine = css.createEngine(
 				"""
 					IEclipsePreferences#org-eclipse-jdt-ui:org-eclipse-ui-themes {\
 					preferences: 'semanticHighlighting.abstractClass.color=128,255,0'\
 					}\
 					IEclipsePreferences#org-eclipse-jdt-ui:org-eclipse-ui-themes {\
 					preferences: 'semanticHighlighting.abstractClass.color=255,0,0'\
-					}""",
-				display);
+					}""");
 		engine.applyStyles(preferences, false);
 
 		assertEquals("255,0,0", preferences.get("semanticHighlighting.abstractClass.color", null));

--- a/tests/org.eclipse.e4.ui.tests.css.swt/src/org/eclipse/e4/ui/tests/css/swt/IEclipsePreferencesTest.java
+++ b/tests/org.eclipse.e4.ui.tests.css.swt/src/org/eclipse/e4/ui/tests/css/swt/IEclipsePreferencesTest.java
@@ -18,23 +18,28 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.eclipse.core.internal.preferences.EclipsePreferences;
 import org.eclipse.core.runtime.preferences.IEclipsePreferences;
+import org.eclipse.e4.ui.css.core.engine.CSSEngine;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
-public class IEclipsePreferencesTest extends CSSSWTTestCase {
+public class IEclipsePreferencesTest {
+
+	@RegisterExtension
+	CssSwtEngine css = new CssSwtEngine();
 
 	@Test
 	void testIEclipsePreferences() {
 		// given
 		IEclipsePreferences preferences = new EclipsePreferences(null, "org.eclipse.jdt.ui") {};
 
-		engine = createEngine(
+		CSSEngine engine = css.createEngine(
 				"""
 					IEclipsePreferences#org-eclipse-jdt-ui{preferences:\
 					'semanticHighlighting.abstractClass.color=128,255,0',\
 					'java_bracket=0,255,255',\
 					'java_bracket_italic=true',\
 					'java_bracket_underline='\
-					}""", display);
+					}""");
 		// when
 		engine.applyStyles(preferences, false);
 

--- a/tests/org.eclipse.e4.ui.tests.css.swt/src/org/eclipse/e4/ui/tests/css/swt/IdClassLabelColorTest.java
+++ b/tests/org.eclipse.e4.ui.tests.css.swt/src/org/eclipse/e4/ui/tests/css/swt/IdClassLabelColorTest.java
@@ -16,20 +16,26 @@ package org.eclipse.e4.ui.tests.css.swt;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import org.eclipse.e4.ui.css.core.engine.CSSEngine;
 import org.eclipse.e4.ui.css.swt.dom.WidgetElement;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.graphics.RGB;
 import org.eclipse.swt.layout.FillLayout;
 import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Label;
 import org.eclipse.swt.widgets.Shell;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 /*
  * Tests the CSS class and Id rules
  */
 
-public class IdClassLabelColorTest extends CSSSWTTestCase {
+public class IdClassLabelColorTest {
+
+	@RegisterExtension
+	CssSwtEngine css = new CssSwtEngine();
 
 	static final RGB RED = new RGB(255, 0, 0);
 	static final RGB GREEN = new RGB(0, 255, 0);
@@ -38,9 +44,9 @@ public class IdClassLabelColorTest extends CSSSWTTestCase {
 	static final String CSS_CLASS_NAME = "makeItGreenClass";
 	static final String CSS_ID = "makeItBlueID";
 
-	@Override
 	protected Label createTestLabel(String styleSheet) {
-		engine = createEngine(styleSheet, display);
+		Display display = css.getDisplay();
+		CSSEngine engine = css.createEngine(styleSheet);
 
 		// Create widgets
 		Shell shell = new Shell(display, SWT.SHELL_TRIM);

--- a/tests/org.eclipse.e4.ui.tests.css.swt/src/org/eclipse/e4/ui/tests/css/swt/InheritTest.java
+++ b/tests/org.eclipse.e4.ui.tests.css.swt/src/org/eclipse/e4/ui/tests/css/swt/InheritTest.java
@@ -16,18 +16,23 @@ package org.eclipse.e4.ui.tests.css.swt;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import org.eclipse.e4.ui.css.core.engine.CSSEngine;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.graphics.Color;
 import org.eclipse.swt.graphics.RGB;
 import org.eclipse.swt.layout.FillLayout;
 import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Label;
 import org.eclipse.swt.widgets.Shell;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
-public class InheritTest extends CSSSWTTestCase {
+public class InheritTest {
 
+	@RegisterExtension
+	CssSwtEngine css = new CssSwtEngine();
 
 	private Color redColor;
 
@@ -36,11 +41,7 @@ public class InheritTest extends CSSSWTTestCase {
 	static final RGB RED = new RGB(255, 0, 0);
 
 	@BeforeEach
-	@Override
 	public void setUp() {
-		super.setUp();
-
-
 		redColor = new Color(RED);
 	}
 
@@ -102,7 +103,8 @@ public class InheritTest extends CSSSWTTestCase {
 	 */
 	private Label createTestLabel(String styleSheet,
 			boolean setCompositeBackgroundExplicitly) {
-		engine = createEngine(styleSheet, display);
+		Display display = css.getDisplay();
+		CSSEngine engine = css.createEngine(styleSheet);
 
 		// Create widgets
 		Shell shell = new Shell(display, SWT.SHELL_TRIM);

--- a/tests/org.eclipse.e4.ui.tests.css.swt/src/org/eclipse/e4/ui/tests/css/swt/InnerClassElementTest.java
+++ b/tests/org.eclipse.e4.ui.tests.css.swt/src/org/eclipse/e4/ui/tests/css/swt/InnerClassElementTest.java
@@ -17,15 +17,20 @@ package org.eclipse.e4.ui.tests.css.swt;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import org.eclipse.e4.ui.css.core.engine.CSSEngine;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.layout.FillLayout;
 import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Label;
 import org.eclipse.swt.widgets.Shell;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
-public class InnerClassElementTest extends CSSSWTTestCase {
+public class InnerClassElementTest {
 
+	@RegisterExtension
+	CssSwtEngine css = new CssSwtEngine();
 
 	// create an inner class to address via CSS
 	static class CustomComposite extends Composite {
@@ -34,9 +39,9 @@ public class InnerClassElementTest extends CSSSWTTestCase {
 		}
 	}
 
-	@Override
 	protected Label createTestLabel(String styleSheet) {
-		engine = createEngine(styleSheet, display);
+		Display display = css.getDisplay();
+		CSSEngine engine = css.createEngine(styleSheet);
 
 		// Create widgets
 		Shell shell = new Shell(display, SWT.SHELL_TRIM);

--- a/tests/org.eclipse.e4.ui.tests.css.swt/src/org/eclipse/e4/ui/tests/css/swt/LabelTest.java
+++ b/tests/org.eclipse.e4.ui.tests.css.swt/src/org/eclipse/e4/ui/tests/css/swt/LabelTest.java
@@ -15,25 +15,31 @@
  *******************************************************************************/
 package org.eclipse.e4.ui.tests.css.swt;
 
+import static org.eclipse.e4.ui.tests.css.swt.CssSwtEngine.BLUE;
+import static org.eclipse.e4.ui.tests.css.swt.CssSwtEngine.RED;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.graphics.FontData;
 import org.eclipse.swt.widgets.Label;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
-public class LabelTest extends CSSSWTTestCase {
+public class LabelTest {
+
+	@RegisterExtension
+	CssSwtEngine css = new CssSwtEngine();
 
 	@Test
 	void testColor() {
-		Label labelToTest = createTestLabel("Label { background-color: #FF0000; color: #0000FF }");
+		Label labelToTest = css.createTestLabel("Label { background-color: #FF0000; color: #0000FF }");
 		assertEquals(RED, labelToTest.getBackground().getRGB());
 		assertEquals(BLUE, labelToTest.getForeground().getRGB());
 	}
 
 	@Test
 	void testFontRegular() {
-		Label labelToTest = createTestLabel("Label { font: Verdana 16px }");
+		Label labelToTest = css.createTestLabel("Label { font: Verdana 16px }");
 		assertEquals(1, labelToTest.getFont().getFontData().length);
 		FontData fontData = labelToTest.getFont().getFontData()[0];
 		assertEquals("Verdana", fontData.getName());
@@ -43,7 +49,7 @@ public class LabelTest extends CSSSWTTestCase {
 
 	@Test
 	void testFontBold() {
-		Label labelToTest = createTestLabel("Label { font: Arial 12px; font-weight: bold }");
+		Label labelToTest = css.createTestLabel("Label { font: Arial 12px; font-weight: bold }");
 		assertEquals(1, labelToTest.getFont().getFontData().length);
 		FontData fontData = labelToTest.getFont().getFontData()[0];
 		assertEquals("Arial", fontData.getName());
@@ -53,7 +59,7 @@ public class LabelTest extends CSSSWTTestCase {
 
 	@Test
 	void testFontItalic() {
-		Label labelToTest = createTestLabel("Label { font-style: italic }");
+		Label labelToTest = css.createTestLabel("Label { font-style: italic }");
 		assertEquals(1, labelToTest.getFont().getFontData().length);
 		FontData fontData = labelToTest.getFont().getFontData()[0];
 		assertEquals(SWT.ITALIC, fontData.getStyle());
@@ -61,23 +67,23 @@ public class LabelTest extends CSSSWTTestCase {
 
 	@Test
 	void testAlignment() {
-		Label labelToTest = createTestLabel("Label { swt-alignment: right }");
+		Label labelToTest = css.createTestLabel("Label { swt-alignment: right }");
 		assertEquals(SWT.RIGHT, labelToTest.getAlignment());
 
-		labelToTest = createTestLabel("Label { swt-alignment: center; }");
+		labelToTest = css.createTestLabel("Label { swt-alignment: center; }");
 		assertEquals(SWT.CENTER, labelToTest.getAlignment());
 
-		labelToTest = createTestLabel("Label { swt-alignment: left; }");
+		labelToTest = css.createTestLabel("Label { swt-alignment: left; }");
 		assertEquals(SWT.LEFT, labelToTest.getAlignment());
 
 	}
 
 	@Test
 	void testAlignment2() {
-		Label labelToTest = createTestLabel("Label { swt-alignment: trail }");
+		Label labelToTest = css.createTestLabel("Label { swt-alignment: trail }");
 		assertEquals(SWT.TRAIL, labelToTest.getAlignment());
 
-		labelToTest = createTestLabel("Label { swt-alignment: lead; }");
+		labelToTest = css.createTestLabel("Label { swt-alignment: lead; }");
 		assertEquals(SWT.LEAD, labelToTest.getAlignment());
 	}
 }

--- a/tests/org.eclipse.e4.ui.tests.css.swt/src/org/eclipse/e4/ui/tests/css/swt/LinkTest.java
+++ b/tests/org.eclipse.e4.ui.tests.css.swt/src/org/eclipse/e4/ui/tests/css/swt/LinkTest.java
@@ -14,19 +14,29 @@
  *******************************************************************************/
 package org.eclipse.e4.ui.tests.css.swt;
 
+import static org.eclipse.e4.ui.tests.css.swt.CssSwtEngine.BLUE;
+import static org.eclipse.e4.ui.tests.css.swt.CssSwtEngine.GREEN;
+import static org.eclipse.e4.ui.tests.css.swt.CssSwtEngine.RED;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import org.eclipse.e4.ui.css.core.engine.CSSEngine;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.layout.FillLayout;
 import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Link;
 import org.eclipse.swt.widgets.Shell;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
-public class LinkTest extends CSSSWTTestCase {
+public class LinkTest {
+
+	@RegisterExtension
+	CssSwtEngine css = new CssSwtEngine();
 
 	private Link createTestLink(String styleSheet) {
-		engine = createEngine(styleSheet, display);
+		Display display = css.getDisplay();
+		CSSEngine engine = css.createEngine(styleSheet);
 
 		// Create widgets
 		Shell shell = new Shell(display, SWT.SHELL_TRIM);

--- a/tests/org.eclipse.e4.ui.tests.css.swt/src/org/eclipse/e4/ui/tests/css/swt/MarginTest.java
+++ b/tests/org.eclipse.e4.ui.tests.css.swt/src/org/eclipse/e4/ui/tests/css/swt/MarginTest.java
@@ -17,6 +17,7 @@ package org.eclipse.e4.ui.tests.css.swt;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
 
+import org.eclipse.e4.ui.css.core.engine.CSSEngine;
 import org.eclipse.e4.ui.css.swt.CSSSWTConstants;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.graphics.RGB;
@@ -24,10 +25,15 @@ import org.eclipse.swt.layout.GridLayout;
 import org.eclipse.swt.widgets.Button;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;
+import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Shell;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
-public class MarginTest extends CSSSWTTestCase {
+public class MarginTest {
+
+	@RegisterExtension
+	CssSwtEngine css = new CssSwtEngine();
 
 	private static final RGB RED = new RGB(255, 0, 0);
 
@@ -37,7 +43,8 @@ public class MarginTest extends CSSSWTTestCase {
 	private static final int LEFT = 3;
 
 	protected Control createTestControl(String styleSheet) {
-		engine = createEngine(styleSheet, display);
+		Display display = css.getDisplay();
+		CSSEngine engine = css.createEngine(styleSheet);
 
 		// Create widgets
 		Shell shell = new Shell(display, SWT.SHELL_TRIM);
@@ -62,7 +69,8 @@ public class MarginTest extends CSSSWTTestCase {
 	}
 
 	protected Control createBadControlNoLayout(String styleSheet) {
-		engine = createEngine(styleSheet, display);
+		Display display = css.getDisplay();
+		CSSEngine engine = css.createEngine(styleSheet);
 
 		Shell shell = new Shell(display, SWT.SHELL_TRIM);
 		Composite panel = new Composite(shell, SWT.NONE);
@@ -76,7 +84,8 @@ public class MarginTest extends CSSSWTTestCase {
 	}
 
 	protected Control createBadControlNoComposite(String styleSheet) {
-		engine = createEngine(styleSheet, display);
+		Display display = css.getDisplay();
+		CSSEngine engine = css.createEngine(styleSheet);
 
 		Shell shell = new Shell(display, SWT.SHELL_TRIM);
 		//No composite
@@ -88,7 +97,8 @@ public class MarginTest extends CSSSWTTestCase {
 	}
 
 	protected Control createBadControlNoKey(String styleSheet) {
-		engine = createEngine(styleSheet, display);
+		Display display = css.getDisplay();
+		CSSEngine engine = css.createEngine(styleSheet);
 
 		// Create widgets
 		Shell shell = new Shell(display, SWT.SHELL_TRIM);

--- a/tests/org.eclipse.e4.ui.tests.css.swt/src/org/eclipse/e4/ui/tests/css/swt/PaddingTest.java
+++ b/tests/org.eclipse.e4.ui.tests.css.swt/src/org/eclipse/e4/ui/tests/css/swt/PaddingTest.java
@@ -17,6 +17,7 @@ import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import org.eclipse.e4.ui.css.core.engine.CSSEngine;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.custom.CTabFolder;
 import org.eclipse.swt.custom.CTabFolderRenderer;
@@ -24,8 +25,10 @@ import org.eclipse.swt.graphics.Rectangle;
 import org.eclipse.swt.layout.FillLayout;
 import org.eclipse.swt.widgets.Button;
 import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Shell;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 /**
  * Tests for {@code CSSPropertyPaddingSWTHandler}. Padding only takes effect
@@ -35,7 +38,10 @@ import org.junit.jupiter.api.Test;
  * reflection. The default {@link CTabFolderRenderer} does not expose those
  * methods, so the test installs a capturing subclass that does.
  */
-public class PaddingTest extends CSSSWTTestCase {
+public class PaddingTest {
+
+	@RegisterExtension
+	CssSwtEngine css = new CssSwtEngine();
 
 	/**
 	 * Captures arguments passed to the reflective {@code setPadding} call.
@@ -63,7 +69,8 @@ public class PaddingTest extends CSSSWTTestCase {
 	}
 
 	private CapturingRenderer applyToCapturingFolder(String styleSheet) {
-		engine = createEngine(styleSheet, display);
+		Display display = css.getDisplay();
+		CSSEngine engine = css.createEngine(styleSheet);
 		Shell shell = new Shell(display, SWT.SHELL_TRIM);
 		shell.setLayout(new FillLayout());
 		CTabFolder folder = new CTabFolder(shell, SWT.NONE);
@@ -124,7 +131,8 @@ public class PaddingTest extends CSSSWTTestCase {
 		// setPadding helper only acts on CTabFolder, every other widget is a
 		// no-op.
 		assertDoesNotThrow(() -> {
-			engine = createEngine("Button { padding: 10px }", display);
+			Display display = css.getDisplay();
+			CSSEngine engine = css.createEngine("Button { padding: 10px }");
 			Shell shell = new Shell(display, SWT.SHELL_TRIM);
 			shell.setLayout(new FillLayout());
 			Composite panel = new Composite(shell, SWT.NONE);
@@ -141,7 +149,8 @@ public class PaddingTest extends CSSSWTTestCase {
 		// is caught and swallowed. Locks in this behaviour: applying padding
 		// to a folder with the default renderer must not surface an error.
 		assertDoesNotThrow(() -> {
-			engine = createEngine("CTabFolder { padding: 10px 20px }", display);
+			Display display = css.getDisplay();
+			CSSEngine engine = css.createEngine("CTabFolder { padding: 10px 20px }");
 			Shell shell = new Shell(display, SWT.SHELL_TRIM);
 			shell.setLayout(new FillLayout());
 			new CTabFolder(shell, SWT.NONE);

--- a/tests/org.eclipse.e4.ui.tests.css.swt/src/org/eclipse/e4/ui/tests/css/swt/ShellActiveTest.java
+++ b/tests/org.eclipse.e4.ui.tests.css.swt/src/org/eclipse/e4/ui/tests/css/swt/ShellActiveTest.java
@@ -16,20 +16,27 @@ package org.eclipse.e4.ui.tests.css.swt;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import org.eclipse.e4.ui.css.core.engine.CSSEngine;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.graphics.RGB;
+import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Shell;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 @Disabled("see bug #273582")
-public class ShellActiveTest extends CSSSWTTestCase {
+public class ShellActiveTest {
+
+	@RegisterExtension
+	CssSwtEngine css = new CssSwtEngine();
 
 	static final RGB RED = new RGB(255, 0, 0);
 	static final RGB BLUE = new RGB(0, 0, 255);
 
 	protected Shell createShell(String styleSheet) {
-		createEngine(styleSheet, display);
+		Display display = css.getDisplay();
+		CSSEngine engine = css.createEngine(styleSheet);
 
 		// Create widgets
 		Shell shell = new Shell(display, SWT.NONE);

--- a/tests/org.eclipse.e4.ui.tests.css.swt/src/org/eclipse/e4/ui/tests/css/swt/ShellTest.java
+++ b/tests/org.eclipse.e4.ui.tests.css.swt/src/org/eclipse/e4/ui/tests/css/swt/ShellTest.java
@@ -19,23 +19,30 @@ import static org.junit.jupiter.api.Assertions.assertNotSame;
 
 import java.util.HashSet;
 
+import org.eclipse.e4.ui.css.core.engine.CSSEngine;
 import org.eclipse.e4.ui.css.swt.dom.WidgetElement;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.graphics.FontData;
 import org.eclipse.swt.graphics.RGB;
 import org.eclipse.swt.layout.FillLayout;
 import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Shell;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
-public class ShellTest extends CSSSWTTestCase {
+public class ShellTest {
+
+	@RegisterExtension
+	CssSwtEngine css = new CssSwtEngine();
 
 	static final RGB RED = new RGB(255, 0, 0);
 	static final RGB GREEN = new RGB(0, 255, 0);
 	static final RGB BLUE = new RGB(0, 0, 255);
 
 	protected Shell createTestShell(String styleSheet) {
-		engine = createEngine(styleSheet, display);
+		Display display = css.getDisplay();
+		CSSEngine engine = css.createEngine(styleSheet);
 
 		// Create widgets
 		Shell shell = new Shell(display, SWT.SHELL_TRIM);
@@ -91,7 +98,8 @@ public class ShellTest extends CSSSWTTestCase {
 	// bug 375069: ensure children aren't caught up in parent
 	@Test
 	void test375069ChildShellDifferentiation() {
-		engine = createEngine("Shell.parent { font-style: italic; }", display);
+		Display display = css.getDisplay();
+		CSSEngine engine = css.createEngine("Shell.parent { font-style: italic; }");
 
 		Shell parent = new Shell(display, SWT.NONE);
 		WidgetElement.setCSSClass(parent, "parent");
@@ -115,7 +123,8 @@ public class ShellTest extends CSSSWTTestCase {
 	// bug 375069: ensure children shells are still captured by Shell
 	@Test
 	void test375069AllShell() {
-		engine = createEngine("Shell { font-style: italic; }", display);
+		Display display = css.getDisplay();
+		CSSEngine engine = css.createEngine("Shell { font-style: italic; }");
 
 		Shell parent = new Shell(display, SWT.NONE);
 		WidgetElement.setCSSClass(parent, "parent");
@@ -138,8 +147,9 @@ public class ShellTest extends CSSSWTTestCase {
 	// bug 375069: ensure children shells are still captured by Shell
 	@Test
 	void testShellParentage() {
-		engine = createEngine(
-				"Shell[parentage='parent'] { font-style: italic; }", display);
+		Display display = css.getDisplay();
+		CSSEngine engine = css.createEngine(
+				"Shell[parentage='parent'] { font-style: italic; }");
 
 		Shell parent = new Shell(display, SWT.NONE);
 		WidgetElement.setID(parent, "parent");
@@ -161,8 +171,9 @@ public class ShellTest extends CSSSWTTestCase {
 
 	@Test
 	void testShellUnparentedPseudoelement() {
-		engine = createEngine(
-				"Shell:swt-unparented { font-style: italic; }", display);
+		Display display = css.getDisplay();
+		CSSEngine engine = css.createEngine(
+				"Shell:swt-unparented { font-style: italic; }");
 
 		Shell parent = new Shell(display, SWT.NONE);
 		WidgetElement.setCSSClass(parent, "parent");
@@ -184,8 +195,9 @@ public class ShellTest extends CSSSWTTestCase {
 
 	@Test
 	void testShellParentedPseudoelement() {
-		engine = createEngine(
-				"Shell:swt-parented { font-style: italic; }", display);
+		Display display = css.getDisplay();
+		CSSEngine engine = css.createEngine(
+				"Shell:swt-parented { font-style: italic; }");
 
 		Shell parent = new Shell(display, SWT.NONE);
 		WidgetElement.setCSSClass(parent, "parent");
@@ -207,9 +219,9 @@ public class ShellTest extends CSSSWTTestCase {
 
 	@Test
 	void testSwtDataClassAttribute() {
-		engine = createEngine(
-				"Shell[swt-data-class ~= 'java.util.HashSet'] { font-style: italic; }",
-				display);
+		Display display = css.getDisplay();
+		CSSEngine engine = css.createEngine(
+				"Shell[swt-data-class ~= 'java.util.HashSet'] { font-style: italic; }");
 
 		Shell parent = new Shell(display, SWT.NONE);
 		parent.setData(new HashSet<>());

--- a/tests/org.eclipse.e4.ui.tests.css.swt/src/org/eclipse/e4/ui/tests/css/swt/TableTest.java
+++ b/tests/org.eclipse.e4.ui.tests.css.swt/src/org/eclipse/e4/ui/tests/css/swt/TableTest.java
@@ -15,22 +15,29 @@ package org.eclipse.e4.ui.tests.css.swt;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import org.eclipse.e4.ui.css.core.engine.CSSEngine;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.graphics.RGB;
 import org.eclipse.swt.layout.FillLayout;
 import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Shell;
 import org.eclipse.swt.widgets.Table;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
-public class TableTest extends CSSSWTTestCase {
+public class TableTest {
+
+	@RegisterExtension
+	CssSwtEngine css = new CssSwtEngine();
 
 	static final RGB RED = new RGB(255, 0, 0);
 	static final RGB GREEN = new RGB(0, 255, 0);
 	static final RGB BLUE = new RGB(0, 0, 255);
 
 	protected Table createTestTable(String styleSheet) {
-		engine = createEngine(styleSheet, display);
+		Display display = css.getDisplay();
+		CSSEngine engine = css.createEngine(styleSheet);
 
 		// Create widgets
 		Shell shell = new Shell(display, SWT.SHELL_TRIM);

--- a/tests/org.eclipse.e4.ui.tests.css.swt/src/org/eclipse/e4/ui/tests/css/swt/TextTransformTest.java
+++ b/tests/org.eclipse.e4.ui.tests.css.swt/src/org/eclipse/e4/ui/tests/css/swt/TextTransformTest.java
@@ -16,12 +16,15 @@ package org.eclipse.e4.ui.tests.css.swt;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import org.eclipse.e4.ui.css.core.engine.CSSEngine;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.layout.FillLayout;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;
+import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Shell;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 /**
  * Tests the <code>text-transform</code> property.
@@ -38,8 +41,10 @@ import org.junit.jupiter.api.Test;
  * <code>text-transform</code> specification from W3C</a>
  * </p>
  */
-public abstract class TextTransformTest extends CSSSWTTestCase {
+public abstract class TextTransformTest {
 
+	@RegisterExtension
+	CssSwtEngine css = new CssSwtEngine();
 
 	/**
 	 * Retrieves the name of the widget that is being tested, must not be
@@ -80,7 +85,8 @@ public abstract class TextTransformTest extends CSSSWTTestCase {
 	protected abstract void setText(Control control, String string);
 
 	private Control createTestControl(String styleSheet) {
-		engine = createEngine(styleSheet, display);
+		Display display = css.getDisplay();
+		CSSEngine engine = css.createEngine(styleSheet);
 
 		// Create widgets
 		Shell shell = new Shell(display, SWT.SHELL_TRIM);

--- a/tests/org.eclipse.e4.ui.tests.css.swt/src/org/eclipse/e4/ui/tests/css/swt/ThemeTest.java
+++ b/tests/org.eclipse.e4.ui.tests.css.swt/src/org/eclipse/e4/ui/tests/css/swt/ThemeTest.java
@@ -29,6 +29,7 @@ import org.eclipse.swt.widgets.Display;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.FrameworkUtil;
@@ -37,15 +38,17 @@ import org.osgi.framework.ServiceRegistration;
 import org.osgi.service.event.EventConstants;
 import org.osgi.service.event.EventHandler;
 
-public class ThemeTest extends CSSSWTTestCase {
+public class ThemeTest {
+
+	@RegisterExtension
+	CssSwtEngine css = new CssSwtEngine();
+
 	private BundleContext context;
 	private ServiceRegistration<EventHandler> themeListenerRegistration;
 	private ServiceReference<IThemeManager> themeManagerReference;
 
-	@Override
 	@BeforeEach
 	public void setUp() {
-		super.setUp();
 		Bundle b = FrameworkUtil.getBundle(this.getClass());
 		assertNotNull(b, "Not running in an OSGi environment");
 		context = b.getBundleContext();
@@ -54,11 +57,9 @@ public class ThemeTest extends CSSSWTTestCase {
 				.getServiceReference(IThemeManager.class);
 	}
 
-	@Override
 	@AfterEach
 	public void tearDown() {
 		themeListenerRegistration.unregister();
-		super.tearDown();
 	}
 
 	@Test

--- a/tests/org.eclipse.e4.ui.tests.css.swt/src/org/eclipse/e4/ui/tests/css/swt/ThemesExtensionTest.java
+++ b/tests/org.eclipse.e4.ui.tests.css.swt/src/org/eclipse/e4/ui/tests/css/swt/ThemesExtensionTest.java
@@ -19,20 +19,25 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import org.eclipse.e4.ui.css.core.engine.CSSEngine;
 import org.eclipse.ui.internal.themes.ColorDefinition;
 import org.eclipse.ui.internal.themes.FontDefinition;
 import org.eclipse.ui.internal.themes.ThemesExtension;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
-public class ThemesExtensionTest extends CSSSWTTestCase {
+public class ThemesExtensionTest {
+
+	@RegisterExtension
+	CssSwtEngine css = new CssSwtEngine();
 
 	@Test
 	void testThemesExtension() {
 		//given
-		engine = createEngine(
+		CSSEngine engine = css.createEngine(
 				"ThemesExtension {font-definition: '#org-eclipse-ui-workbench-FONT_DEF_1',"
 						+
-						"'#org-eclipse-ui-workbench-FONT_DEF_2'; color-definition: '#org-eclipse-ui-workbench-COLOR_DEF_1';}", display);
+						"'#org-eclipse-ui-workbench-FONT_DEF_2'; color-definition: '#org-eclipse-ui-workbench-COLOR_DEF_1';}");
 		ThemesExtension themesExtention = new ThemesExtension();
 
 		//when

--- a/tests/org.eclipse.e4.ui.tests.css.swt/src/org/eclipse/e4/ui/tests/css/swt/ToolItemTest.java
+++ b/tests/org.eclipse.e4.ui.tests.css.swt/src/org/eclipse/e4/ui/tests/css/swt/ToolItemTest.java
@@ -13,22 +13,31 @@
  *******************************************************************************/
 package org.eclipse.e4.ui.tests.css.swt;
 
+import static org.eclipse.e4.ui.tests.css.swt.CssSwtEngine.BLUE;
+import static org.eclipse.e4.ui.tests.css.swt.CssSwtEngine.RED;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
+import org.eclipse.e4.ui.css.core.engine.CSSEngine;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.layout.FillLayout;
 import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Shell;
 import org.eclipse.swt.widgets.ToolBar;
 import org.eclipse.swt.widgets.ToolItem;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
-public class ToolItemTest extends CSSSWTTestCase {
+public class ToolItemTest {
+
+	@RegisterExtension
+	CssSwtEngine css = new CssSwtEngine();
 
 	protected ToolItem createTestToolItem(String styleSheet, int styleBit) {
-		engine = createEngine(styleSheet, display);
+		Display display = css.getDisplay();
+		CSSEngine engine = css.createEngine(styleSheet);
 
 		// Create widgets
 		var shell = new Shell(display, SWT.SHELL_TRIM);
@@ -70,7 +79,7 @@ public class ToolItemTest extends CSSSWTTestCase {
 				"ToolItem { color: #FF0000; }\n" + "ToolItem:checked { color: #0000FF; }", SWT.PUSH);
 		assertEquals(RED, toolItemToTest.getForeground().getRGB());
 		toolItemToTest.setSelection(true);
-		engine.applyStyles(toolItemToTest, false);
+		css.getEngine().applyStyles(toolItemToTest, false);
 		assertEquals(BLUE, toolItemToTest.getForeground().getRGB());
 	}
 

--- a/tests/org.eclipse.e4.ui.tests.css.swt/src/org/eclipse/e4/ui/tests/css/swt/TreeTest.java
+++ b/tests/org.eclipse.e4.ui.tests.css.swt/src/org/eclipse/e4/ui/tests/css/swt/TreeTest.java
@@ -13,19 +13,28 @@
  *******************************************************************************/
 package org.eclipse.e4.ui.tests.css.swt;
 
+import static org.eclipse.e4.ui.tests.css.swt.CssSwtEngine.BLUE;
+import static org.eclipse.e4.ui.tests.css.swt.CssSwtEngine.RED;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import org.eclipse.e4.ui.css.core.engine.CSSEngine;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.layout.FillLayout;
 import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Shell;
 import org.eclipse.swt.widgets.Tree;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
-public class TreeTest extends CSSSWTTestCase {
+public class TreeTest {
+
+	@RegisterExtension
+	CssSwtEngine css = new CssSwtEngine();
 
 	protected Tree createTestTree(String styleSheet) {
-		engine = createEngine(styleSheet, display);
+		Display display = css.getDisplay();
+		CSSEngine engine = css.createEngine(styleSheet);
 
 		// Create widgets
 		Shell shell = new Shell(display, SWT.SHELL_TRIM);


### PR DESCRIPTION
The widget tests in org.eclipse.e4.ui.tests.css.swt all had to extend CSSSWTTestCase to get a Display, engine creation and shell cleanup, and they shared its protected mutable display field. This replaces the base class with a CssSwtEngine extension registered via @RegisterExtension: the extension owns the engine and widget helpers, exposes the display and engine through accessors, and disposes open shells after each test. The tests keep their exact behavior (the full suite passes with the same totals as before) and are now free to extend other bases.

Part of #3980.