### PR TITLE
Do not poll 100 times when asserting a reference is not enqueued

### DIFF
--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/dynamicplugins/DynamicSupportTests.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/dynamicplugins/DynamicSupportTests.java
@@ -16,7 +16,6 @@ package org.eclipse.ui.tests.dynamicplugins;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThrows;
 
 import java.lang.ref.ReferenceQueue;
 import java.lang.ref.WeakReference;
@@ -93,7 +92,7 @@ public class DynamicSupportTests {
 		ReferenceQueue<Object> queue = new ReferenceQueue<>();
 		WeakReference<Object> ref = new WeakReference<>(o1, queue);
 		o1 = null;
-		assertThrows(Throwable.class, () -> LeakTests.checkRef(queue, ref));
+		LeakTests.checkRefNotEnqueued(queue, ref);
 		Object [] results = tracker.getObjects(e1);
 		assertNotNull(results);
 		assertEquals(1, results.length);

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/leaks/LeakTests.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/leaks/LeakTests.java
@@ -17,6 +17,7 @@ package org.eclipse.ui.tests.leaks;
 
 import static org.eclipse.ui.tests.harness.util.UITestUtil.openTestWindow;
 import static org.eclipse.ui.tests.harness.util.UITestUtil.processEvents;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -69,19 +70,30 @@ public class LeakTests {
 
 	public static void checkRef(ReferenceQueue<?> queue, Reference<?> ref)
 			throws IllegalArgumentException, InterruptedException {
-		boolean flag = false;
-		for (int i = 0; i < 100; i++) {
+		assertTrue(pollForRef(queue, ref, 100), "Reference not enqueued");
+	}
+
+	/**
+	 * Asserts that the given reference is not enqueued. Polls far fewer times than
+	 * {@link #checkRef}, because this case always exhausts every attempt.
+	 */
+	public static void checkRefNotEnqueued(ReferenceQueue<?> queue, Reference<?> ref)
+			throws IllegalArgumentException, InterruptedException {
+		assertFalse(pollForRef(queue, ref, 5), "Reference enqueued");
+	}
+
+	private static boolean pollForRef(ReferenceQueue<?> queue, Reference<?> ref, int attempts)
+			throws InterruptedException {
+		for (int i = 0; i < attempts; i++) {
 			System.gc();
 			Thread.yield();
 			processEvents();
 			Reference<?> checkRef = queue.remove(100);
 			if (checkRef != null && checkRef.equals(ref)) {
-				flag = true;
-				break;
+				return true;
 			}
 		}
-
-		assertTrue(flag, "Reference not enqueued");
+		return false;
 	}
 
 	@SuppressWarnings("unchecked")


### PR DESCRIPTION
`LeakTests.checkRef()` polls up to 100 times, calling `System.gc()` and blocking for up to 100ms on `ReferenceQueue.remove()` in each round. It breaks out as soon as the reference is enqueued, so the normal positive case is cheap.

`DynamicSupportTests.testConfigurationElementTracker4` asserts the opposite, that the object stays reachable because the tracker holds a strong reference, by wrapping `checkRef()` in `assertThrows()`. That case exhausts all 100 rounds by design, costing 10s of poll timeouts plus 100 full garbage collections on every run. On a recent full CI run it accounted for 20.33s of the class total of 20.4s, while its three sibling tests together take 0.10s.

This adds `checkRefNotEnqueued()` with a small poll count for that case, which also reads better than asserting that a helper throws. It is the only negative call site among the 23 `checkRef()` uses in the repository, so the positive path is untouched. Locally the class drops from 13.9s to 0.8s, with `LeakTests` and the other `checkRef` callers still passing.