### PR TITLE
Restore settle delay in code mining test fixtures

### DIFF
--- a/tests/org.eclipse.jface.text.tests/src/org/eclipse/jface/text/tests/codemining/CodeMiningLineHeaderAnnotationTest.java
+++ b/tests/org.eclipse.jface.text.tests/src/org/eclipse/jface/text/tests/codemining/CodeMiningLineHeaderAnnotationTest.java
@@ -70,6 +70,7 @@ public class CodeMiningLineHeaderAnnotationTest {
 				return fViewer.getTextWidget().isVisible();
 			}
 		}.waitForCondition(display, 3000));
+		DisplayHelper.sleep(textWidget.getDisplay(), 1000);
 	}
 
 	@AfterEach

--- a/tests/org.eclipse.jface.text.tests/src/org/eclipse/jface/text/tests/codemining/CodeMiningTest.java
+++ b/tests/org.eclipse.jface.text.tests/src/org/eclipse/jface/text/tests/codemining/CodeMiningTest.java
@@ -132,10 +132,12 @@ public class CodeMiningTest {
 				return fViewer.getTextWidget().isVisible();
 			}
 		}.waitForCondition(display, 3000));
+		DisplayHelper.sleep(textWidget.getDisplay(), 1000);
 	}
 
 	@AfterEach
 	public void tearDown() {
+		DelayedEchoCodeMiningProvider.DELAY= 0;
 		if (fReconciler != null) {
 			fReconciler.uninstall();
 			fReconciler = null;


### PR DESCRIPTION
Reverts 13b7e488b7, which made `CodeMiningTest.testCodeMiningCompletableFutureReturnsNull()` fail sporadically on the I-builds.

The reasoning behind removing the settle only covered the code minings, not the reconciler. `AbstractReconciler.startReconciling()` schedules a job that waits `fDelay` before running `initialProcess()` and starting the worker thread, so the sleep was what let the reconciler finish starting up before a test ran. Without it the document change in the test body arrives mid-startup and takes an extra delay cycle before it is reconciled, which on a loaded machine exceeds the 3s assertion budget. The two affected tests are the only ones in the class that rely on the reconciler picking up a document change rather than on a `setCodeMiningProviders()` call issued after the document is set.

Also resets `DelayedEchoCodeMiningProvider.DELAY` in `tearDown`, since `testCodeMiningCtrlHome()` raises that static field to 500 and every later test in the class inherited the slower provider.

Fixes #4217