### PR TITLE
Find/replace overlay: move action management to command class

### DIFF
--- a/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/overlay/AccessibleToolItem.java
+++ b/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/overlay/AccessibleToolItem.java
@@ -23,7 +23,8 @@ import org.eclipse.jface.layout.GridDataFactory;
 class AccessibleToolItem {
 	private final ToolItem toolItem;
 
-	private FindReplaceOverlayAction action;
+	private String baseToolTipText;
+
 
 	AccessibleToolItem(Composite parent, int styleBits) {
 		ToolBar toolbar = new ToolBar(parent, SWT.FLAT | SWT.HORIZONTAL);
@@ -44,13 +45,22 @@ class AccessibleToolItem {
 	}
 
 	void setToolTipText(String text) {
-		toolItem.setToolTipText(action != null ? action.addShortcutHintToTooltipText(text) : text);
+		this.baseToolTipText = text;
+		toolItem.setToolTipText(text);
 	}
 
-	void setAction(FindReplaceOverlayAction newAction) {
-		this.action = newAction;
+	void setAction(FindReplaceOverlayAction action) {
 		setToolTipText(toolItem.getToolTipText());
 		toolItem.addSelectionListener(SelectionListener.widgetSelectedAdapter(__ -> action.execute()));
+		action.addShortcutHintListener(hint -> {
+			if (!toolItem.isDisposed()) {
+				String tooltipWithHint = baseToolTipText;
+				if (!hint.isEmpty()) {
+					tooltipWithHint += " (" + hint + ")"; //$NON-NLS-1$//$NON-NLS-2$
+				}
+				toolItem.setToolTipText(tooltipWithHint);
+			}
+		});
 	}
 
 }

--- a/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/overlay/FindReplaceOverlay.java
+++ b/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/overlay/FindReplaceOverlay.java
@@ -13,7 +13,6 @@
  *******************************************************************************/
 package org.eclipse.ui.internal.findandreplace.overlay;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -136,10 +135,6 @@ public class FindReplaceOverlay {
 	private ToolItem replaceButton;
 	private ToolItem replaceAllButton;
 
-	private final List<FindReplaceOverlayAction> commonActions = new ArrayList<>();
-	private final List<FindReplaceOverlayAction> searchActions = new ArrayList<>();
-	private final List<FindReplaceOverlayAction> replaceActions = new ArrayList<>();
-
 	private Color widgetBackgroundColor;
 	private Color overlayBackgroundColor;
 	private Color normalTextForegroundColor;
@@ -154,12 +149,16 @@ public class FindReplaceOverlay {
 	private final FocusListener targetActionActivationHandling = new FocusListener() {
 		@Override
 		public void focusGained(FocusEvent e) {
-			commandSupport.overlayActivated();
+			if (e.widget == searchBar.getTextBar()) {
+				commandSupport.searchBarActivated();
+			} else if (replaceBar != null && e.widget == replaceBar.getTextBar()) {
+				commandSupport.replaceBarActivated();
+			}
 		}
 
 		@Override
 		public void focusLost(FocusEvent e) {
-			commandSupport.overlayDeactivated();
+			commandSupport.searchOrReplaceBarDeactivated();
 		}
 	};
 
@@ -415,14 +414,8 @@ public class FindReplaceOverlay {
 	}
 
 	private void initializeSearchShortcutHandlers() {
-		registerActionShortcutsAtControl(commonActions, searchBar);
-		registerActionShortcutsAtControl(searchActions, searchBar);
-	}
-
-	private void registerActionShortcutsAtControl(List<FindReplaceOverlayAction> actions, Control control) {
-		for (FindReplaceOverlayAction action : actions) {
-			FindReplaceShortcutUtil.registerActionShortcutsAtControl(action, control);
-		}
+		commandSupport.registerCommonActionShortcutsAtControl(searchBar);
+		commandSupport.registerSearchActionShortcutsAtControl(searchBar);
 	}
 
 	/**
@@ -498,7 +491,7 @@ public class FindReplaceOverlay {
 
 		FindReplaceOverlayAction replaceToggleAction = new FindReplaceOverlayAction(() -> setReplaceVisible(!replaceBarOpen));
 		replaceToggleAction.addShortcuts(KeyboardShortcuts.TOGGLE_REPLACE);
-		commonActions.add(replaceToggleAction);
+		commandSupport.registerCommonAction(replaceToggleAction);
 
 		replaceToggle = new AccessibleToolItemBuilder(replaceToggleTools)
 				.withImage(FindReplaceOverlayImages.get(FindReplaceOverlayImages.KEY_OPEN_REPLACE_AREA))
@@ -530,7 +523,7 @@ public class FindReplaceOverlay {
 
 		FindReplaceOverlayAction searchBackwardAction = new FindReplaceOverlayAction(() -> performSearch(false));
 		searchBackwardAction.addShortcuts(KeyboardShortcuts.SEARCH_BACKWARD);
-		searchActions.add(searchBackwardAction);
+		commandSupport.registerSearchAction(searchBackwardAction);
 		searchBackwardButton = new AccessibleToolItemBuilder(searchTools).withStyleBits(SWT.PUSH)
 				.withImage(FindReplaceOverlayImages.get(FindReplaceOverlayImages.KEY_FIND_PREV))
 				.withToolTipText(FindReplaceMessages.FindReplaceOverlay_upSearchButton_toolTip)
@@ -538,7 +531,7 @@ public class FindReplaceOverlay {
 
 		FindReplaceOverlayAction searchForwardAction = new FindReplaceOverlayAction(() -> performSearch(true));
 		searchForwardAction.addShortcuts(KeyboardShortcuts.SEARCH_FORWARD);
-		searchActions.add(searchForwardAction);
+		commandSupport.registerSearchAction(searchForwardAction);
 		searchForwardButton = new AccessibleToolItemBuilder(searchTools).withStyleBits(SWT.PUSH)
 				.withImage(FindReplaceOverlayImages.get(FindReplaceOverlayImages.KEY_FIND_NEXT))
 				.withToolTipText(FindReplaceMessages.FindReplaceOverlay_downSearchButton_toolTip)
@@ -546,7 +539,7 @@ public class FindReplaceOverlay {
 
 		FindReplaceOverlayAction selectAllAction = new FindReplaceOverlayAction(this::performSelectAll);
 		selectAllAction.addShortcuts(KeyboardShortcuts.SEARCH_ALL);
-		searchActions.add(selectAllAction);
+		commandSupport.registerSearchAction(selectAllAction);
 		selectAllButton = new AccessibleToolItemBuilder(searchTools).withStyleBits(SWT.PUSH)
 				.withImage(FindReplaceOverlayImages.get(FindReplaceOverlayImages.KEY_SEARCH_ALL))
 				.withToolTipText(FindReplaceMessages.FindReplaceOverlay_searchAllButton_toolTip)
@@ -559,7 +552,7 @@ public class FindReplaceOverlay {
 
 		FindReplaceOverlayAction closeAction = new FindReplaceOverlayAction(this::close);
 		closeAction.addShortcuts(KeyboardShortcuts.CLOSE);
-		commonActions.add(closeAction);
+		commandSupport.registerCommonAction(closeAction);
 
 		// Close button
 		new AccessibleToolItemBuilder(closeTools).withStyleBits(SWT.PUSH)
@@ -572,7 +565,7 @@ public class FindReplaceOverlay {
 		FindReplaceOverlaySearchOptionAction searchInSelectionAction = new FindReplaceOverlaySearchOptionAction(SearchOptions.GLOBAL, findReplaceLogic);
 		searchInSelectionAction.addExecutionListener(this::updateIncrementalSearch);
 		searchInSelectionAction.addShortcuts(KeyboardShortcuts.OPTION_SEARCH_IN_SELECTION);
-		commonActions.add(searchInSelectionAction);
+		commandSupport.registerCommonAction(searchInSelectionAction);
 		searchInSelectionButton = new AccessibleToolItemBuilder(searchTools).withStyleBits(SWT.CHECK)
 				.withImage(FindReplaceOverlayImages.get(FindReplaceOverlayImages.KEY_SEARCH_IN_AREA))
 				.withToolTipText(FindReplaceMessages.FindReplaceOverlay_searchInSelectionButton_toolTip)
@@ -584,7 +577,7 @@ public class FindReplaceOverlay {
 				findReplaceLogic);
 		regexAction.addExecutionListener(this::updateIncrementalSearch);
 		regexAction.addShortcuts(KeyboardShortcuts.OPTION_REGEX);
-		commonActions.add(regexAction);
+		commandSupport.registerCommonAction(regexAction);
 		regexSearchButton = new AccessibleToolItemBuilder(searchTools).withStyleBits(SWT.CHECK)
 				.withImage(FindReplaceOverlayImages.get(FindReplaceOverlayImages.KEY_FIND_REGEX))
 				.withToolTipText(FindReplaceMessages.FindReplaceOverlay_regexSearchButton_toolTip)
@@ -600,7 +593,7 @@ public class FindReplaceOverlay {
 				SearchOptions.CASE_SENSITIVE, findReplaceLogic);
 		caseSensitiveAction.addExecutionListener(this::updateIncrementalSearch);
 		caseSensitiveAction.addShortcuts(KeyboardShortcuts.OPTION_CASE_SENSITIVE);
-		commonActions.add(caseSensitiveAction);
+		commandSupport.registerCommonAction(caseSensitiveAction);
 		caseSensitiveSearchButton = new AccessibleToolItemBuilder(searchTools).withStyleBits(SWT.CHECK)
 				.withImage(FindReplaceOverlayImages.get(FindReplaceOverlayImages.KEY_CASE_SENSITIVE))
 				.withToolTipText(FindReplaceMessages.FindReplaceOverlay_caseSensitiveButton_toolTip)
@@ -612,7 +605,7 @@ public class FindReplaceOverlay {
 				SearchOptions.WHOLE_WORD, findReplaceLogic);
 		wholeWordAction.addExecutionListener(this::updateIncrementalSearch);
 		wholeWordAction.addShortcuts(KeyboardShortcuts.OPTION_WHOLE_WORD);
-		commonActions.add(wholeWordAction);
+		commandSupport.registerCommonAction(wholeWordAction);
 		wholeWordSearchButton = new AccessibleToolItemBuilder(searchTools).withStyleBits(SWT.CHECK)
 				.withImage(FindReplaceOverlayImages.get(FindReplaceOverlayImages.KEY_WHOLE_WORD))
 				.withToolTipText(FindReplaceMessages.FindReplaceOverlay_wholeWordsButton_toolTip)
@@ -633,7 +626,7 @@ public class FindReplaceOverlay {
 			performSingleReplace();
 		});
 		replaceAction.addShortcuts(KeyboardShortcuts.SEARCH_FORWARD);
-		replaceActions.add(replaceAction);
+		commandSupport.registerReplaceAction(replaceAction);
 		replaceButton = new AccessibleToolItemBuilder(replaceTools).withStyleBits(SWT.PUSH)
 				.withImage(FindReplaceOverlayImages.get(FindReplaceOverlayImages.KEY_REPLACE))
 				.withToolTipText(FindReplaceMessages.FindReplaceOverlay_replaceButton_toolTip)
@@ -647,7 +640,7 @@ public class FindReplaceOverlay {
 			performReplaceAll();
 		});
 		replaceAllAction.addShortcuts(KeyboardShortcuts.SEARCH_ALL);
-		replaceActions.add(replaceAllAction);
+		commandSupport.registerReplaceAction(replaceAllAction);
 		replaceAllButton = new AccessibleToolItemBuilder(replaceTools).withStyleBits(SWT.PUSH)
 				.withImage(FindReplaceOverlayImages.get(FindReplaceOverlayImages.KEY_REPLACE_ALL))
 				.withToolTipText(FindReplaceMessages.FindReplaceOverlay_replaceAllButton_toolTip)
@@ -753,6 +746,7 @@ public class FindReplaceOverlay {
 			return;
 		}
 		customFocusOrder.dispose();
+		commandSupport.unregisterReplaceActions();
 		searchBar.forceFocus();
 		contentAssistReplaceField = null;
 		replaceBarOpen = false;
@@ -775,8 +769,8 @@ public class FindReplaceOverlay {
 	}
 
 	private void initializeReplaceShortcutHandlers() {
-		registerActionShortcutsAtControl(commonActions, replaceBar);
-		registerActionShortcutsAtControl(replaceActions, replaceBar);
+		commandSupport.registerCommonActionShortcutsAtControl(replaceBar);
+		commandSupport.registerReplaceActionShortcutsAtControl(replaceBar);
 	}
 
 	private void enableSearchTools(boolean enable) {

--- a/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/overlay/FindReplaceOverlayAction.java
+++ b/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/overlay/FindReplaceOverlayAction.java
@@ -13,6 +13,7 @@ package org.eclipse.ui.internal.findandreplace.overlay;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.function.Consumer;
 
 import org.eclipse.jface.bindings.keys.KeyStroke;
 
@@ -20,6 +21,8 @@ class FindReplaceOverlayAction {
 	private final Runnable operation;
 
 	private final List<Runnable> executionListeners = new ArrayList<>();
+
+	private final List<Consumer<String>> shortcutHintListeners = new ArrayList<>();
 
 	private final List<KeyStroke> shortcuts = new ArrayList<>();
 
@@ -48,13 +51,6 @@ class FindReplaceOverlayAction {
 		return false;
 	}
 
-	String addShortcutHintToTooltipText(String originalTooltipText) {
-		if (shortcuts.isEmpty()) {
-			return originalTooltipText;
-		}
-		return originalTooltipText + " (" + shortcuts.get(0).format() + ")"; //$NON-NLS-1$ //$NON-NLS-2$
-	}
-
 	void addExecutionListener(Runnable listener) {
 		executionListeners.add(listener);
 	}
@@ -63,6 +59,25 @@ class FindReplaceOverlayAction {
 		for (Runnable listener : executionListeners) {
 			listener.run();
 		}
+	}
+
+	void addShortcutHintListener(Consumer<String> listener) {
+		shortcutHintListeners.add(listener);
+	}
+
+	void activateKeyBinding() {
+		shortcutHintListeners.forEach(listener -> listener.accept(getShortcutHint()));
+	}
+
+	private String getShortcutHint() {
+		if (shortcuts.isEmpty()) {
+			return ""; //$NON-NLS-1$
+		}
+		return shortcuts.get(0).format(); // $NON-NLS-1$
+	}
+
+	void deactivateKeyBinding() {
+		shortcutHintListeners.forEach(listener -> listener.accept("")); //$NON-NLS-1$
 	}
 
 }

--- a/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/overlay/FindReplaceOverlayCommandSupport.java
+++ b/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/overlay/FindReplaceOverlayCommandSupport.java
@@ -11,9 +11,12 @@
 package org.eclipse.ui.internal.findandreplace.overlay;
 
 import java.lang.reflect.Method;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+
+import org.eclipse.swt.widgets.Control;
 
 import org.eclipse.core.runtime.ILog;
 
@@ -37,15 +40,61 @@ class FindReplaceOverlayCommandSupport {
 	private final IWorkbenchPart targetPart;
 	private DeactivateGlobalActionHandlers globalActionHandlerDeaction;
 
+	private final List<FindReplaceOverlayAction> commonActions = new ArrayList<>();
+	private final List<FindReplaceOverlayAction> searchActions = new ArrayList<>();
+	private final List<FindReplaceOverlayAction> replaceActions = new ArrayList<>();
+
 	FindReplaceOverlayCommandSupport(IWorkbenchPart targetPart) {
 		this.targetPart = targetPart;
 	}
 
-	void overlayActivated() {
-		setTextEditorActionsActivated(false);
+	void registerCommonAction(FindReplaceOverlayAction action) {
+		this.commonActions.add(action);
 	}
 
-	void overlayDeactivated() {
+	void registerSearchAction(FindReplaceOverlayAction action) {
+		this.searchActions.add(action);
+	}
+
+	void registerReplaceAction(FindReplaceOverlayAction action) {
+		this.replaceActions.add(action);
+	}
+
+	void unregisterReplaceActions() {
+		this.replaceActions.clear();
+	}
+
+	void registerCommonActionShortcutsAtControl(Control control) {
+		commonActions.forEach(action -> FindReplaceShortcutUtil.registerActionShortcutsAtControl(action, control));
+	}
+
+	void registerSearchActionShortcutsAtControl(Control control) {
+		searchActions.forEach(action -> FindReplaceShortcutUtil.registerActionShortcutsAtControl(action, control));
+	}
+
+	void registerReplaceActionShortcutsAtControl(Control control) {
+		replaceActions.forEach(action -> FindReplaceShortcutUtil.registerActionShortcutsAtControl(action, control));
+	}
+
+	void searchBarActivated() {
+		searchOrReplaceBarActivated();
+		searchActions.forEach(FindReplaceOverlayAction::activateKeyBinding);
+	}
+
+	void replaceBarActivated() {
+		searchOrReplaceBarActivated();
+		replaceActions.forEach(FindReplaceOverlayAction::activateKeyBinding);
+	}
+
+	private void searchOrReplaceBarActivated() {
+		setTextEditorActionsActivated(false);
+		commonActions.forEach(FindReplaceOverlayAction::activateKeyBinding);
+	}
+
+	void searchOrReplaceBarDeactivated() {
+		commonActions.forEach(FindReplaceOverlayAction::deactivateKeyBinding);
+		searchActions.forEach(FindReplaceOverlayAction::deactivateKeyBinding);
+		replaceActions.forEach(FindReplaceOverlayAction::deactivateKeyBinding);
 		setTextEditorActionsActivated(true);
 	}
 


### PR DESCRIPTION
The management of actions for the find/replace overlay, the registration of key shortcuts and the initialization of according tooltips with the shortcuts is currently part of the FindReplaceOverlay itself. In addition, the tooltip texts are static throughout the overlay lifecycle and show conflicting shortcuts, such as Enter for both the "search forward" and "replace" button, even though only either of them is registered, depending on which of the input fields has focus.

With this change, the responsibility for the action management with the activation and deactivation of their key bindings is moved to the FindReplaceOverlayCommandSupport. This prepares for the provision of the actions as Eclipse handlers in order to allow rebinding shortcuts.

Contributes to:
- https://github.com/eclipse-platform/eclipse.platform.ui/issues/1912
- https://github.com/eclipse-platform/eclipse.platform.ui/issues/2015

### Example

#### Before
Shortcuts for replace actions are shown even if search input field has focus and shortcuts are bound to search actions.
<img width="571" height="101" alt="image" src="https://github.com/user-attachments/assets/99be3b8e-c0ad-4d6a-9944-a5aa562279dc" />

#### After
Shortcuts for replace actions are not shown when search input field has focus and shortcuts are bound to search actions.
<img width="557" height="104" alt="image" src="https://github.com/user-attachments/assets/ebf86a66-59a4-4da7-b435-dfc73797de28" />



### Towards proper Eclipse key binding handlers

Having a dedicated class own all command infrastructure is a prerequisite for incrementally replacing the current reflection-based workaround with proper Eclipse command-framework handlers for the overlay actions. This change prepares that future migration. It follows:
- https://github.com/eclipse-platform/eclipse.platform.ui/pull/4164
- https://github.com/eclipse-platform/eclipse.platform.ui/pull/4169
- https://github.com/eclipse-platform/eclipse.platform.ui/pull/4178
- https://github.com/eclipse-platform/eclipse.platform.ui/pull/4176
- https://github.com/eclipse-platform/eclipse.platform.ui/pull/4184