### PR TITLE
Extract findExistingProject from isExistingProject

### DIFF
--- a/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/wizards/datatransfer/SmartImportRootWizardPage.java
+++ b/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/wizards/datatransfer/SmartImportRootWizardPage.java
@@ -787,14 +787,19 @@ public class SmartImportRootWizardPage extends WizardPage {
 		}
 
 	}
-	protected boolean isExistingProject(File element) {
+
+	private IProject findExistingProject(File element) {
 		for (IProject project : ResourcesPlugin.getWorkspace().getRoot().getProjects()) {
 			IPath location = project.getLocation();
 			if (location != null && element.equals(location.toFile())) {
-				return true;
+				return project;
 			}
 		}
-		return false;
+		return null;
+	}
+
+	protected boolean isExistingProject(File element) {
+		return findExistingProject(element) != null;
 	}
 
 	protected boolean isExistingProjectName(File element) {


### PR DESCRIPTION
isExistingProject(File) looked up a matching IProject by location but only returned whether a match was found, discarding the IProject itself. Extract that lookup into a new findExistingProject(File), returning the matching IProject or null, and have isExistingProject delegate to it.

All 7 existing references of isExistingProject(File) continue to receive the same boolean result for the same input as before; none are affected in behavior.

This is groundwork split out from the discussion on #4170, which proposed letting users act on already-imported projects from the Smart Import wizard. That interactive behavior is still under review; this change is limited to the underlying lookup and carries no UI or behavior change on its own.

Why this pr?
#4170  proposes letting users take action on a project that's already imported (open it if closed, navigate to it if open), which needs the actual `IProject`, not just a yes/no. Reviewer feedback on that PR raised open questions about the right interaction model for that (modal dialog vs. inline action vs. a different approach entirely), so that part is still being worked out.

This lookup, though, is needed regardless of which ever direction that discussion lands on. So splitting it out lets it be reviewed and merged on its own, rather than being tied up in a larger design discussion.