### PR TITLE
Fix Tab navigation in split editors (revert CTabFolder workaround, requires SWT fix)

### DIFF
--- a/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/handlers/TraversePageHandler.java
+++ b/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/handlers/TraversePageHandler.java
@@ -13,11 +13,8 @@
  *******************************************************************************/
 package org.eclipse.ui.internal.handlers;
 import java.lang.reflect.Method;
-import java.util.Arrays;
 import org.eclipse.core.commands.ExecutionEvent;
 import org.eclipse.swt.SWT;
-import org.eclipse.swt.custom.CTabFolder;
-import org.eclipse.swt.custom.CTabItem;
 import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Shell;
@@ -38,16 +35,9 @@ public class TraversePageHandler extends WidgetMethodHandler {
 		Control focusControl = Display.getCurrent().getFocusControl();
 		if (focusControl != null) {
 			boolean forward = "next".equals(methodName); //$NON-NLS-1$
-			int traversalDirection = translateToTraversalDirection(forward);
+			final int traversalDirection = translateToTraversalDirection(forward);
 			Control control = focusControl;
 			do {
-				if (control instanceof CTabFolder) {
-					CTabFolder folder = getTopLevelCTabFolderInParentHierarchy(control);
-					if (isFinalItemInCTabFolder(folder, forward) && !hasHiddenItem(folder)) {
-						loopToFirstOrLastItem(folder, forward);
-						traversalDirection = translateToTraversalDirection(!forward);
-					}
-				}
 				if (control.traverse(traversalDirection)) {
 					return null;
 				}
@@ -60,63 +50,8 @@ public class TraversePageHandler extends WidgetMethodHandler {
 		return null;
 	}
 
-	/**
-	 * @param c a {@code Control}.
-	 * @return the top-level {@code CTabFolder} in the parent hierarchy.
-	 */
-	private CTabFolder getTopLevelCTabFolderInParentHierarchy(Control c) {
-		Control current = c;
-		CTabFolder ret = null;
-		do {
-			if (current instanceof CTabFolder folder) {
-				ret = folder;
-			}
-			current = current.getParent();
-		} while (current != null);
-		return ret;
-	}
-
-	private boolean hasHiddenItem(CTabFolder folder) {
-		return Arrays.stream(folder.getItems()).anyMatch(i -> !i.isShowing());
-	}
-
 	private int translateToTraversalDirection(boolean forward) {
 		return forward ? SWT.TRAVERSE_PAGE_NEXT : SWT.TRAVERSE_PAGE_PREVIOUS;
-	}
-
-	/**
-	 * Sets the current selection to the first or last item the given direction.
-	 *
-	 * @param folder  the CTabFolder which we want to inspect
-	 * @param forward whether we want to traverse forwards of backwards
-	 */
-	private void loopToFirstOrLastItem(CTabFolder folder, boolean forward) {
-		if (forward) {
-			folder.showItem(folder.getItem(0));
-			folder.setSelection(1);
-		} else {
-			int itemCount = folder.getItemCount();
-			folder.setSelection(itemCount - 2);
-		}
-	}
-
-	/**
-	 * {@return Returns whether the folder has currently selected the final item in
-	 * the given direction.}
-	 *
-	 * @param folder  the CTabFolder which we want to inspect
-	 * @param forward whether we want to traverse forwards of backwards
-	 */
-	private boolean isFinalItemInCTabFolder(CTabFolder folder, boolean forward) {
-		CTabItem currentFolder = folder.getSelection();
-		CTabItem lastFolder = null;
-		if (forward) {
-			int itemCount = folder.getItemCount();
-			lastFolder = folder.getItem(itemCount - 1);
-		} else {
-			lastFolder = folder.getItem(0);
-		}
-		return currentFolder.equals(lastFolder);
 	}
 
 	/**


### PR DESCRIPTION
## What
Fixes #4135.

This PR **reverts `TraversePageHandler` back to its standard, original traversal behavior**, removing the `CTabFolder`-specific special-casing that had been added as a workaround (loop-to-first/last-item logic, hidden-item detection, and the top-level `CTabFolder` parent-hierarchy lookup helper introduced by #2864 and the earlier attempt at fixing #4135).

That special-casing was only needed because `CTabFolder` itself did not loop over its own tabs when navigating with Ctrl+PageUp/PageDown, and it caused regressions such as bypassing the chevron drop-down list when tabs did not fit on screen (which is presumably the root cause of #4135, since the workaround interfered with focus traversal in split editors).

## Dependency
**This PR requires eclipse-platform/eclipse.platform.swt#3448 to be merged/available.** That SWT PR fixes `CTabFolder.onPageTraversal` directly, so `CTabFolder` now correctly wraps around from the last tab to the first (and vice versa) on its own — without needing any workaround at the `TraversePageHandler` level, and without breaking the chevron behavior when not all tabs fit.

## How to test
1. Make sure you have a build of SWT that includes eclipse-platform/eclipse.platform.swt#3448.
2. Open two editors side-by-side (split editors) so that Ctrl+PageUp/PageDown needs to traverse between the editor area's `CTabFolder`s correctly.
3. Confirm that tab navigation with Ctrl+PageUp/PageDown behaves as expected and no longer misbehaves in the split-editor scenario described in #4135.
4. Resize the editor area so that not all tabs fit and the chevron (drop-down list) appears; confirm that traversing past the last/first visible tab still opens the chevron drop-down as expected (this is the behavior that the old workaround used to bypass).
