### PR TITLE
Find/replace: centralize UI state notifications in FindReplaceLogic

### DIFF
--- a/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/FindReplaceLogic.java
+++ b/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/FindReplaceLogic.java
@@ -16,6 +16,7 @@ package org.eclipse.ui.internal.findandreplace;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.EnumMap;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -63,26 +64,56 @@ public class FindReplaceLogic implements IFindReplaceLogic {
 	private String findString = ""; //$NON-NLS-1$
 	private String replaceString = ""; //$NON-NLS-1$
 
-	private final Map<SearchOptions, List<Consumer<Boolean>>> searchOptionListeners = new HashMap<>();
+	private final Map<SearchOptions, List<Consumer<Boolean>>> activationChangedListeners = new HashMap<>();
+	private final Map<SearchOptions, List<Consumer<Boolean>>> availabilityChangedListeners = new HashMap<>();
 
 	@Override
-	public void addSearchOptionChangedListener(SearchOptions option, Consumer<Boolean> listener) {
+	public void addSearchOptionActivationChangedListener(SearchOptions option, Consumer<Boolean> listener) {
 		Objects.requireNonNull(option);
 		Objects.requireNonNull(listener);
-		searchOptionListeners.computeIfAbsent(option, k -> new CopyOnWriteArrayList<>()).add(listener);
+		activationChangedListeners.computeIfAbsent(option, k -> new CopyOnWriteArrayList<>()).add(listener);
 	}
 
-	private void notifySearchOptionChangedListeners(SearchOptions option, boolean newState) {
-		List<Consumer<Boolean>> listeners = searchOptionListeners.getOrDefault(option, Collections.emptyList());
+	@Override
+	public void addSearchOptionAvailabilityChangedListener(SearchOptions option, Consumer<Boolean> listener) {
+		Objects.requireNonNull(option);
+		Objects.requireNonNull(listener);
+		availabilityChangedListeners.computeIfAbsent(option, k -> new CopyOnWriteArrayList<>()).add(listener);
+	}
+
+	private void notifyActivationChangedListeners(SearchOptions option, boolean newState) {
+		List<Consumer<Boolean>> listeners = activationChangedListeners.getOrDefault(option, Collections.emptyList());
 		listeners.forEach(l -> l.accept(newState));
+	}
+
+	private void notifyAvailabilityChangedListeners(SearchOptions option, boolean newAvailability) {
+		List<Consumer<Boolean>> listeners = availabilityChangedListeners.getOrDefault(option, Collections.emptyList());
+		listeners.forEach(l -> l.accept(newAvailability));
+	}
+
+	private Map<SearchOptions, Boolean> captureAvailabilities() {
+		Map<SearchOptions, Boolean> snapshot = new EnumMap<>(SearchOptions.class);
+		availabilityChangedListeners.keySet().forEach(option -> snapshot.put(option, isAvailable(option)));
+		return snapshot;
+	}
+
+	private void notifyAvailabilityChangedIfNeeded(Map<SearchOptions, Boolean> oldAvailabilities) {
+		oldAvailabilities.forEach((option, oldAvailability) -> {
+			boolean newAvailability = isAvailable(option);
+			if (oldAvailability != newAvailability) {
+				notifyAvailabilityChangedListeners(option, newAvailability);
+			}
+		});
 	}
 
 	@Override
 	public void setFindString(String findString) {
+		Map<SearchOptions, Boolean> oldAvailabilities = captureAvailabilities();
 		this.findString = Objects.requireNonNull(findString);
 		if (isAvailableAndActive(SearchOptions.INCREMENTAL)) {
 			performSearch(true);
 		}
+		notifyAvailabilityChangedIfNeeded(oldAvailabilities);
 	}
 
 	@Override
@@ -92,6 +123,7 @@ public class FindReplaceLogic implements IFindReplaceLogic {
 
 	@Override
 	public void activate(SearchOptions searchOption) {
+		Map<SearchOptions, Boolean> oldAvailabilities = captureAvailabilities();
 		if (!searchOptions.add(searchOption)) {
 			return;
 		}
@@ -110,11 +142,13 @@ public class FindReplaceLogic implements IFindReplaceLogic {
 		default:
 			break;
 		}
-		notifySearchOptionChangedListeners(searchOption, true);
+		notifyActivationChangedListeners(searchOption, true);
+		notifyAvailabilityChangedIfNeeded(oldAvailabilities);
 	}
 
 	@Override
 	public void deactivate(SearchOptions searchOption) {
+		Map<SearchOptions, Boolean> oldAvailabilities = captureAvailabilities();
 		if (!searchOptions.remove(searchOption)) {
 			return;
 		}
@@ -126,7 +160,8 @@ public class FindReplaceLogic implements IFindReplaceLogic {
 		if (searchOption == SearchOptions.FORWARD && shouldInitIncrementalBaseLocation()) {
 			resetIncrementalBaseLocation();
 		}
-		notifySearchOptionChangedListeners(searchOption, false);
+		notifyActivationChangedListeners(searchOption, false);
+		notifyAvailabilityChangedIfNeeded(oldAvailabilities);
 	}
 
 	@Override
@@ -613,6 +648,7 @@ public class FindReplaceLogic implements IFindReplaceLogic {
 		this.isTargetEditable = canEditTarget;
 
 		if (this.target != newTarget) {
+			Map<SearchOptions, Boolean> oldAvailabilities = captureAvailabilities();
 			if (this.target instanceof IFindReplaceTargetExtension) {
 				((IFindReplaceTargetExtension) this.target).endSession();
 			}
@@ -625,6 +661,7 @@ public class FindReplaceLogic implements IFindReplaceLogic {
 
 				activate(SearchOptions.GLOBAL);
 			}
+			notifyAvailabilityChangedIfNeeded(oldAvailabilities);
 		}
 
 		resetIncrementalBaseLocation();

--- a/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/IFindReplaceLogic.java
+++ b/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/IFindReplaceLogic.java
@@ -74,7 +74,25 @@ public interface IFindReplaceLogic {
 	 * @param option   the search option to observe
 	 * @param listener the listener to register
 	 */
-	public void addSearchOptionChangedListener(SearchOptions option, Consumer<Boolean> listener);
+	public void addSearchOptionActivationChangedListener(SearchOptions option, Consumer<Boolean> listener);
+
+	/**
+	 * Registers a listener that is notified whenever the availability of the given
+	 * search option changes. The listener is called with {@code true} when the
+	 * option becomes available and {@code false} when it becomes unavailable.
+	 *
+	 * <p>
+	 * Availability is determined by {@link #isAvailable(SearchOptions)} and depends
+	 * on the state of the target and the compatibility of active options (e.g.
+	 * {@link SearchOptions#WHOLE_WORD} is unavailable when
+	 * {@link SearchOptions#REGEX} is active or the search string is not a single
+	 * word). Listeners are only notified when availability actually changes.
+	 * </p>
+	 *
+	 * @param option   the search option to observe
+	 * @param listener the listener to register
+	 */
+	public void addSearchOptionAvailabilityChangedListener(SearchOptions option, Consumer<Boolean> listener);
 
 	/**
 	 * @param searchOption option

--- a/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/overlay/AccessibleToolItemBuilder.java
+++ b/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/overlay/AccessibleToolItemBuilder.java
@@ -61,8 +61,9 @@ class AccessibleToolItemBuilder {
 
 	/**
 	 * Binds a {@link SearchOptions} value to this item. When built, the item's
-	 * selection state is initialized from the logic's current state and kept in
-	 * sync automatically whenever the option changes.
+	 * selection state is initialized from the logic's current activation state and
+	 * kept in sync automatically. The item's enabled state is also initialized from
+	 * and kept in sync with the option's availability.
 	 */
 	public AccessibleToolItemBuilder withSearchOption(SearchOptions option, IFindReplaceLogic logic) {
 		this.searchOption = option;
@@ -73,9 +74,10 @@ class AccessibleToolItemBuilder {
 
 	/**
 	 * Like {@link #withSearchOption(SearchOptions, IFindReplaceLogic)} but inverts
-	 * the mapping: the item is selected when the option is <em>inactive</em>.
-	 * Useful for options like {@link SearchOptions#GLOBAL} where a "search in
-	 * selection" button should be selected when searching globally is turned off.
+	 * the selection mapping: the item is selected when the option is
+	 * <em>inactive</em>. Useful for options like {@link SearchOptions#GLOBAL} where
+	 * a "search in selection" button should be selected when searching globally is
+	 * turned off.
 	 */
 	public AccessibleToolItemBuilder withInvertedSearchOption(SearchOptions option, IFindReplaceLogic logic) {
 		this.searchOption = option;
@@ -99,9 +101,15 @@ class AccessibleToolItemBuilder {
 		if (searchOption != null) {
 			boolean initial = findReplaceLogic.isActive(searchOption);
 			toolItem.setSelection(invertSearchOption ? !initial : initial);
-			findReplaceLogic.addSearchOptionChangedListener(searchOption, state -> {
+			findReplaceLogic.addSearchOptionActivationChangedListener(searchOption, state -> {
 				if (!toolItem.isDisposed()) {
 					toolItem.setSelection(invertSearchOption ? !state : state);
+				}
+			});
+			toolItem.setEnabled(findReplaceLogic.isAvailable(searchOption));
+			findReplaceLogic.addSearchOptionAvailabilityChangedListener(searchOption, available -> {
+				if (!toolItem.isDisposed()) {
+					toolItem.setEnabled(available);
 				}
 			});
 		}

--- a/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/overlay/FindReplaceOverlay.java
+++ b/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/overlay/FindReplaceOverlay.java
@@ -646,10 +646,7 @@ public class FindReplaceOverlay {
 	private void createRegexSearchButton() {
 		FindReplaceOverlayAction regexAction = new FindReplaceOverlayAction(() -> {
 			activateInFindReplacerIf(SearchOptions.REGEX, !findReplaceLogic.isActive(SearchOptions.REGEX));
-			wholeWordSearchButton.setEnabled(findReplaceLogic.isAvailable(SearchOptions.WHOLE_WORD));
 			updateIncrementalSearch();
-			updateContentAssistAvailability();
-			decorate();
 		});
 		regexAction.addShortcuts(KeyboardShortcuts.OPTION_REGEX);
 		commonActions.add(regexAction);
@@ -658,6 +655,10 @@ public class FindReplaceOverlay {
 				.withToolTipText(FindReplaceMessages.FindReplaceOverlay_regexSearchButton_toolTip)
 				.withSearchOption(SearchOptions.REGEX, findReplaceLogic)
 				.withAction(regexAction).build();
+		findReplaceLogic.addSearchOptionActivationChangedListener(SearchOptions.REGEX, activated -> {
+			updateContentAssistAvailability();
+			decorate();
+		});
 	}
 
 	private void createCaseSensitiveButton() {
@@ -744,7 +745,6 @@ public class FindReplaceOverlay {
 		searchBar.selectAll();
 		searchBar.addModifyListener(e -> {
 			updateIncrementalSearch();
-			wholeWordSearchButton.setEnabled(findReplaceLogic.isAvailable(SearchOptions.WHOLE_WORD));
 			decorate();
 		});
 		searchBar.addFocusListener(new FocusListener() {

--- a/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/internal/findandreplace/FindReplaceLogicTest.java
+++ b/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/internal/findandreplace/FindReplaceLogicTest.java
@@ -987,7 +987,7 @@ public class FindReplaceLogicTest {
 	public void testSearchOptionListenerCalledOnActivation() {
 		IFindReplaceLogic findReplaceLogic= setupFindReplaceLogicObject(null);
 		List<Boolean> receivedValues= new ArrayList<>();
-		findReplaceLogic.addSearchOptionChangedListener(SearchOptions.CASE_SENSITIVE, receivedValues::add);
+		findReplaceLogic.addSearchOptionActivationChangedListener(SearchOptions.CASE_SENSITIVE, receivedValues::add);
 
 		findReplaceLogic.activate(SearchOptions.CASE_SENSITIVE);
 
@@ -999,7 +999,7 @@ public class FindReplaceLogicTest {
 		IFindReplaceLogic findReplaceLogic= setupFindReplaceLogicObject(null);
 		findReplaceLogic.activate(SearchOptions.CASE_SENSITIVE);
 		List<Boolean> receivedValues= new ArrayList<>();
-		findReplaceLogic.addSearchOptionChangedListener(SearchOptions.CASE_SENSITIVE, receivedValues::add);
+		findReplaceLogic.addSearchOptionActivationChangedListener(SearchOptions.CASE_SENSITIVE, receivedValues::add);
 
 		findReplaceLogic.deactivate(SearchOptions.CASE_SENSITIVE);
 
@@ -1011,7 +1011,7 @@ public class FindReplaceLogicTest {
 		IFindReplaceLogic findReplaceLogic= setupFindReplaceLogicObject(null);
 		findReplaceLogic.activate(SearchOptions.CASE_SENSITIVE);
 		List<Boolean> receivedValues= new ArrayList<>();
-		findReplaceLogic.addSearchOptionChangedListener(SearchOptions.CASE_SENSITIVE, receivedValues::add);
+		findReplaceLogic.addSearchOptionActivationChangedListener(SearchOptions.CASE_SENSITIVE, receivedValues::add);
 
 		findReplaceLogic.activate(SearchOptions.CASE_SENSITIVE);
 
@@ -1023,7 +1023,7 @@ public class FindReplaceLogicTest {
 		IFindReplaceLogic findReplaceLogic= setupFindReplaceLogicObject(null);
 		// CASE_SENSITIVE is inactive by default
 		List<Boolean> receivedValues= new ArrayList<>();
-		findReplaceLogic.addSearchOptionChangedListener(SearchOptions.CASE_SENSITIVE, receivedValues::add);
+		findReplaceLogic.addSearchOptionActivationChangedListener(SearchOptions.CASE_SENSITIVE, receivedValues::add);
 
 		findReplaceLogic.deactivate(SearchOptions.CASE_SENSITIVE);
 
@@ -1035,13 +1035,79 @@ public class FindReplaceLogicTest {
 		IFindReplaceLogic findReplaceLogic= setupFindReplaceLogicObject(null);
 		List<Boolean> received1= new ArrayList<>();
 		List<Boolean> received2= new ArrayList<>();
-		findReplaceLogic.addSearchOptionChangedListener(SearchOptions.CASE_SENSITIVE, received1::add);
-		findReplaceLogic.addSearchOptionChangedListener(SearchOptions.CASE_SENSITIVE, received2::add);
+		findReplaceLogic.addSearchOptionActivationChangedListener(SearchOptions.CASE_SENSITIVE, received1::add);
+		findReplaceLogic.addSearchOptionActivationChangedListener(SearchOptions.CASE_SENSITIVE, received2::add);
 
 		findReplaceLogic.activate(SearchOptions.CASE_SENSITIVE);
 
 		assertThat(received1, is(List.of(true)));
 		assertThat(received2, is(List.of(true)));
+	}
+
+	@Test
+	public void testAvailabilityListenerCalledWhenRegexActivationMakesWholeWordUnavailable() {
+		TextViewer textViewer= setupTextViewer("");
+		IFindReplaceLogic findReplaceLogic= setupFindReplaceLogicObject(textViewer);
+		findReplaceLogic.setFindString("word");
+		List<Boolean> receivedValues= new ArrayList<>();
+		findReplaceLogic.addSearchOptionAvailabilityChangedListener(SearchOptions.WHOLE_WORD, receivedValues::add);
+
+		findReplaceLogic.activate(SearchOptions.REGEX);
+
+		assertThat(receivedValues, is(List.of(false)));
+	}
+
+	@Test
+	public void testAvailabilityListenerCalledWhenRegexDeactivationMakesWholeWordAvailable() {
+		TextViewer textViewer= setupTextViewer("");
+		IFindReplaceLogic findReplaceLogic= setupFindReplaceLogicObject(textViewer);
+		findReplaceLogic.setFindString("word");
+		findReplaceLogic.activate(SearchOptions.REGEX);
+		List<Boolean> receivedValues= new ArrayList<>();
+		findReplaceLogic.addSearchOptionAvailabilityChangedListener(SearchOptions.WHOLE_WORD, receivedValues::add);
+
+		findReplaceLogic.deactivate(SearchOptions.REGEX);
+
+		assertThat(receivedValues, is(List.of(true)));
+	}
+
+	@Test
+	public void testAvailabilityListenerCalledWhenFindStringBecomesNonWord() {
+		IFindReplaceLogic findReplaceLogic= setupFindReplaceLogicObject(null);
+		findReplaceLogic.setFindString("word");
+		List<Boolean> receivedValues= new ArrayList<>();
+		findReplaceLogic.addSearchOptionAvailabilityChangedListener(SearchOptions.WHOLE_WORD, receivedValues::add);
+
+		findReplaceLogic.setFindString("hello world");
+
+		assertThat(receivedValues, is(List.of(false)));
+	}
+
+	@Test
+	public void testAvailabilityListenerCalledWhenFindStringBecomesWord() {
+		IFindReplaceLogic findReplaceLogic= setupFindReplaceLogicObject(null);
+		findReplaceLogic.setFindString("hello world");
+		List<Boolean> receivedValues= new ArrayList<>();
+		findReplaceLogic.addSearchOptionAvailabilityChangedListener(SearchOptions.WHOLE_WORD, receivedValues::add);
+
+		findReplaceLogic.setFindString("word");
+
+		assertThat(receivedValues, is(List.of(true)));
+	}
+
+	@Test
+	public void testAvailabilityListenerNotCalledWhenAvailabilityUnchanged() {
+		TextViewer textViewer= setupTextViewer("");
+		IFindReplaceLogic findReplaceLogic= setupFindReplaceLogicObject(textViewer);
+		findReplaceLogic.setFindString("hello world");
+		List<Boolean> receivedValues= new ArrayList<>();
+		findReplaceLogic.addSearchOptionAvailabilityChangedListener(SearchOptions.WHOLE_WORD, receivedValues::add);
+
+		// WHOLE_WORD is already unavailable due to non-word string; activating REGEX
+		// does not change its availability
+		findReplaceLogic.activate(SearchOptions.REGEX);
+
+		assertTrue(receivedValues.isEmpty());
 	}
 
 	private void expectStatusEmpty(IFindReplaceLogic findReplaceLogic) {


### PR DESCRIPTION
### Motivation

Button enablement in the Find/Replace overlay was managed imperatively: toggle lambdas and search-bar listeners scattered `setEnabled()` calls across `FindReplaceOverlay`, replicating logic that `FindReplaceLogic` already encapsulates internally. This made it easy to miss update sites, apply updates in the wrong order, or have the UI diverge from the actual logic state.

This is part of the ongoing effort to separate UI setup from controller logic in the Find/Replace overlay, tracked in issue #1912.

### Change

`FindReplaceLogic` now exposes two notification channels:

- `addSearchOptionActivationChangedListener` — fires when an option is toggled on or off
- `addSearchOptionAvailabilityChangedListener` — fires when the result of `isAvailable()` changes for an option

UI components subscribe to these channels and update themselves reactively. `AccessibleToolItemBuilder` registers both listeners for every button bound to a `SearchOption`, so `FindReplaceOverlay` no longer needs to know which widgets to update when logic state changes.

### Towards proper Eclipse key binding handlers

Having the logic state drive UI state reactively through well-defined listener channels is a prerequisite for introducing proper Eclipse command-framework handlers for the overlay actions: the handler enablement state must be kept in sync with `FindReplaceLogic` availability without the overlay manually orchestrating updates. This change prepares that future migration. It follows:
- https://github.com/eclipse-platform/eclipse.platform.ui/pull/4164
- https://github.com/eclipse-platform/eclipse.platform.ui/pull/4169
- https://github.com/eclipse-platform/eclipse.platform.ui/pull/4178

---

This change was created with the help of [GitHub Copilot](https://github.com/features/copilot).