### PR TITLE
Find/replace tests: assert proper selection of options

### DIFF
--- a/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/internal/findandreplace/overlay/OverlayAccess.java
+++ b/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/internal/findandreplace/overlay/OverlayAccess.java
@@ -122,6 +122,7 @@ class OverlayAccess implements IFindReplaceUIAccess {
 		ToolItem button= getButtonForSearchOption(option);
 		if (button != null) {
 			button.notifyListeners(SWT.Selection, null);
+			assertSelected(option);
 		}
 	}
 
@@ -133,6 +134,7 @@ class OverlayAccess implements IFindReplaceUIAccess {
 		ToolItem button= getButtonForSearchOption(option);
 		if (button != null) {
 			button.notifyListeners(SWT.Selection, null);
+			assertUnselected(option);
 		}
 	}
 

--- a/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/workbench/texteditor/tests/DialogAccess.java
+++ b/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/workbench/texteditor/tests/DialogAccess.java
@@ -132,6 +132,7 @@ class DialogAccess implements IFindReplaceUIAccess {
 		Button button= getButtonForSearchOption(option);
 		button.setSelection(true);
 		button.notifyListeners(SWT.Selection, null);
+		assertSelected(option);
 	}
 
 	@Override
@@ -145,6 +146,7 @@ class DialogAccess implements IFindReplaceUIAccess {
 			button.setSelection(false);
 		}
 		button.notifyListeners(SWT.Selection, null);
+		assertUnselected(option);
 	}
 
 

--- a/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/workbench/texteditor/tests/WorkbenchTextEditorTestSuite.java
+++ b/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/workbench/texteditor/tests/WorkbenchTextEditorTestSuite.java
@@ -13,8 +13,8 @@
  *******************************************************************************/
 package org.eclipse.ui.workbench.texteditor.tests;
 
-import org.junit.platform.suite.api.Suite;
 import org.junit.platform.suite.api.SelectClasses;
+import org.junit.platform.suite.api.Suite;
 
 import org.eclipse.ui.internal.findandreplace.FindReplaceLogicTest;
 import org.eclipse.ui.internal.findandreplace.HistoryStoreTest;
@@ -46,9 +46,9 @@ import org.eclipse.ui.workbench.texteditor.tests.rulers.RulerTestSuite;
 		MinimapWidgetTest.class,
 		TextEditorPluginTest.class,
 		TextViewerDeleteLineTargetTest.class,
-		FindReplaceDialogTest.class,
-		FindReplaceOverlayTest.class,
 		FindReplaceLogicTest.class,
+		FindReplaceOverlayTest.class,
+		FindReplaceDialogTest.class,
 		HistoryStoreTest.class,
 })
 public class WorkbenchTextEditorTestSuite {


### PR DESCRIPTION
In case search options are not properly selected/unselected in tests, test may be effectively executed with different search options than expected and succeed without identifying issues when having the options properly selected/unselected. This adds according assertions to make sure that selection changes succeed.
This also enhances the order of test execution in the texteditor test suite.

This is an extract of / preparation for:
- https://github.com/eclipse-platform/eclipse.platform.ui/pull/4192