### PR TITLE
Deprecate forRemoval StructuredViewer.getSorter

### DIFF
--- a/bundles/org.eclipse.jface/src/org/eclipse/jface/viewers/StructuredViewer.java
+++ b/bundles/org.eclipse.jface/src/org/eclipse/jface/viewers/StructuredViewer.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corporation and others.
+ * Copyright (c) 2000, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -1045,6 +1045,7 @@ public abstract class StructuredViewer extends ContentViewer implements IPostSel
 	 * @return a viewer sorter, or <code>null</code> if none or if the comparator is
 	 * 				not an instance of ViewerSorter
 	 */
+	@Deprecated(forRemoval = true, since = "2026-09 (removal in 2028-09 or later)")
 	public ViewerSorter getSorter() {
 		if (sorter instanceof ViewerSorter) {
 			return (ViewerSorter)sorter;


### PR DESCRIPTION
Yet another step towards eventually getting rid of ViewerSorter.