### PR TITLE
Remove the deprecated getViewCSS() compatibility bridge

### DIFF
--- a/bundles/org.eclipse.e4.ui.css.core/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.e4.ui.css.core/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-SymbolicName: org.eclipse.e4.ui.css.core;singleton:=true
 Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
-Bundle-Version: 0.14.800.qualifier
+Bundle-Version: 0.14.900.qualifier
 Export-Package: org.eclipse.e4.ui.css.core.css2;x-friends:="org.eclipse.e4.ui.css.swt.theme,org.eclipse.e4.ui.css.swt,org.eclipse.e4.ui.css.jface",
  org.eclipse.e4.ui.css.core.dom;x-friends:="org.eclipse.e4.ui.css.swt,org.eclipse.ui.views.properties.tabbed,org.eclipse.ui.forms",
  org.eclipse.e4.ui.css.core.dom.properties;

--- a/bundles/org.eclipse.e4.ui.css.core/src/org/eclipse/e4/ui/css/core/engine/CSSEngine.java
+++ b/bundles/org.eclipse.e4.ui.css.core/src/org/eclipse/e4/ui/css/core/engine/CSSEngine.java
@@ -27,8 +27,6 @@ import org.eclipse.e4.ui.css.core.util.resources.IResourcesLocatorManager;
 import org.w3c.dom.Element;
 import org.w3c.dom.css.CSSStyleDeclaration;
 import org.w3c.dom.css.CSSValue;
-import org.w3c.dom.css.ViewCSS;
-import org.w3c.dom.views.DocumentView;
 
 /**
  * CSS Engine interface used to parse style sheet and apply styles to something
@@ -190,25 +188,6 @@ public interface CSSEngine {
 	 * element from all stylesheets registered with this engine.
 	 */
 	CSSStyleDeclaration computeStyle(Element element, String pseudoElt);
-
-	/**
-	 * Binary-compatibility bridge for callers compiled against the removed
-	 * W3C cascade accessor; use {@link #computeStyle(Element, String)}.
-	 */
-	@Deprecated(forRemoval = true, since = "2026-06")
-	default ViewCSS getViewCSS() {
-		return new ViewCSS() {
-			@Override
-			public DocumentView getDocument() {
-				return null;
-			}
-
-			@Override
-			public CSSStyleDeclaration getComputedStyle(Element elt, String pseudoElt) {
-				return computeStyle(elt, pseudoElt);
-			}
-		};
-	}
 
 	/*--------------- w3c Element -----------------*/
 


### PR DESCRIPTION
Removes the deprecated `getViewCSS()` default method from `CSSEngine`. It was added in #4122 as a bridge for the PDE CSS spy, which at the time still went through the W3C cascade accessor, and was always meant to be temporary.

Nothing in this repository calls it: the `org.eclipse.e4.ui.css.core.engine` package is not exported to any PDE bundle, so the spy reached it reflectively rather than at compile time.

The current spy no longer needs it either. `CssEngineCompat` in `org.eclipse.pde.spy.css` (eclipse-pde#2396, merged) gates on `hasMethod(CSSEngine.class, "computeStyle", Element.class, String.class)` and takes the `computeStyle` path on any engine that has it, so the `getViewCSS` branch is already unreachable on a reworked platform. eclipse-pde#2399 deletes that reflection entirely, but this removal does not depend on it.

Local verification: `org.eclipse.e4.ui.css.core` and `org.eclipse.e4.ui.css.swt` build clean and both suites are green (128 css.core, 210 css.swt with 9 skipped).

Kept as a draft for now so it can follow eclipse-pde#2399. 

The whole CSS engine is internal API
