### PR TITLE
Dispose SourceViewerDecorationSupport in QuickSearchDialog

### DIFF
--- a/bundles/org.eclipse.text.quicksearch/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.text.quicksearch/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.text.quicksearch;singleton:=true
-Bundle-Version: 1.3.500.qualifier
+Bundle-Version: 1.3.600.qualifier
 Bundle-Activator: org.eclipse.text.quicksearch.internal.ui.QuickSearchActivator
 Require-Bundle: org.eclipse.ui;bundle-version="[3.113.0,4.0.0)",
  org.eclipse.core.resources;bundle-version="[3.13.0,4.0.0)",

--- a/bundles/org.eclipse.text.quicksearch/src/org/eclipse/text/quicksearch/internal/ui/QuickSearchDialog.java
+++ b/bundles/org.eclipse.text.quicksearch/src/org/eclipse/text/quicksearch/internal/ui/QuickSearchDialog.java
@@ -384,6 +384,7 @@ public class QuickSearchDialog extends SelectionStatusDialog {
 
 	private SourceViewer viewer;
 	private LineNumberRulerColumn lineNumberColumn;
+	private SourceViewerDecorationSupport sourceViewerDecorationSupport;
 	private FixedLineHighlighter targetLineHighlighter;
 	private final IPropertyChangeListener preferenceChangeListener = this::handlePropertyChangeEvent;
 
@@ -561,26 +562,7 @@ public class QuickSearchDialog extends SelectionStatusDialog {
 	 */
 	@Override
 	public boolean close() {
-		this.progressJob.cancel();
-		this.progressJob = null;
-//		this.refreshProgressMessageJob.cancel();
-		if (showViewHandler != null) {
-			IHandlerService service = PlatformUI
-					.getWorkbench().getService(IHandlerService.class);
-			service.deactivateHandler(showViewHandler);
-			showViewHandler.getHandler().dispose();
-			showViewHandler = null;
-		}
-		if (menuManager != null) {
-			menuManager.dispose();
-		}
-		if (contextMenuManager != null) {
-			contextMenuManager.dispose();
-		}
 		storeDialog(getDialogSettings());
-		if (searcher!=null) {
-			searcher.cancel();
-		}
 		return super.close();
 	}
 
@@ -1015,6 +997,32 @@ public class QuickSearchDialog extends SelectionStatusDialog {
 	}
 
 	protected void dispose() {
+		if (progressJob != null) {
+			progressJob.cancel();
+			progressJob = null;
+		}
+		if (showViewHandler != null) {
+			IHandlerService service = PlatformUI.getWorkbench().getService(IHandlerService.class);
+			service.deactivateHandler(showViewHandler);
+			showViewHandler.getHandler().dispose();
+			showViewHandler = null;
+		}
+		if (menuManager != null) {
+			menuManager.dispose();
+			menuManager = null;
+		}
+		if (contextMenuManager != null) {
+			contextMenuManager.dispose();
+			contextMenuManager = null;
+		}
+		if (searcher != null) {
+			searcher.cancel();
+			searcher = null;
+		}
+		if (sourceViewerDecorationSupport != null) {
+			sourceViewerDecorationSupport.dispose();
+			sourceViewerDecorationSupport = null;
+		}
 		if (blankImage!=null) {
 			blankImage.dispose();
 			blankImage = null;
@@ -1086,7 +1094,7 @@ public class QuickSearchDialog extends SelectionStatusDialog {
 		lineNumberColumn.setForeground(getLineNumbersColor());
 		viewer.addVerticalRulerColumn(lineNumberColumn);
 
-		var sourceViewerDecorationSupport = new SourceViewerDecorationSupport(viewer, null, null, EditorsUI.getSharedTextColors());
+		sourceViewerDecorationSupport = new SourceViewerDecorationSupport(viewer, null, null, EditorsUI.getSharedTextColors());
 		sourceViewerDecorationSupport.setCursorLinePainterPreferenceKeys(EDITOR_CURRENT_LINE, EDITOR_CURRENT_LINE_COLOR);
 		sourceViewerDecorationSupport.install(EditorsUI.getPreferenceStore());
 		targetLineHighlighter = new FixedLineHighlighter();


### PR DESCRIPTION
The `QuickSearchDialog` did not dispose the `SourceViewerDecorationSupport` created in `createViewerDecorations()`, leading to a resource leak. This disposes `SourceViewerDecorationSupport` when closing the dialog.