### PR TITLE
Find/replace: add toggle functionality for search options to logic

### DIFF
--- a/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/FindReplaceLogic.java
+++ b/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/FindReplaceLogic.java
@@ -165,6 +165,15 @@ public class FindReplaceLogic implements IFindReplaceLogic {
 	}
 
 	@Override
+	public void toggle(SearchOptions searchOption) {
+		if (isActive(searchOption)) {
+			deactivate(searchOption);
+		} else {
+			activate(searchOption);
+		}
+	}
+
+	@Override
 	public boolean isActive(SearchOptions searchOption) {
 		return searchOptions.contains(searchOption);
 	}

--- a/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/IFindReplaceLogic.java
+++ b/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/IFindReplaceLogic.java
@@ -61,6 +61,13 @@ public interface IFindReplaceLogic {
 	public void deactivate(SearchOptions searchOption);
 
 	/**
+	 * Toggles a search option
+	 *
+	 * @param searchOption option
+	 */
+	public void toggle(SearchOptions searchOption);
+
+	/**
 	 * Registers a listener that is notified whenever the given search option is
 	 * activated or deactivated. The listener is called with {@code true} when the
 	 * option becomes active and {@code false} when it becomes inactive.

--- a/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/overlay/FindReplaceOverlay.java
+++ b/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/overlay/FindReplaceOverlay.java
@@ -631,7 +631,7 @@ public class FindReplaceOverlay {
 
 	private void createAreaSearchButton() {
 		FindReplaceOverlayAction searchInSelectionAction = new FindReplaceOverlayAction(() -> {
-			activateInFindReplacerIf(SearchOptions.GLOBAL, !findReplaceLogic.isActive(SearchOptions.GLOBAL));
+			findReplaceLogic.toggle(SearchOptions.GLOBAL);
 			updateIncrementalSearch();
 		});
 		searchInSelectionAction.addShortcuts(KeyboardShortcuts.OPTION_SEARCH_IN_SELECTION);
@@ -645,7 +645,7 @@ public class FindReplaceOverlay {
 
 	private void createRegexSearchButton() {
 		FindReplaceOverlayAction regexAction = new FindReplaceOverlayAction(() -> {
-			activateInFindReplacerIf(SearchOptions.REGEX, !findReplaceLogic.isActive(SearchOptions.REGEX));
+			findReplaceLogic.toggle(SearchOptions.REGEX);
 			updateIncrementalSearch();
 		});
 		regexAction.addShortcuts(KeyboardShortcuts.OPTION_REGEX);
@@ -663,7 +663,7 @@ public class FindReplaceOverlay {
 
 	private void createCaseSensitiveButton() {
 		FindReplaceOverlayAction caseSensitiveAction = new FindReplaceOverlayAction(() -> {
-			activateInFindReplacerIf(SearchOptions.CASE_SENSITIVE, !findReplaceLogic.isActive(SearchOptions.CASE_SENSITIVE));
+			findReplaceLogic.toggle(SearchOptions.CASE_SENSITIVE);
 			updateIncrementalSearch();
 		});
 		caseSensitiveAction.addShortcuts(KeyboardShortcuts.OPTION_CASE_SENSITIVE);
@@ -677,7 +677,7 @@ public class FindReplaceOverlay {
 
 	private void createWholeWordsButton() {
 		FindReplaceOverlayAction wholeWordAction = new FindReplaceOverlayAction(() -> {
-			activateInFindReplacerIf(SearchOptions.WHOLE_WORD, !findReplaceLogic.isActive(SearchOptions.WHOLE_WORD));
+			findReplaceLogic.toggle(SearchOptions.WHOLE_WORD);
 			updateIncrementalSearch();
 		});
 		wholeWordAction.addShortcuts(KeyboardShortcuts.OPTION_WHOLE_WORD);


### PR DESCRIPTION
The search options can be changed via keyboard shortcuts / commands, which effectively triggers a toggle of those options. That is currently implemented at consumer-side unnecessarily. With this change, the FindReplaceLogic itself allows to toggle its search options.