### PR TITLE
Find/replace overlay: add test for proper shortcut hints

### DIFF
--- a/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/internal/findandreplace/overlay/FindReplaceOverlayTest.java
+++ b/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/internal/findandreplace/overlay/FindReplaceOverlayTest.java
@@ -19,6 +19,7 @@ import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
 
@@ -30,6 +31,7 @@ import org.eclipse.core.runtime.preferences.InstanceScope;
 
 import org.eclipse.text.tests.Accessor;
 
+import org.eclipse.jface.bindings.keys.KeyStroke;
 import org.eclipse.jface.viewers.ISelection;
 
 import org.eclipse.jface.text.IFindReplaceTarget;
@@ -55,6 +57,27 @@ public class FindReplaceOverlayTest extends FindReplaceUITest<OverlayAccess> {
 		OverlayAccess uiAccess= new OverlayAccess(getFindReplaceTarget(), overlay);
 		waitForFocus(uiAccess::hasFocus, testInfo.getTestMethod().get().getName());
 		return uiAccess;
+	}
+
+	@Test
+	public void testShortcutHintReflectsFocusedInputField() {
+		initializeTextViewerWithFindReplaceUI("line");
+		OverlayAccess dialog= getDialog();
+
+		String searchForwardHint= KeyStroke.getInstance(SWT.CR).format();
+
+		// The search bar has focus right after opening: its own shortcut hint is shown.
+		assertTrue(dialog.getSearchForwardToolTipText().contains(searchForwardHint));
+
+		// Opening the replace bar moves focus there: the search-scoped hint disappears and the
+		// replace-scoped hint (which happens to reuse the same shortcut) appears instead.
+		dialog.openReplaceDialog();
+		assertFalse(dialog.getSearchForwardToolTipText().contains(searchForwardHint));
+		assertTrue(dialog.getReplaceToolTipText().contains(searchForwardHint));
+
+		// Closing the replace bar returns focus to the search bar: its hint is shown again.
+		dialog.closeReplaceDialog();
+		assertTrue(dialog.getSearchForwardToolTipText().contains(searchForwardHint));
 	}
 
 	@Test

--- a/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/internal/findandreplace/overlay/OverlayAccess.java
+++ b/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/internal/findandreplace/overlay/OverlayAccess.java
@@ -254,6 +254,14 @@ class OverlayAccess implements IFindReplaceUIAccess {
 		replaceButton.notifyListeners(SWT.Selection, null);
 	}
 
+	public String getSearchForwardToolTipText() {
+		return searchForward.getToolTipText();
+	}
+
+	public String getReplaceToolTipText() {
+		return replaceButton != null ? replaceButton.getToolTipText() : null;
+	}
+
 	public boolean isReplaceDialogOpen() {
 		return replace != null;
 	}


### PR DESCRIPTION
## Motivation

#4185 fixed the search/replace bars' buttons showing shortcut-hint tooltips for actions that weren't actually reachable via that shortcut at the time — e.g. both the "search forward" and "replace" buttons showed the same "Enter" hint regardless of which input field had focus, since only one of them is actually bound to Enter depending on context.

That fix had no dedicated regression test. This adds one.

## What the test covers

Verifies that a button's shortcut-hint tooltip is only shown while its action is actually reachable via that shortcut — i.e. it appears when the corresponding input field (search or replace) has focus, and disappears again once focus moves elsewhere.

---
This PR description and the test were generated with the help of Claude Code.
