### PR TITLE
Add family for the quick diff initialize job

### DIFF
--- a/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/texteditor/quickdiff/DocumentLineDiffer.java
+++ b/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/texteditor/quickdiff/DocumentLineDiffer.java
@@ -134,6 +134,11 @@ public class DocumentLineDiffer implements ILineDiffer, IDocumentListener, IAnno
 		}
 	}
 
+	/**
+	 * Family for the quick diff initialize job.
+	 */
+	public static final Object QUICKDIFF_INITIALIZE_FAMILY = new Object();
+
 	/** Tells whether this class is in debug mode. */
 	private static boolean DEBUG= "true".equalsIgnoreCase(Platform.getDebugOption("org.eclipse.ui.workbench.texteditor/debug/DocumentLineDiffer"));  //$NON-NLS-1$//$NON-NLS-2$
 
@@ -549,6 +554,11 @@ public class DocumentLineDiffer implements ILineDiffer, IDocumentListener, IAnno
 				? NLSUtility.format(QuickDiffMessages.quickdiff_initialize_file, fDisplayName)
 				: QuickDiffMessages.quickdiff_initialize;
 		fInitializationJob= new Job(jobName) {
+
+			@Override
+			public boolean belongsTo(Object family) {
+				return family == QUICKDIFF_INITIALIZE_FAMILY;
+			}
 
 			/*
 			 * This is run in a different thread. As the documents might be synchronized, never ever


### PR DESCRIPTION
The quick diff initialization job currently has no family, making it difficult to wait on it during tests.
During JDT UI `SaveParticipantTest` we observe the job running in parallel to the test, potentially running into errors due to file operations done in the test.

This change adds a family that tests can use to wait on the job.

Fixes: https://github.com/eclipse-platform/eclipse.platform.ui/issues/4172

See also: https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/79