### PR TITLE
Find/replace overlay: Read regex option from model instead button state

### DIFF
--- a/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/overlay/FindReplaceOverlay.java
+++ b/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/overlay/FindReplaceOverlay.java
@@ -1039,7 +1039,7 @@ public class FindReplaceOverlay {
 	}
 
 	private void decorate() {
-		if (regexSearchButton.getSelection()) {
+		if (findReplaceLogic.isAvailableAndActive(SearchOptions.REGEX)) {
 			SearchDecoration.validateRegex(getFindString(), searchBarDecoration);
 		} else {
 			searchBarDecoration.hide();


### PR DESCRIPTION
The regex search button state is synchronized from the find/replace logic's option state via a listener, so decorate() reading the button's selection depends on that synchronization having happened. Reading the option directly from the logic removes this hidden ordering dependency and is consistent with how the other consumers (e.g., content assist availability) already query the model.