### PR TITLE
Publish the effective theme id so clients can read it back

### DIFF
--- a/bundles/org.eclipse.e4.ui.css.swt.theme/src/org/eclipse/e4/ui/css/swt/internal/theme/ThemeEngine.java
+++ b/bundles/org.eclipse.e4.ui.css.swt.theme/src/org/eclipse/e4/ui/css/swt/internal/theme/ThemeEngine.java
@@ -41,9 +41,12 @@ import org.eclipse.core.runtime.ILog;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.Platform;
 import org.eclipse.core.runtime.RegistryFactory;
+import org.eclipse.core.runtime.preferences.ConfigurationScope;
+import org.eclipse.core.runtime.preferences.DefaultScope;
 import org.eclipse.core.runtime.preferences.IEclipsePreferences;
 import org.eclipse.core.runtime.preferences.IPreferencesService;
 import org.eclipse.core.runtime.preferences.InstanceScope;
+import org.eclipse.core.runtime.preferences.UserScope;
 import org.eclipse.e4.ui.css.core.engine.CSSElementContext;
 import org.eclipse.e4.ui.css.core.engine.CSSEngine;
 import org.eclipse.e4.ui.css.core.util.impl.resources.FileResourcesLocatorImpl;
@@ -61,6 +64,7 @@ import org.osgi.framework.ServiceReference;
 import org.osgi.service.event.Event;
 import org.osgi.service.event.EventAdmin;
 import org.osgi.service.prefs.BackingStoreException;
+import org.osgi.service.prefs.Preferences;
 import org.w3c.dom.Element;
 import org.w3c.dom.css.CSSStyleDeclaration;
 
@@ -72,6 +76,8 @@ public class ThemeEngine implements IThemeEngine {
 	private final Display display;
 
 	private ITheme currentTheme;
+
+	private boolean effectiveThemeIdPublished;
 
 	private final List<String> globalStyles = new ArrayList<>();
 	private final List<IResourceLocator> globalSourceLocators = new ArrayList<>();
@@ -512,6 +518,8 @@ public class ThemeEngine implements IThemeEngine {
 				ThemeEngineManager.logError(e.getMessage(), e);
 			}
 		}
+		publishEffectiveThemeId();
+
 		boolean isDark = theme.getId().contains("dark"); //$NON-NLS-1$
 		display.setDarkThemePreferred(isDark);
 
@@ -569,9 +577,31 @@ public class ThemeEngine implements IThemeEngine {
 		}
 	}
 
+	/**
+	 * Returns the theme that was selected for this installation, which may come from the
+	 * user, from a product customization, or from nowhere at all.
+	 */
 	private String getPreferenceThemeId() {
 		IPreferencesService prefService = Platform.getPreferencesService();
-		return prefService.getString(THEME_PLUGIN_ID, THEMEID_KEY, null, null);
+		if (!effectiveThemeIdPublished) {
+			return prefService.getString(THEME_PLUGIN_ID, THEMEID_KEY, null, null);
+		}
+		// skip the default scope, it now holds the effective id published below
+		return prefService.get(THEMEID_KEY, null, new Preferences[] { InstanceScope.INSTANCE.getNode(THEME_PLUGIN_ID),
+				ConfigurationScope.INSTANCE.getNode(THEME_PLUGIN_ID), UserScope.INSTANCE.getNode(THEME_PLUGIN_ID) });
+	}
+
+	/**
+	 * Publishes the theme that was actually applied into the default scope, so clients
+	 * asking the preference service for the current theme also get an inherited one. The
+	 * default scope is never persisted, which keeps the instance scope meaning "the user
+	 * chose this" and lets a later start follow the operating system again.
+	 */
+	private void publishEffectiveThemeId() {
+		if (currentTheme != null) {
+			DefaultScope.INSTANCE.getNode(THEME_PLUGIN_ID).put(THEMEID_KEY, currentTheme.getId());
+			effectiveThemeIdPublished = true;
+		}
 	}
 
 	private IEclipsePreferences getPreferences() {

--- a/tests/org.eclipse.e4.ui.tests.css.swt/src/org/eclipse/e4/ui/tests/css/swt/ThemeTest.java
+++ b/tests/org.eclipse.e4.ui.tests.css.swt/src/org/eclipse/e4/ui/tests/css/swt/ThemeTest.java
@@ -14,14 +14,22 @@
  *******************************************************************************/
 package org.eclipse.e4.ui.tests.css.swt;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Dictionary;
 import java.util.Hashtable;
 
+import org.eclipse.core.runtime.Platform;
+import org.eclipse.core.runtime.preferences.ConfigurationScope;
+import org.eclipse.core.runtime.preferences.IEclipsePreferences;
+import org.eclipse.core.runtime.preferences.InstanceScope;
+import org.eclipse.core.runtime.preferences.UserScope;
 import org.eclipse.e4.ui.css.swt.internal.theme.Theme;
+import org.eclipse.e4.ui.css.swt.internal.theme.ThemeEngine;
 import org.eclipse.e4.ui.css.swt.theme.ITheme;
 import org.eclipse.e4.ui.css.swt.theme.IThemeEngine;
 import org.eclipse.e4.ui.css.swt.theme.IThemeManager;
@@ -39,6 +47,8 @@ import org.osgi.service.event.EventConstants;
 import org.osgi.service.event.EventHandler;
 
 public class ThemeTest {
+
+	private static final String THEMEID_KEY = "themeid";
 
 	@RegisterExtension
 	CssSwtEngine css = new CssSwtEngine();
@@ -59,7 +69,9 @@ public class ThemeTest {
 
 	@AfterEach
 	public void tearDown() {
-		themeListenerRegistration.unregister();
+		if (themeListenerRegistration != null) {
+			themeListenerRegistration.unregister();
+		}
 	}
 
 	@Test
@@ -87,6 +99,38 @@ public class ThemeTest {
 		assertFalse(success[0]);
 		themer.setTheme(new Theme("test", "Test"), true);
 		assertTrue(success[0]);
+	}
+
+	@Test
+	void testInheritedThemeIsReadableFromPreferenceService() {
+		IThemeEngine themer = getThemeEngine(Display.getDefault());
+		ITheme previousTheme = themer.getActiveTheme();
+		IEclipsePreferences[] explicitNodes = { InstanceScope.INSTANCE.getNode(ThemeEngine.THEME_PLUGIN_ID),
+				ConfigurationScope.INSTANCE.getNode(ThemeEngine.THEME_PLUGIN_ID),
+				UserScope.INSTANCE.getNode(ThemeEngine.THEME_PLUGIN_ID) };
+		String[] previousIds = new String[explicitNodes.length];
+
+		// an inherited theme is applied without any scope recording an explicit choice
+		for (int i = 0; i < explicitNodes.length; i++) {
+			previousIds[i] = explicitNodes[i].get(THEMEID_KEY, null);
+			explicitNodes[i].remove(THEMEID_KEY);
+		}
+		try {
+			themer.setTheme(new Theme("inherited.test", "Inherited"), false);
+
+			assertEquals("inherited.test",
+					Platform.getPreferencesService().getString(ThemeEngine.THEME_PLUGIN_ID, THEMEID_KEY, null, null));
+			assertNull(explicitNodes[0].get(THEMEID_KEY, null), "an inherited theme must not be persisted");
+		} finally {
+			if (previousTheme != null) {
+				themer.setTheme(previousTheme, false);
+			}
+			for (int i = 0; i < explicitNodes.length; i++) {
+				if (previousIds[i] != null) {
+					explicitNodes[i].put(THEMEID_KEY, previousIds[i]);
+				}
+			}
+		}
 	}
 
 	private IThemeEngine getThemeEngine(Display display) {


### PR DESCRIPTION
`ThemeEngine` recorded the theme id only when the user picked one explicitly, so a theme inherited from the operating system or from the product's alternate theme was applied but never stored anywhere. Clients probing the preference node for the current theme found it empty, which is issue #4168.

The applied theme is now published into the default scope. That scope is never persisted, so the instance scope keeps its meaning of "the user chose this" and a later start still follows the operating system rather than being pinned to the first theme it happened to inherit. Reading the preference back skips the default scope once the engine has published there, and uses the full lookup order before that, so a product default from `plugin_customization.ini` still applies.

One caveat worth knowing: a managed default theme stored in the user scope still wins over the published value, since the user scope sits above the default scope in the lookup order.

Fixes https://github.com/eclipse-platform/eclipse.platform.ui/issues/4168