### PR TITLE
Skip forceActive in generic editor tests when shell is already active

### DIFF
--- a/tests/org.eclipse.ui.genericeditor.tests/src/org/eclipse/ui/genericeditor/tests/AbstratGenericEditorTest.java
+++ b/tests/org.eclipse.ui.genericeditor.tests/src/org/eclipse/ui/genericeditor/tests/AbstratGenericEditorTest.java
@@ -30,6 +30,8 @@ import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IResource;
 import org.eclipse.core.resources.ResourcesPlugin;
 
+import org.eclipse.swt.widgets.Shell;
+
 import org.eclipse.ui.IEditorInput;
 import org.eclipse.ui.IWorkbenchWindow;
 import org.eclipse.ui.PlatformUI;
@@ -62,7 +64,11 @@ public class AbstratGenericEditorTest {
 		project.setDefaultCharset(StandardCharsets.UTF_8.name(), null);
 		waitForJobs(100, 5000);
 		window= PlatformUI.getWorkbench().getActiveWorkbenchWindow();
-		forceActive(window.getShell());
+		Shell shell= window.getShell();
+		// forceActive() has a one second floor, so skip it when the shell is already active
+		if (shell.getDisplay().getActiveShell() != shell) {
+			forceActive(shell);
+		}
 		createAndOpenFile();
 	 }
 


### PR DESCRIPTION
`UITestUtil.forceActive()` has a documented one second floor made up of four `waitForJobs()` calls, see bug 417258#c27, and on top of that it minimizes and restores every visible shell. `AbstratGenericEditorTest.setUp()` calls it on every test method, so all 45 tests in the bundle pay the full cost even when the shell is already active.

This only forces the shell active when it is not already the active shell, which is the same condition `forceActive()` itself returns. Whenever the shell genuinely needs activating the behaviour is unchanged.

Measured locally the bundle drops from 65.3s to 19.4s with all 45 tests still passing. For context, on a recent full CI run `org.eclipse.ui.genericeditor.tests` was the second slowest bundle in the suite at 66.3s, and 58.5s of that was a flat per-test floor of about 1.25s present in every one of its 14 test classes.