### PR TITLE
Find/Replace overlay tests: use correct simulated event character for CR

### DIFF
--- a/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/internal/findandreplace/overlay/OverlayAccess.java
+++ b/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/internal/findandreplace/overlay/OverlayAccess.java
@@ -143,6 +143,9 @@ class OverlayAccess implements IFindReplaceUIAccess {
 		if (shiftPressed) {
 			event.stateMask= SWT.SHIFT;
 		}
+		if (keyCode == SWT.CR | keyCode == SWT.KEYPAD_CR) {
+			event.character= '\r';
+		}
 		event.keyCode= keyCode;
 		find.getTextBar().notifyListeners(SWT.KeyDown, event);
 		runEventQueue();

--- a/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/workbench/texteditor/tests/DialogAccess.java
+++ b/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/workbench/texteditor/tests/DialogAccess.java
@@ -175,6 +175,9 @@ class DialogAccess implements IFindReplaceUIAccess {
 		if (shiftPressed) {
 			event.stateMask= SWT.SHIFT;
 		}
+		if (keyCode == SWT.CR | keyCode == SWT.KEYPAD_CR) {
+			event.character= '\r';
+		}
 		event.keyCode= keyCode;
 		findCombo.traverse(SWT.TRAVERSE_RETURN, event);
 		runEventQueue();


### PR DESCRIPTION
The tests for find/replace overlay (and dialog) also simulate specific keyboard interactions. This especially contains tests for pressing the Return button. The created events currently only have the keyCode set, whereas the actual events that are generated by human keyboard interactions also contain the key character. In case of pressing any of the Return buttons, the character is `\r`. This is not only an incomplete simulation (which currently has no negative effect) but also leads to test failures once key bindings for the find/replace overlay are implemented via the Eclipse command infrastructure and the according key binding dispatcher, as that one relies on the `\r` character for also mapping they numpad Return to a configured key binding for the Return (CR) button.

This enhances the simulated key events for find/replace UI tests accordingly. It adds the proper character value for Return presses to correctly reflect the event structure that is generated upon a real keyboard interaction.

Failures because of this test event incompleteness would occur when switching to proper Eclipse commands for the find/replace overlay with:
- https://github.com/eclipse-platform/eclipse.platform.ui/pull/4192

Thus this is an extract/preparatory change of that PR which is reasonable on its own.