### PR TITLE
Register model-contributed perspectives in PerspectiveRegistry

### DIFF
--- a/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/registry/PerspectiveRegistry.java
+++ b/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/registry/PerspectiveRegistry.java
@@ -104,6 +104,8 @@ public class PerspectiveRegistry implements IPerspectiveRegistry, IExtensionChan
 			}
 		}
 
+		registerModelPerspectives();
+
 		impExpHandlerContext = context.createChild();
 		impExpHandlerContext.set(PerspectiveRegistry.class, this);
 		ContextInjectionFactory.make(ImportExportPespectiveHandler.class, impExpHandlerContext);
@@ -112,6 +114,20 @@ public class PerspectiveRegistry implements IPerspectiveRegistry, IExtensionChan
 	public void addPerspective(MPerspective perspective) {
 		application.getSnippets().add(perspective);
 		createDescriptor(perspective);
+	}
+
+	/**
+	 * Registers descriptors for perspectives contributed directly into the model
+	 * (not via the extension point or as snippets), leaving already known ones
+	 * untouched, so they are visible to the "Open Perspective" dialog.
+	 */
+	private void registerModelPerspectives() {
+		for (MPerspective perspective : modelService.findElements(application, null, MPerspective.class)) {
+			String id = perspective.getElementId();
+			if (id != null && !descriptors.containsKey(id)) {
+				createDescriptor(perspective);
+			}
+		}
 	}
 
 	public void createDescriptor(MPerspective perspective) {
@@ -221,6 +237,9 @@ public class PerspectiveRegistry implements IPerspectiveRegistry, IExtensionChan
 
 	@Override
 	public IPerspectiveDescriptor[] getPerspectives() {
+		// Pick up perspectives contributed into the model after this registry was
+		// created so the returned list stays in sync with what is available.
+		registerModelPerspectives();
 		Collection<?> descs = WorkbenchActivityHelper.restrictCollection(descriptors.values(), new ArrayList<>());
 		return descs.toArray(new IPerspectiveDescriptor[descs.size()]);
 	}

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/IPerspectiveRegistryTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/IPerspectiveRegistryTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2013 IBM Corporation and others.
+ * Copyright (c) 2000, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -14,13 +14,22 @@
 package org.eclipse.ui.tests.api;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
+import java.util.Arrays;
+import java.util.List;
+
+import org.eclipse.e4.ui.model.application.ui.advanced.MPerspective;
+import org.eclipse.e4.ui.model.application.ui.advanced.MPerspectiveStack;
+import org.eclipse.e4.ui.workbench.modeling.EModelService;
 import org.eclipse.ui.IPerspectiveDescriptor;
 import org.eclipse.ui.IPerspectiveRegistry;
 import org.eclipse.ui.IWorkbenchPage;
 import org.eclipse.ui.PlatformUI;
+import org.eclipse.ui.internal.WorkbenchWindow;
 import org.eclipse.ui.tests.harness.util.ArrayUtil;
 import org.junit.Before;
 import org.junit.Ignore;
@@ -87,6 +96,46 @@ public class IPerspectiveRegistryTest {
 
 		for (IPerspectiveDescriptor per : pers) {
 			assertNotNull(per);
+		}
+	}
+
+	/**
+	 * Perspectives contributed directly into the model (not via the extension
+	 * point) must still be registered so they are listed and can be opened by id.
+	 */
+	@Test
+	public void testModelPerspective() {
+		WorkbenchWindow window = (WorkbenchWindow) PlatformUI.getWorkbench().getActiveWorkbenchWindow();
+		EModelService modelService = window.getService(EModelService.class);
+
+		List<MPerspectiveStack> stacks = modelService.findElements(window.getModel(), null, MPerspectiveStack.class);
+		assertFalse("expected a perspective stack in the active window", stacks.isEmpty());
+		MPerspectiveStack stack = stacks.get(0);
+
+		String id = "org.eclipse.ui.tests.modelContributedPerspective";
+		String label = "Model Contributed Perspective";
+		MPerspective perspective = modelService.createModelElement(MPerspective.class);
+		perspective.setElementId(id);
+		perspective.setLabel(label);
+		perspective.setToBeRendered(false);
+		stack.getChildren().add(perspective);
+
+		try {
+			// It must appear in the list backing the "Open Perspective" dialog.
+			assertTrue("the model-contributed perspective should be listed in the registry",
+					Arrays.stream(fReg.getPerspectives()).anyMatch(d -> id.equals(d.getId())));
+
+			// It must be resolvable by id so that opening it actually works.
+			IPerspectiveDescriptor descriptor = fReg.findPerspectiveWithId(id);
+			assertNotNull("model-contributed perspective must be resolvable by id", descriptor);
+			assertEquals(id, descriptor.getId());
+			assertEquals(label, descriptor.getLabel());
+		} finally {
+			stack.getChildren().remove(perspective);
+			IPerspectiveDescriptor descriptor = fReg.findPerspectiveWithId(id);
+			if (descriptor != null) {
+				fReg.deletePerspective(descriptor);
+			}
 		}
 	}
 


### PR DESCRIPTION
Perspectives contributed directly into the application model (e.g. as children of a perspective stack via a model fragment) rather than through the org.eclipse.ui.perspectives extension point or as application snippets were unknown to the PerspectiveRegistry, and therefore invisible to the "Open Perspective" dialog and unresolvable by id.

Scan the model for such perspectives and register descriptors for them, both at startup and lazily from getPerspectives(). Add a test covering a model-contributed perspective.