### PR TITLE
Find/Replace overlay: fix whole-word button enablement lagging by one keystroke

### DIFF
--- a/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/overlay/FindReplaceOverlay.java
+++ b/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/overlay/FindReplaceOverlay.java
@@ -701,8 +701,8 @@ public class FindReplaceOverlay {
 		searchBar.forceFocus();
 		searchBar.selectAll();
 		searchBar.addModifyListener(e -> {
-			wholeWordSearchButton.setEnabled(findReplaceLogic.isAvailable(SearchOptions.WHOLE_WORD));
 			updateIncrementalSearch();
+			wholeWordSearchButton.setEnabled(findReplaceLogic.isAvailable(SearchOptions.WHOLE_WORD));
 			decorate();
 		});
 		searchBar.addFocusListener(new FocusListener() {

--- a/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/internal/findandreplace/overlay/FindReplaceOverlayTest.java
+++ b/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/internal/findandreplace/overlay/FindReplaceOverlayTest.java
@@ -202,6 +202,18 @@ public class FindReplaceOverlayTest extends FindReplaceUITest<OverlayAccess> {
 	}
 
 	@Test
+	public void testWholeWordButtonEnabledStateImmediatelyReflectsCurrentSearchTerm() {
+		initializeTextViewerWithFindReplaceUI("foo bar foo");
+		OverlayAccess dialog= getDialog();
+
+		dialog.setFindText("foo ");
+		dialog.assertDisabled(SearchOptions.WHOLE_WORD);
+
+		dialog.setFindText("foo");
+		dialog.assertEnabled(SearchOptions.WHOLE_WORD);
+	}
+
+	@Test
 	public void testSearchTermStoredInHistoryAfterSearchBackward() {
 		// Backward search must persist the term to history just like forward search.
 		initializeTextViewerWithFindReplaceUI("foo bar foo");


### PR DESCRIPTION
The modify listener in `createSearchBar()` called `wholeWordSearchButton.setEnabled(findReplaceLogic.isAvailable(WHOLE_WORD))` before `updateIncrementalSearch()`. Because `updateIncrementalSearch()` is responsible for pushing the new text into `FindReplaceLogic` via `setFindString()`, the availability check always operated on the *previous* find string. As a result, the enabled state of the whole-word button was always one keystroke behind the actual content of the search field.

The fix moves `setEnabled` to after `updateIncrementalSearch()` so that `isAvailable(WHOLE_WORD)` evaluates the current, already-updated find string.

A regression test is added to `FindReplaceOverlayTest` that sets a multi-word search term and immediately asserts the button is disabled, then sets a single-word term and asserts it is re-enabled -- both without an intervening keystroke.

## Before
<img width="579" height="97" alt="whole_word_broken" src="https://github.com/user-attachments/assets/385ec399-05b3-423d-87c3-005b9bae893e" />

## After
<img width="579" height="97" alt="whole_word_fixed" src="https://github.com/user-attachments/assets/4fca7206-56b6-403a-a2a2-1ad9769be176" />

---

This change was extracted from PR #4164 to keep one concern per PR: https://github.com/eclipse-platform/eclipse.platform.ui/pull/4164

This change was created with the help of [GitHub Copilot](https://github.com/features/copilot).