### PR TITLE
Find/replace: add test for whole-word availability with unavailable regex

### DIFF
--- a/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/internal/findandreplace/FindReplaceLogicTest.java
+++ b/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/internal/findandreplace/FindReplaceLogicTest.java
@@ -720,6 +720,19 @@ public class FindReplaceLogicTest {
 	}
 
 	@Test
+	public void testWholeWordRemainsAvailableWhenUnavailableRegexIsActivated() {
+		IFindReplaceLogic findReplaceLogic= setupFindReplaceLogicObject(null);
+		findReplaceLogic.setFindString("word");
+		assertFalse(findReplaceLogic.isAvailable(SearchOptions.REGEX)); // null target has no regex support
+		assertTrue(findReplaceLogic.isAvailable(SearchOptions.WHOLE_WORD));
+
+		findReplaceLogic.activate(SearchOptions.REGEX);
+
+		// Activating an unavailable option has no effective impact, so whole-word must remain available
+		assertTrue(findReplaceLogic.isAvailable(SearchOptions.WHOLE_WORD));
+	}
+
+	@Test
 	public void testReplaceInScopeStaysInScope() {
 		TextViewer textViewer= setupTextViewer(LINE_STRING + lineSeparator() + LINE_STRING + lineSeparator() + LINE_STRING);
 		int lineSeparatorLength= lineSeparator().length();


### PR DESCRIPTION
Adds a test to document and protect the invariant that activating an unavailable search option must not restrict other options.

Specifically, whole-word search and regex mode are mutually exclusive — but only when regex is *effectively* active (i.e., both activated and available on the current target). Activating regex mode on a target that does not support regex has no effective impact and must therefore leave the whole-word option unaffected. This is already the correct behavior in `FindReplaceLogic`, but was previously untested.

This change was extracted from https://github.com/eclipse-platform/eclipse.platform.ui/pull/4176 to keep one concern per PR.

This change was created with the help of GitHub Copilot.