### PR TITLE
Remove duplicate Link with Editor from menu bar in project explorer

### DIFF
--- a/bundles/org.eclipse.ui.navigator/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.ui.navigator/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Plugin.name
 Bundle-SymbolicName: org.eclipse.ui.navigator; singleton:=true
-Bundle-Version: 3.14.100.qualifier
+Bundle-Version: 3.14.200.qualifier
 Bundle-Activator: org.eclipse.ui.internal.navigator.NavigatorPlugin
 Bundle-Vendor: %Plugin.providerName
 Bundle-Localization: plugin

--- a/bundles/org.eclipse.ui.navigator/src/org/eclipse/ui/internal/navigator/CommonNavigatorActionGroup.java
+++ b/bundles/org.eclipse.ui.navigator/src/org/eclipse/ui/internal/navigator/CommonNavigatorActionGroup.java
@@ -182,9 +182,6 @@ public class CommonNavigatorActionGroup extends ActionGroup implements IMementoA
 		menu.add(new Separator());
 		menu.add(new Separator(IWorkbenchActionConstants.MB_ADDITIONS));
 		menu.add(new Separator(IWorkbenchActionConstants.MB_ADDITIONS + "-end"));//$NON-NLS-1$
-		if (toggleLinkingAction != null) {
-			menu.insertAfter(IWorkbenchActionConstants.MB_ADDITIONS + "-end", toggleLinkingAction); //$NON-NLS-1$
-		}
 	}
 
 	private void updateToolBar(IToolBarManager toolBar) {


### PR DESCRIPTION
This change removes the `Link with Editor` option from the view menu in project explorer.

The same action is already available in the toolbar, so having it in both places is unnecessary. This also makes the view consistent with the other toolbar actions, which do not have duplicate entries in the view menu.

A similar duplicate entry is there in Package Explorer in JDT UI. I plan to raise for that, once this change is merged.

Before :
<img width="301" height="321" alt="Screenshot 2026-07-29 at 7 04 31 PM" src="https://github.com/user-attachments/assets/277045f7-c9c0-464b-a172-eadfe3698883" />

After :
<img width="360" height="362" alt="Screenshot 2026-07-29 at 7 04 03 PM" src="https://github.com/user-attachments/assets/57a5400c-3b90-418f-be93-b48d37e5b4fe" />


