### PR TITLE
Find/Replace overlay: use handler enablement for button enabled state

### DIFF
--- a/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/overlay/AccessibleToolItem.java
+++ b/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/overlay/AccessibleToolItem.java
@@ -18,13 +18,15 @@ import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.ToolBar;
 import org.eclipse.swt.widgets.ToolItem;
 
+import org.eclipse.core.commands.HandlerEvent;
+import org.eclipse.core.commands.IHandlerListener;
+
 import org.eclipse.jface.layout.GridDataFactory;
 
 class AccessibleToolItem {
 	private final ToolItem toolItem;
 
 	private String baseToolTipText;
-
 
 	AccessibleToolItem(Composite parent, int styleBits) {
 		ToolBar toolbar = new ToolBar(parent, SWT.FLAT | SWT.HORIZONTAL);
@@ -51,6 +53,15 @@ class AccessibleToolItem {
 
 	void setAction(FindReplaceOverlayAction action) {
 		setToolTipText(toolItem.getToolTipText());
+		toolItem.setEnabled(action.isEnabled());
+		action.addHandlerListener(new IHandlerListener() {
+			@Override
+			public void handlerChanged(HandlerEvent event) {
+				if (event.isEnabledChanged() && !toolItem.isDisposed()) {
+					toolItem.setEnabled(action.isEnabled());
+				}
+			}
+		});
 		toolItem.addSelectionListener(SelectionListener.widgetSelectedAdapter(__ -> action.execute()));
 		action.addShortcutHintListener(hint -> {
 			if (!toolItem.isDisposed()) {

--- a/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/overlay/AccessibleToolItemBuilder.java
+++ b/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/overlay/AccessibleToolItemBuilder.java
@@ -104,12 +104,8 @@ class AccessibleToolItemBuilder {
 					toolItem.setSelection(invertSearchOption ? !state : state);
 				}
 			});
-			toolItem.setEnabled(findReplaceLogic.isAvailable(searchOption));
-			findReplaceLogic.addSearchOptionAvailabilityChangedListener(searchOption, state -> {
-				if (!toolItem.isDisposed()) {
-					toolItem.setEnabled(state);
-				}
-			});
+			searchOptionAction.setAvailable(findReplaceLogic.isAvailable(searchOption));
+			findReplaceLogic.addSearchOptionAvailabilityChangedListener(searchOption, searchOptionAction::setAvailable);
 			return toolItem;
 		}
 	}

--- a/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/overlay/FindReplaceOverlayAction.java
+++ b/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/overlay/FindReplaceOverlayAction.java
@@ -15,9 +15,12 @@ import java.util.Collections;
 import java.util.List;
 import java.util.function.Consumer;
 
+import org.eclipse.core.commands.AbstractHandler;
+import org.eclipse.core.commands.ExecutionEvent;
+
 import org.eclipse.jface.bindings.keys.KeyStroke;
 
-class FindReplaceOverlayAction {
+class FindReplaceOverlayAction extends AbstractHandler {
 	private final Runnable operation;
 
 	private final List<Runnable> executionListeners = new ArrayList<>();
@@ -34,9 +37,19 @@ class FindReplaceOverlayAction {
 		this.shortcuts.addAll(shortcutsToAdd);
 	}
 
+	@Override
+	public Object execute(ExecutionEvent event) {
+		execute();
+		return null;
+	}
+
 	void execute() {
 		operation.run();
 		notifyExecutionListeners();
+	}
+
+	void setAvailable(boolean available) {
+		setBaseEnabled(available);
 	}
 
 	List<KeyStroke> getShortcuts() {


### PR DESCRIPTION
The enablement of the buttons for search options of the find/replace overlay are currently derived from the availability of the underlying search option. However, there are actions attached to the buttons (changing activation of the search option) and the button enablement should actually reflect if that action is available or not. Though these are effectively equal, mapping the button enablement to the action availability is the conceptually more correct representation.

With this change, FindReplaceOverlayAction extends AbstractHandler, making the action itself a handler and providing and enablement state. Enablement of the buttons for the search options is not kept in sync with enablement of the action/handler via an according handler listener.

This is a standalone-reasonable change extracted from:
- https://github.com/eclipse-platform/eclipse.platform.ui/pull/4192