### PR TITLE
Auto-clear persisted workbench state when Eclipse is launched with a different locale

### DIFF
--- a/bundles/org.eclipse.e4.ui.workbench.swt/src/org/eclipse/e4/ui/internal/workbench/swt/E4Application.java
+++ b/bundles/org.eclipse.e4.ui.workbench.swt/src/org/eclipse/e4/ui/internal/workbench/swt/E4Application.java
@@ -26,9 +26,13 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.OutputStream;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.List;
 import java.util.Locale;
 import java.util.Optional;
@@ -120,6 +124,8 @@ public class E4Application implements IApplication {
 	private static final String SHOWLOCATION_ARG_NAME = "showLocation";
 	private static final String DEFAULT_THEME_ID = "org.eclipse.e4.ui.css.theme.e4_default";
 	public static final String HIGH_CONTRAST_THEME_ID = "org.eclipse.e4.ui.css.theme.high-contrast";
+	private static final String NL_STATE_FILENAME = "last_nl.properties"; //$NON-NLS-1$
+	private static final String NL_STATE_KEY = "eclipse.last.nl"; //$NON-NLS-1$
 
 	private String[] args;
 
@@ -371,6 +377,10 @@ public class E4Application implements IApplication {
 		// Persisted state
 		Boolean clearPersistedState = getArgValue(IWorkbench.CLEAR_PERSISTED_STATE, appContext, true)
 				.map(Boolean::parseBoolean).orElse(Boolean.FALSE);
+		// If not already clearing, check if NL locale changed since last run
+		if (!clearPersistedState) {
+			clearPersistedState = hasNlChanged(instanceLocation);
+		}
 		eclipseContext.set(IWorkbench.CLEAR_PERSISTED_STATE, clearPersistedState);
 
 		String resourceHandler = getArgValue(IWorkbench.MODEL_RESOURCE_HANDLER, appContext, false)
@@ -383,6 +393,59 @@ public class E4Application implements IApplication {
 
 		Resource resource = handler.loadMostRecentModel();
 		return (MApplication) resource.getContents().get(0);
+	}
+
+	/**
+	 * Checks whether the Eclipse locale (-nl) has changed since the last launch.
+	 * Persists the current locale in a properties file alongside workbench.xmi.
+	 *
+	 * @return true if the locale has changed since the last launch, false otherwise
+	 */
+	private boolean hasNlChanged(Location instanceLocation) {
+		if (instanceLocation == null || instanceLocation.getURL() == null) {
+			return false;
+		}
+
+		Path stateDir;
+		try {
+			stateDir = Path.of(instanceLocation.getURL().toURI()).resolve(".metadata") //$NON-NLS-1$
+					.resolve(".plugins") //$NON-NLS-1$
+					.resolve("org.eclipse.e4.workbench"); //$NON-NLS-1$
+		} catch (URISyntaxException e) {
+			return false;
+		}
+		Path nlFile = stateDir.resolve(NL_STATE_FILENAME);
+
+		String currentNL = Platform.getNL();
+		Properties props = new Properties();
+		boolean localeChanged = false;
+
+		// Read previously saved locale if file exists
+		if (Files.isRegularFile(nlFile)) {
+			try (InputStream in = Files.newInputStream(nlFile)) {
+				props.load(in);
+				String savedNL = props.getProperty(NL_STATE_KEY);
+				if (!currentNL.equals(savedNL)) {
+					localeChanged = true;
+				}
+			} catch (IOException e) {
+				// Cannot read - file will be rewritten below
+				localeChanged = true;
+			}
+		}
+		// Write current locale - covers first launch, locale change and recovery cases
+		props.setProperty(NL_STATE_KEY, currentNL);
+		try {
+			Files.createDirectories(stateDir); // ensure directory exists before writing
+			try (OutputStream out = Files.newOutputStream(nlFile)) {
+				props.store(out, "Eclipse last used NL locale"); //$NON-NLS-1$
+			}
+		} catch (IOException e) {
+			// Cannot write - non-fatal, skip clearing to be safe
+			return false;
+		}
+
+		return localeChanged;
 	}
 
 	private URI determineApplicationModelURI(IApplicationContext appContext) {


### PR DESCRIPTION
**The Problem**
When Eclipse is launched with -nl <locale> and the workspace already has a persisted workbench.xmi from a previous session in a different language, the UI starts up showing stale labels - view tabs like Declaration, Problems and Javadoc remain in the old language until the user manually clicks on each tab. The only workaround today is launching with -clearPersistedState, which throws away the entire workbench layout every time.

Fixes #3108 

**Root Cause**
Eclipse caches view labels and other UI strings directly in workbench.xmi at shutdown. On the next launch, these cached values are rendered before the NL bundles have a chance to supply the correct translated strings. Since nothing was comparing the current locale against the one used in the previous session, stale labels went undetected.

**Fix in-detail**
A single new private method - hasNlChanged() - is introduced in E4Application. On each startup it does three things:

- Reads the locale recorded from the last launch from a small properties file (last_nl.properties) stored alongside workbench.xmi
- Compares it against the current Platform.getNL()
- If they differ, signals the existing CLEAR_PERSISTED_STATE mechanism to rebuild the workbench model fresh from the correct NL bundles

If the locale is unchanged, or if this is the first ever launch, nothing happens - the user's layout is fully preserved.

**What Changes**
- E4Application.java - the only file modified
- last_nl.properties - a new small file written to `<workspace>/.metadata/.plugins/org.eclipse.e4.workbench/` at first launch, updated on each locale change

No new dependencies. No schema changes. No impact on the common single-locale case(except that locale is being saved now).

_Notes_
- The CLEAR_PERSISTED_STATE path used here is well-tested and already used in production via the -clearPersistedState launch argument. This change simply triggers it conditionally and automatically.
- Locale changes between Eclipse sessions are infrequent - the cost of a one-time layout reset in that scenario is acceptable and consistent with user expectations.
- First launch on a fresh workspace is handled gracefully - last_nl.properties is created silently with no side effects.
- Path resolution uses instanceLocation.getURL().toURI() rather than getFile() to correctly handle Windows paths, where getFile() returns a URL-style path with a leading /C:/ that Path.of() rejects on Windows.


**Without Fix** 
1. Locale is English -> 
<img width="1270" height="464" alt="image" src="https://github.com/user-attachments/assets/afeaa7c0-acc7-40d3-ba53-a0d78e1d94ab" />

2. Locale changed to French, immediately seen labels -> 
<img width="1331" height="467" alt="image" src="https://github.com/user-attachments/assets/0e1c1406-b098-445b-b64f-835d220fcd7d" />

3. On refresh of the tabs, it then shows -> 
<img width="1333" height="418" alt="image" src="https://github.com/user-attachments/assets/a25ca802-a262-4dbe-878e-b5c6f5b78b8c" />


**With Fix**
1. Locale is English -> 
<img width="1316" height="457" alt="image" src="https://github.com/user-attachments/assets/e28a41b8-e7cb-4615-a463-ffb40325da32" />

2. Locale changed to French, immediately seen labels -> 
<img width="1527" height="467" alt="image" src="https://github.com/user-attachments/assets/dd8e8bfb-f7e8-4b83-817e-e3011e873a99" />

