### PR TITLE
Find/replace overlay tests: correctly dispatch simulated key events

### DIFF
--- a/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/internal/findandreplace/overlay/OverlayAccess.java
+++ b/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/internal/findandreplace/overlay/OverlayAccess.java
@@ -144,7 +144,7 @@ class OverlayAccess implements IFindReplaceUIAccess {
 			event.stateMask= SWT.SHIFT;
 		}
 		event.keyCode= keyCode;
-		find.notifyListeners(SWT.KeyDown, event);
+		find.getTextBar().notifyListeners(SWT.KeyDown, event);
 		runEventQueue();
 	}
 


### PR DESCRIPTION
## Motivation

`OverlayAccess.simulateKeyboardInteractionInFindInputField()` (used by `FindReplaceOverlayTest`) simulates a keystroke by notifying listeners on a wrapper widget that internally forwards the event to two different widgets. Since SWT's global event filters react to a dispatched event regardless of which widget triggered it, this causes a single simulated keystroke to be processed twice by anything hooking into such a global filter, such as Eclipse's key-binding dispatch.

This currently has no observable effect, since the overlay's own key handling only relies on a listener attached directly to the actual text control, not on any global event filter. It would, however, cause a command bound to a key sequence through Eclipse's key-binding infrastructure to execute twice per simulated keystroke — which is exactly the failure mode surfaced by #4192, which moves the overlay onto real Eclipse key bindings.

## What changed

The synthetic event is now dispatched directly on the search text control instead of the wrapper, matching how a single real keystroke is delivered.

This has no effect on the current state of `master` (the `FindReplaceOverlayTest` suite passes unchanged), but is required for the tests to pass correctly on top of #4192.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
