### PR TITLE
Stabilize SortingTest match count

### DIFF
--- a/tests/org.eclipse.search.tests/src/org/eclipse/search/tests/filesearch/SortingTest.java
+++ b/tests/org.eclipse.search.tests/src/org/eclipse/search/tests/filesearch/SortingTest.java
@@ -52,8 +52,8 @@ public class SortingTest {
 		NewSearchUI.activateSearchResultView();
 		NewSearchUI.runQueryInForeground(null, fQuery1);
 		AbstractTextSearchResult result= (AbstractTextSearchResult) fQuery1.getSearchResult();
-		int originalMatchCount= result.getMatchCount();
-		List<Match> allMatches= new ArrayList<>(originalMatchCount);
+		List<Match> allMatches= new ArrayList<>(result.getMatchCount());
+		int originalMatchCount= 0;
 
 		// first, collect all matches
 		Object[] elements= result.getElements();
@@ -61,6 +61,7 @@ public class SortingTest {
 			int sizeBefore= allMatches.size();
 			Match[] matches = result.getMatches(element);
 			Collections.addAll(allMatches, matches);
+			originalMatchCount += matches.length;
 			int sizeAfter= allMatches.size();
 			assertEquals(sizeBefore + matches.length, sizeAfter, "Failed to add matches:" +
 					Arrays.stream(matches).map(Match::toString).collect(Collectors.joining(System.lineSeparator())));
@@ -80,7 +81,7 @@ public class SortingTest {
 			assertEquals(sizeBefore + 1, sizeAfter, "Failed to add match:" + match);
 		}
 
-		assertEquals(result.getMatchCount(), originalMatchCount, "Test that all matches have been added again");
+		assertEquals(originalMatchCount, result.getMatchCount(), "Test that all matches have been added again");
 
 		// now check that they're ordered by position.
 		for (Object element : elements) {


### PR DESCRIPTION
Why mismatch: getMatchCount() can observe a different concurrent state than getElements()/getMatches() (cached count vs traversal), so the old comparison could race on Windows.

Fix: derive baseline count from the same collected match snapshot used for allMatches.

Should stabilize https://github.com/eclipse-platform/eclipse.platform.ui/issues/3987