### PR TITLE
Find/Replace overlay: unify action responsibility in FindReplaceOverlayAction

### DIFF
--- a/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/overlay/AccessibleToolBar.java
+++ b/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/overlay/AccessibleToolBar.java
@@ -65,11 +65,6 @@ class AccessibleToolBar extends Composite {
 		}
 	}
 
-	void registerActionShortcutsAtControl(Control control) {
-		for (AccessibleToolItem item : accessibleToolItems) {
-			item.registerActionShortcutsAtControl(control);
-		}
-	}
 
 	Control getFirstControl() {
 		Control[] children = getChildren();

--- a/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/overlay/AccessibleToolItem.java
+++ b/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/overlay/AccessibleToolItem.java
@@ -10,24 +10,20 @@
  *******************************************************************************/
 package org.eclipse.ui.internal.findandreplace.overlay;
 
-import java.util.List;
-
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.events.SelectionListener;
 import org.eclipse.swt.graphics.Color;
 import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.widgets.Composite;
-import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.ToolBar;
 import org.eclipse.swt.widgets.ToolItem;
 
-import org.eclipse.jface.bindings.keys.KeyStroke;
 import org.eclipse.jface.layout.GridDataFactory;
 
 class AccessibleToolItem {
 	private final ToolItem toolItem;
 
-	private FindReplaceOverlayAction action = new FindReplaceOverlayAction(null);
+	private FindReplaceOverlayAction action;
 
 	AccessibleToolItem(Composite parent, int styleBits) {
 		ToolBar toolbar = new ToolBar(parent, SWT.FLAT | SWT.HORIZONTAL);
@@ -48,18 +44,13 @@ class AccessibleToolItem {
 	}
 
 	void setToolTipText(String text) {
-		toolItem.setToolTipText(action.addShortcutHintToTooltipText(text));
+		toolItem.setToolTipText(action != null ? action.addShortcutHintToTooltipText(text) : text);
 	}
 
-	void setOperation(Runnable operation, List<KeyStroke> shortcuts) {
-		action = new FindReplaceOverlayAction(operation);
-		action.addShortcuts(shortcuts);
+	void setAction(FindReplaceOverlayAction newAction) {
+		this.action = newAction;
 		setToolTipText(toolItem.getToolTipText());
-		toolItem.addSelectionListener(SelectionListener.widgetSelectedAdapter(__ -> operation.run()));
-	}
-
-	void registerActionShortcutsAtControl(Control control) {
-		FindReplaceShortcutUtil.registerActionShortcutsAtControl(action, control);
+		toolItem.addSelectionListener(SelectionListener.widgetSelectedAdapter(__ -> action.execute()));
 	}
 
 }

--- a/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/overlay/AccessibleToolItemBuilder.java
+++ b/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/overlay/AccessibleToolItemBuilder.java
@@ -13,15 +13,11 @@
  *******************************************************************************/
 package org.eclipse.ui.internal.findandreplace.overlay;
 
-import java.util.Collections;
-import java.util.List;
 import java.util.Objects;
 
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.widgets.ToolItem;
-
-import org.eclipse.jface.bindings.keys.KeyStroke;
 
 import org.eclipse.ui.internal.findandreplace.IFindReplaceLogic;
 import org.eclipse.ui.internal.findandreplace.SearchOptions;
@@ -34,8 +30,7 @@ class AccessibleToolItemBuilder {
 	private int styleBits = SWT.NONE;
 	private Image image;
 	private String toolTipText;
-	private List<KeyStroke> shortcuts = Collections.emptyList();
-	private Runnable operation;
+	private FindReplaceOverlayAction action;
 	private SearchOptions searchOption;
 	private IFindReplaceLogic findReplaceLogic;
 	private boolean invertSearchOption;
@@ -59,13 +54,8 @@ class AccessibleToolItemBuilder {
 		return this;
 	}
 
-	public AccessibleToolItemBuilder withShortcuts(List<KeyStroke> newShortcuts) {
-		this.shortcuts = newShortcuts;
-		return this;
-	}
-
-	public AccessibleToolItemBuilder withOperation(Runnable newOperation) {
-		this.operation = newOperation;
+	public AccessibleToolItemBuilder withAction(FindReplaceOverlayAction newAction) {
+		this.action = newAction;
 		return this;
 	}
 
@@ -102,8 +92,8 @@ class AccessibleToolItemBuilder {
 		if (toolTipText != null) {
 			accessibleToolItem.setToolTipText(toolTipText);
 		}
-		if (operation != null) {
-			accessibleToolItem.setOperation(operation, shortcuts);
+		if (action != null) {
+			accessibleToolItem.setAction(action);
 		}
 		ToolItem toolItem = accessibleToolItem.getToolItem();
 		if (searchOption != null) {

--- a/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/overlay/FindReplaceOverlay.java
+++ b/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/overlay/FindReplaceOverlay.java
@@ -14,6 +14,7 @@
 package org.eclipse.ui.internal.findandreplace.overlay;
 
 import java.lang.reflect.Method;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -144,6 +145,10 @@ public class FindReplaceOverlay {
 	private AccessibleToolBar replaceTools;
 	private ToolItem replaceButton;
 	private ToolItem replaceAllButton;
+
+	private final List<FindReplaceOverlayAction> commonActions = new ArrayList<>();
+	private final List<FindReplaceOverlayAction> searchActions = new ArrayList<>();
+	private final List<FindReplaceOverlayAction> replaceActions = new ArrayList<>();
 
 	private Color widgetBackgroundColor;
 	private Color overlayBackgroundColor;
@@ -470,9 +475,14 @@ public class FindReplaceOverlay {
 	}
 
 	private void initializeSearchShortcutHandlers() {
-		searchTools.registerActionShortcutsAtControl(searchBar);
-		closeTools.registerActionShortcutsAtControl(searchBar);
-		replaceToggleTools.registerActionShortcutsAtControl(searchBar);
+		registerActionShortcutsAtControl(commonActions, searchBar);
+		registerActionShortcutsAtControl(searchActions, searchBar);
+	}
+
+	private void registerActionShortcutsAtControl(List<FindReplaceOverlayAction> actions, Control control) {
+		for (FindReplaceOverlayAction action : actions) {
+			FindReplaceShortcutUtil.registerActionShortcutsAtControl(action, control);
+		}
 	}
 
 	/**
@@ -546,11 +556,14 @@ public class FindReplaceOverlay {
 				.applyTo(replaceToggleTools);
 		replaceToggleTools.addMouseListener(MouseListener.mouseDownAdapter(__ -> setReplaceVisible(!replaceBarOpen)));
 
+		FindReplaceOverlayAction replaceToggleAction = new FindReplaceOverlayAction(() -> setReplaceVisible(!replaceBarOpen));
+		replaceToggleAction.addShortcuts(KeyboardShortcuts.TOGGLE_REPLACE);
+		commonActions.add(replaceToggleAction);
+
 		replaceToggle = new AccessibleToolItemBuilder(replaceToggleTools)
-				.withShortcuts(KeyboardShortcuts.TOGGLE_REPLACE)
 				.withImage(FindReplaceOverlayImages.get(FindReplaceOverlayImages.KEY_OPEN_REPLACE_AREA))
 				.withToolTipText(FindReplaceMessages.FindReplaceOverlay_replaceToggle_toolTip)
-				.withOperation(() -> setReplaceVisible(!replaceBarOpen)).withShortcuts(KeyboardShortcuts.TOGGLE_REPLACE)
+				.withAction(replaceToggleAction)
 				.build();
 	}
 
@@ -575,90 +588,104 @@ public class FindReplaceOverlay {
 
 		searchTools.createToolItem(SWT.SEPARATOR);
 
+		FindReplaceOverlayAction searchBackwardAction = new FindReplaceOverlayAction(() -> performSearch(false));
+		searchBackwardAction.addShortcuts(KeyboardShortcuts.SEARCH_BACKWARD);
+		searchActions.add(searchBackwardAction);
 		searchBackwardButton = new AccessibleToolItemBuilder(searchTools).withStyleBits(SWT.PUSH)
 				.withImage(FindReplaceOverlayImages.get(FindReplaceOverlayImages.KEY_FIND_PREV))
 				.withToolTipText(FindReplaceMessages.FindReplaceOverlay_upSearchButton_toolTip)
-				.withOperation(() -> performSearch(false))
-				.withShortcuts(KeyboardShortcuts.SEARCH_BACKWARD).build();
+				.withAction(searchBackwardAction).build();
 
+		FindReplaceOverlayAction searchForwardAction = new FindReplaceOverlayAction(() -> performSearch(true));
+		searchForwardAction.addShortcuts(KeyboardShortcuts.SEARCH_FORWARD);
+		searchActions.add(searchForwardAction);
 		searchForwardButton = new AccessibleToolItemBuilder(searchTools).withStyleBits(SWT.PUSH)
 				.withImage(FindReplaceOverlayImages.get(FindReplaceOverlayImages.KEY_FIND_NEXT))
 				.withToolTipText(FindReplaceMessages.FindReplaceOverlay_downSearchButton_toolTip)
-				.withOperation(() -> performSearch(true))
-				.withShortcuts(KeyboardShortcuts.SEARCH_FORWARD).build();
+				.withAction(searchForwardAction).build();
 		searchForwardButton.setSelection(true); // by default, search down
 
+		FindReplaceOverlayAction selectAllAction = new FindReplaceOverlayAction(this::performSelectAll);
+		selectAllAction.addShortcuts(KeyboardShortcuts.SEARCH_ALL);
+		searchActions.add(selectAllAction);
 		selectAllButton = new AccessibleToolItemBuilder(searchTools).withStyleBits(SWT.PUSH)
 				.withImage(FindReplaceOverlayImages.get(FindReplaceOverlayImages.KEY_SEARCH_ALL))
 				.withToolTipText(FindReplaceMessages.FindReplaceOverlay_searchAllButton_toolTip)
-				.withOperation(this::performSelectAll).withShortcuts(KeyboardShortcuts.SEARCH_ALL).build();
+				.withAction(selectAllAction).build();
 	}
 
 	private void createCloseTools() {
 		closeTools = new AccessibleToolBar(searchContainer);
 		GridDataFactory.fillDefaults().grab(false, true).align(GridData.END, GridData.END).applyTo(closeTools);
 
+		FindReplaceOverlayAction closeAction = new FindReplaceOverlayAction(this::close);
+		closeAction.addShortcuts(KeyboardShortcuts.CLOSE);
+		commonActions.add(closeAction);
+
 		// Close button
 		new AccessibleToolItemBuilder(closeTools).withStyleBits(SWT.PUSH)
 				.withImage(FindReplaceOverlayImages.get(FindReplaceOverlayImages.KEY_CLOSE))
 				.withToolTipText(FindReplaceMessages.FindReplaceOverlay_closeButton_toolTip) //
-				.withOperation(this::close)
-				.withShortcuts(KeyboardShortcuts.CLOSE).build();
+				.withAction(closeAction).build();
 	}
 
 	private void createAreaSearchButton() {
+		FindReplaceOverlayAction searchInSelectionAction = new FindReplaceOverlayAction(() -> {
+			activateInFindReplacerIf(SearchOptions.GLOBAL, !findReplaceLogic.isActive(SearchOptions.GLOBAL));
+			updateIncrementalSearch();
+		});
+		searchInSelectionAction.addShortcuts(KeyboardShortcuts.OPTION_SEARCH_IN_SELECTION);
+		commonActions.add(searchInSelectionAction);
 		searchInSelectionButton = new AccessibleToolItemBuilder(searchTools).withStyleBits(SWT.CHECK)
 				.withImage(FindReplaceOverlayImages.get(FindReplaceOverlayImages.KEY_SEARCH_IN_AREA))
 				.withToolTipText(FindReplaceMessages.FindReplaceOverlay_searchInSelectionButton_toolTip)
-				.withOperation(() -> {
-					activateInFindReplacerIf(SearchOptions.GLOBAL, !findReplaceLogic.isActive(SearchOptions.GLOBAL));
-					updateIncrementalSearch();
-				})
-				.withShortcuts(KeyboardShortcuts.OPTION_SEARCH_IN_SELECTION)
 				.withInvertedSearchOption(SearchOptions.GLOBAL, findReplaceLogic)
-				.build();
+				.withAction(searchInSelectionAction).build();
 	}
 
 	private void createRegexSearchButton() {
+		FindReplaceOverlayAction regexAction = new FindReplaceOverlayAction(() -> {
+			activateInFindReplacerIf(SearchOptions.REGEX, !findReplaceLogic.isActive(SearchOptions.REGEX));
+			wholeWordSearchButton.setEnabled(findReplaceLogic.isAvailable(SearchOptions.WHOLE_WORD));
+			updateIncrementalSearch();
+			updateContentAssistAvailability();
+			decorate();
+		});
+		regexAction.addShortcuts(KeyboardShortcuts.OPTION_REGEX);
+		commonActions.add(regexAction);
 		regexSearchButton = new AccessibleToolItemBuilder(searchTools).withStyleBits(SWT.CHECK)
 				.withImage(FindReplaceOverlayImages.get(FindReplaceOverlayImages.KEY_FIND_REGEX))
 				.withToolTipText(FindReplaceMessages.FindReplaceOverlay_regexSearchButton_toolTip)
-				.withOperation(() -> {
-					activateInFindReplacerIf(SearchOptions.REGEX, !findReplaceLogic.isActive(SearchOptions.REGEX));
-					wholeWordSearchButton.setEnabled(findReplaceLogic.isAvailable(SearchOptions.WHOLE_WORD));
-					updateIncrementalSearch();
-					updateContentAssistAvailability();
-					decorate();
-				})
-				.withShortcuts(KeyboardShortcuts.OPTION_REGEX)
 				.withSearchOption(SearchOptions.REGEX, findReplaceLogic)
-				.build();
+				.withAction(regexAction).build();
 	}
 
 	private void createCaseSensitiveButton() {
+		FindReplaceOverlayAction caseSensitiveAction = new FindReplaceOverlayAction(() -> {
+			activateInFindReplacerIf(SearchOptions.CASE_SENSITIVE, !findReplaceLogic.isActive(SearchOptions.CASE_SENSITIVE));
+			updateIncrementalSearch();
+		});
+		caseSensitiveAction.addShortcuts(KeyboardShortcuts.OPTION_CASE_SENSITIVE);
+		commonActions.add(caseSensitiveAction);
 		caseSensitiveSearchButton = new AccessibleToolItemBuilder(searchTools).withStyleBits(SWT.CHECK)
 				.withImage(FindReplaceOverlayImages.get(FindReplaceOverlayImages.KEY_CASE_SENSITIVE))
 				.withToolTipText(FindReplaceMessages.FindReplaceOverlay_caseSensitiveButton_toolTip)
-				.withOperation(() -> {
-					activateInFindReplacerIf(SearchOptions.CASE_SENSITIVE, !findReplaceLogic.isActive(SearchOptions.CASE_SENSITIVE));
-					updateIncrementalSearch();
-				})
-				.withShortcuts(KeyboardShortcuts.OPTION_CASE_SENSITIVE)
 				.withSearchOption(SearchOptions.CASE_SENSITIVE, findReplaceLogic)
-				.build();
+				.withAction(caseSensitiveAction).build();
 	}
 
 	private void createWholeWordsButton() {
+		FindReplaceOverlayAction wholeWordAction = new FindReplaceOverlayAction(() -> {
+			activateInFindReplacerIf(SearchOptions.WHOLE_WORD, !findReplaceLogic.isActive(SearchOptions.WHOLE_WORD));
+			updateIncrementalSearch();
+		});
+		wholeWordAction.addShortcuts(KeyboardShortcuts.OPTION_WHOLE_WORD);
+		commonActions.add(wholeWordAction);
 		wholeWordSearchButton = new AccessibleToolItemBuilder(searchTools).withStyleBits(SWT.CHECK)
 				.withImage(FindReplaceOverlayImages.get(FindReplaceOverlayImages.KEY_WHOLE_WORD))
 				.withToolTipText(FindReplaceMessages.FindReplaceOverlay_wholeWordsButton_toolTip)
-				.withOperation(() -> {
-					activateInFindReplacerIf(SearchOptions.WHOLE_WORD, !findReplaceLogic.isActive(SearchOptions.WHOLE_WORD));
-					updateIncrementalSearch();
-				})
-				.withShortcuts(KeyboardShortcuts.OPTION_WHOLE_WORD)
 				.withSearchOption(SearchOptions.WHOLE_WORD, findReplaceLogic)
-				.build();
+				.withAction(wholeWordAction).build();
 	}
 
 	private void createReplaceTools() {
@@ -667,27 +694,33 @@ public class FindReplaceOverlay {
 		replaceTools.createToolItem(SWT.SEPARATOR);
 
 		GridDataFactory.fillDefaults().grab(false, true).align(GridData.CENTER, GridData.END).applyTo(replaceTools);
+		FindReplaceOverlayAction replaceAction = new FindReplaceOverlayAction(() -> {
+			if (getFindString().isEmpty()) {
+				applyErrorColor(replaceBar);
+				return;
+			}
+			performSingleReplace();
+		});
+		replaceAction.addShortcuts(KeyboardShortcuts.SEARCH_FORWARD);
+		replaceActions.add(replaceAction);
 		replaceButton = new AccessibleToolItemBuilder(replaceTools).withStyleBits(SWT.PUSH)
 				.withImage(FindReplaceOverlayImages.get(FindReplaceOverlayImages.KEY_REPLACE))
 				.withToolTipText(FindReplaceMessages.FindReplaceOverlay_replaceButton_toolTip)
-				.withOperation(() -> {
-					if (getFindString().isEmpty()) {
-						applyErrorColor(replaceBar);
-						return;
-					}
-					performSingleReplace();
-				}).withShortcuts(KeyboardShortcuts.SEARCH_FORWARD).build();
+				.withAction(replaceAction).build();
 
+		FindReplaceOverlayAction replaceAllAction = new FindReplaceOverlayAction(() -> {
+			if (getFindString().isEmpty()) {
+				applyErrorColor(replaceBar);
+				return;
+			}
+			performReplaceAll();
+		});
+		replaceAllAction.addShortcuts(KeyboardShortcuts.SEARCH_ALL);
+		replaceActions.add(replaceAllAction);
 		replaceAllButton = new AccessibleToolItemBuilder(replaceTools).withStyleBits(SWT.PUSH)
 				.withImage(FindReplaceOverlayImages.get(FindReplaceOverlayImages.KEY_REPLACE_ALL))
 				.withToolTipText(FindReplaceMessages.FindReplaceOverlay_replaceAllButton_toolTip)
-				.withOperation(() -> {
-					if (getFindString().isEmpty()) {
-						applyErrorColor(replaceBar);
-						return;
-					}
-					performReplaceAll();
-				}).withShortcuts(KeyboardShortcuts.SEARCH_ALL).build();
+				.withAction(replaceAllAction).build();
 	}
 
 	private ContentAssistCommandAdapter createContentAssistField(HistoryTextWrapper control, boolean isFind) {
@@ -812,9 +845,8 @@ public class FindReplaceOverlay {
 	}
 
 	private void initializeReplaceShortcutHandlers() {
-		replaceTools.registerActionShortcutsAtControl(replaceBar);
-		closeTools.registerActionShortcutsAtControl(replaceBar);
-		replaceToggleTools.registerActionShortcutsAtControl(replaceBar);
+		registerActionShortcutsAtControl(commonActions, replaceBar);
+		registerActionShortcutsAtControl(replaceActions, replaceBar);
 	}
 
 	private void enableSearchTools(boolean enable) {

--- a/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/overlay/FindReplaceOverlayAction.java
+++ b/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/overlay/FindReplaceOverlayAction.java
@@ -11,6 +11,7 @@
 package org.eclipse.ui.internal.findandreplace.overlay;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import org.eclipse.jface.bindings.keys.KeyStroke;
@@ -30,6 +31,10 @@ class FindReplaceOverlayAction {
 
 	void execute() {
 		operation.run();
+	}
+
+	List<KeyStroke> getShortcuts() {
+		return Collections.unmodifiableList(shortcuts);
 	}
 
 	boolean executeIfMatching(KeyStroke keystroke) {

--- a/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/overlay/HistoryTextWrapper.java
+++ b/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/overlay/HistoryTextWrapper.java
@@ -57,10 +57,11 @@ public class HistoryTextWrapper extends Composite {
 		textBar = new Text(this, style);
 		GridDataFactory.fillDefaults().grab(true, true).align(GridData.FILL, GridData.CENTER).applyTo(textBar);
 		tools = new AccessibleToolBar(this);
+		FindReplaceOverlayAction action = new FindReplaceOverlayAction(this::createHistoryMenuDropdown);
 		dropDown = new AccessibleToolItemBuilder(tools).withStyleBits(SWT.PUSH)
 				.withToolTipText(FindReplaceMessages.FindReplaceOverlay_searchHistory_toolTip)
 				.withImage(FindReplaceOverlayImages.get(FindReplaceOverlayImages.KEY_OPEN_HISTORY))
-				.withOperation(this::createHistoryMenuDropdown)
+				.withAction(action)
 				.build();
 
 		listenForKeyboardHistoryNavigation();


### PR DESCRIPTION
### Motivation

Each overlay button previously had its operation and its keyboard shortcut hints defined as two independent values in the builder, with no single object representing the concept of an "action". As a consequence, registering those shortcuts on additional controls (the search and replace input fields) required reaching into the toolbar widget hierarchy — the overlay asked each toolbar to register shortcuts at a given control, the toolbar delegated to each tool item, and the tool item held an internal action that was not otherwise accessible. This made it impossible to reason in one place about which actions are active on which controls.

This is part of the ongoing effort to separate UI setup from controller logic in the Find/Replace overlay, tracked in issue #1912.

### Change

A `FindReplaceOverlayAction` is now created explicitly before building the corresponding tool item and passed to the builder as a single entity — the sole source of truth for both the operation and its shortcut bindings. The overlay maintains typed action lists (`commonActions`, `searchActions`, `replaceActions`) and registers shortcuts on input fields by iterating them directly, without involving the widget hierarchy at all.

### Towards proper Eclipse key binding handlers

Having actions as explicit, named objects with well-defined shortcut lists is a prerequisite for replacing the current SWT-level keyboard listener approach with proper Eclipse command-framework handlers. Such handlers would let the platform's key binding infrastructure dispatch shortcuts in a context-aware way. This change prepares that future migration. It follows:
- https://github.com/eclipse-platform/eclipse.platform.ui/pull/4164

---

This change was created with the help of [GitHub Copilot](https://github.com/features/copilot).