### PR TITLE
BackPort : Fix Windows Defender status retrieval under Java-25 or later

### DIFF
--- a/bundles/org.eclipse.ui.workbench/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.ui.workbench/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.ui.workbench; singleton:=true
-Bundle-Version: 3.138.0.qualifier
+Bundle-Version: 3.138.1.qualifier
 Bundle-Activator: org.eclipse.ui.internal.WorkbenchPlugin
 Bundle-ActivationPolicy: lazy
 Bundle-Vendor: %providerName

--- a/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/WindowsDefenderConfigurator.java
+++ b/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/WindowsDefenderConfigurator.java
@@ -30,6 +30,7 @@ import java.util.Optional;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.Future;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -389,7 +390,7 @@ public class WindowsDefenderConfigurator implements EventHandler {
 				Thread.onSpinWait();
 				Thread.sleep(5);
 			}
-			if (process.isAlive()) {
+			if (!process.waitFor(5, TimeUnit.SECONDS)) {
 				process.destroyForcibly();
 				process.descendants().forEach(ProcessHandle::destroyForcibly);
 				throw new IOException("Process timed-out and it was attempted to forcefully terminate it"); //$NON-NLS-1$


### PR DESCRIPTION
Apply fix to R4_39_maintenance Branch