### PR TITLE
Remove blind settle delay from code mining test fixtures

### DIFF
--- a/tests/org.eclipse.jface.text.tests/src/org/eclipse/jface/text/tests/codemining/CodeMiningLineHeaderAnnotationTest.java
+++ b/tests/org.eclipse.jface.text.tests/src/org/eclipse/jface/text/tests/codemining/CodeMiningLineHeaderAnnotationTest.java
@@ -70,7 +70,6 @@ public class CodeMiningLineHeaderAnnotationTest {
 				return fViewer.getTextWidget().isVisible();
 			}
 		}.waitForCondition(display, 3000));
-		DisplayHelper.sleep(textWidget.getDisplay(), 1000);
 	}
 
 	@AfterEach

--- a/tests/org.eclipse.jface.text.tests/src/org/eclipse/jface/text/tests/codemining/CodeMiningTest.java
+++ b/tests/org.eclipse.jface.text.tests/src/org/eclipse/jface/text/tests/codemining/CodeMiningTest.java
@@ -132,7 +132,6 @@ public class CodeMiningTest {
 				return fViewer.getTextWidget().isVisible();
 			}
 		}.waitForCondition(display, 3000));
-		DisplayHelper.sleep(textWidget.getDisplay(), 1000);
 	}
 
 	@AfterEach


### PR DESCRIPTION
`CodeMiningTest.setUp()` and `CodeMiningLineHeaderAnnotationTest.setUp()` both ended with `DisplayHelper.sleep(display, 1000)`, placed directly after a `waitForCondition()` that had already established that the text widget is visible. `DisplayHelper.sleep()` is `waitForCondition()` with the condition hardcoded to `false`, so it always burns the full second. In `CodeMiningTest` the provider is installed on an empty document and skips blank lines, so no code minings are produced during setup and there is nothing to settle for.

On a recent full CI run `CodeMiningTest` was 22.6s over 19 tests with a median of 1.04s against a minimum of 0.19s, and `CodeMiningLineHeaderAnnotationTest` was 4.0s over 4 tests with minimum and median both 1.01s. Locally the passing tests drop from 22.6s to 5.8s, with each affected test falling by almost exactly the removed second.
