### PR TITLE
Find/Replace overlay: fix content assist not available in Java files

### DIFF
--- a/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/overlay/FindReplaceOverlay.java
+++ b/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/overlay/FindReplaceOverlay.java
@@ -501,6 +501,8 @@ public class FindReplaceOverlay {
 		// Also close on Ctrl+F: otherwise it would reopen (a duplicate of) this very overlay.
 		commandSupport.registerAction(
 				new FindReplaceOverlayAction(this::close, IWorkbenchCommandConstants.EDIT_FIND_AND_REPLACE));
+		commandSupport.registerAction(new FindReplaceOverlayAction(this::triggerContentAssist,
+				ITextEditorActionDefinitionIds.CONTENT_ASSIST_PROPOSALS));
 
 		// Close button
 		new AccessibleToolItemBuilder(closeTools).withStyleBits(SWT.PUSH)
@@ -974,6 +976,14 @@ public class FindReplaceOverlay {
 
 	private void updateContentAssistAvailability() {
 		setContentAssistsEnablement(findReplaceLogic.isAvailableAndActive(SearchOptions.REGEX));
+	}
+
+	private void triggerContentAssist() {
+		if (searchBar.isFocusControl() && contentAssistSearchField.isEnabled()) {
+			contentAssistSearchField.openProposalPopup();
+		} else if (okayToUse(replaceBar) && replaceBar.isFocusControl() && contentAssistReplaceField.isEnabled()) {
+			contentAssistReplaceField.openProposalPopup();
+		}
 	}
 
 	private void decorate() {


### PR DESCRIPTION
## Motivation

Fixes #2651. Pressing Ctrl+Space in the overlay's search/replace fields while regex mode is active shows the "content assist available" hint, but never actually opens content assist — most noticeably in `.java` files.

The cause: `ContentAssistCommandAdapter` (used by the overlay's regex content-assist fields) activates its handler on the workbench-root `IHandlerService` without an expression. The target editor (e.g. the Java editor) keeps its own handler for the same command permanently active via a part-scoped `ActivePartExpression`. Since Eclipse resolves conflicting handler activations for the same command purely by evaluated source priority — independent of context nesting — the editor's higher-priority activation always wins, regardless of where focus actually is.

## What changed

Register an ordinary `FindReplaceOverlayAction` for the content-assist command, the same way `EDIT_FIND_AND_REPLACE` (Ctrl+F) is already handled: through `registerAction()`'s `overlayFocusedExpression` (an `ACTIVE_FOCUS_CONTROL`-based expression). That expression alone already outranks the editor's `ActivePartExpression`-based activation, regardless of which `IHandlerService` the activation is registered on, so no separate, part-scoped override mechanism is needed for this.

## Screenshot

<img width="687" height="217" alt="image" src="https://github.com/user-attachments/assets/04dff5bf-1bb7-4e53-9454-826db20f73d9" />

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
