### PR TITLE
Migrate org.eclipse.ui.workbench.texteditor.tests off JUnit 4

### DIFF
--- a/tests/org.eclipse.ui.workbench.texteditor.tests/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.ui.workbench.texteditor.tests/META-INF/MANIFEST.MF
@@ -16,13 +16,13 @@ Require-Bundle:
  org.eclipse.jface.text;bundle-version="[3.5.0,4.0.0)",
  org.eclipse.ui.workbench.texteditor;bundle-version="[3.5.0,4.0.0)",
  org.eclipse.ui;bundle-version="[3.208.0,4.0.0)",
- org.junit;bundle-version="4.12.0",
  org.eclipse.text.tests;bundle-version="[3.5.0,4.0.0)",
  org.eclipse.core.expressions;bundle-version="[3.5.0,4.0.0)"
 Bundle-RequiredExecutionEnvironment: JavaSE-21
 Eclipse-BundleShape: dir
 Automatic-Module-Name: org.eclipse.ui.workbench.texteditor.tests
-Import-Package: org.junit.jupiter.api;version="[5.14.0,6.0.0)",
+Import-Package: org.hamcrest;version="[3.0.0,4.0.0)",
+ org.junit.jupiter.api;version="[5.14.0,6.0.0)",
  org.junit.jupiter.api.function;version="[5.14.0,6.0.0)",
  org.junit.platform.suite.api;version="[1.14.0,2.0.0)",
  org.mockito,

--- a/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/internal/findandreplace/WidgetExtractor.java
+++ b/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/internal/findandreplace/WidgetExtractor.java
@@ -13,7 +13,7 @@
  *******************************************************************************/
 package org.eclipse.ui.internal.findandreplace;
 
-import static org.junit.Assert.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -56,7 +56,7 @@ public final class WidgetExtractor {
 
 	private <T extends Widget> T findWidget(Composite container, Class<T> type, String id) {
 		List<T> widgets= findWidgets(container, type, id);
-		assertFalse("more than one matching widget found for id '" + id + "':" + widgets, widgets.size() > 1);
+		assertFalse(widgets.size() > 1, "more than one matching widget found for id '" + id + "':" + widgets);
 		return widgets.isEmpty() ? null : widgets.get(0);
 	}
 

--- a/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/internal/findandreplace/overlay/OverlayAccess.java
+++ b/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/internal/findandreplace/overlay/OverlayAccess.java
@@ -14,8 +14,8 @@
 package org.eclipse.ui.internal.findandreplace.overlay;
 
 import static org.eclipse.ui.internal.findandreplace.FindReplaceTestUtil.runEventQueue;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Arrays;
 import java.util.Set;

--- a/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/workbench/texteditor/tests/DialogAccess.java
+++ b/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/workbench/texteditor/tests/DialogAccess.java
@@ -14,7 +14,7 @@ import static org.eclipse.ui.internal.findandreplace.FindReplaceTestUtil.runEven
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.Matchers.not;
-import static org.junit.Assert.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 import java.util.Arrays;
 import java.util.Set;


### PR DESCRIPTION
This bundle was already almost entirely on JUnit Jupiter. Only three helper classes still statically imported `org.junit.Assert`, so they are switched over to `org.junit.jupiter.api.Assertions`. One `assertFalse` call passes a message, so its argument order is flipped to match the Jupiter signature.

With the last JUnit 4 usage gone, the `org.junit` `Require-Bundle` entry can go too. That bundle also supplied Hamcrest transitively, so `org.hamcrest` is now declared explicitly in `Import-Package`, which makes the real dependency visible instead of relying on a side effect of the JUnit 4 dependency.

The bundle now has a single test framework rather than a mix, and one fewer bundle on its classpath. All 222 tests pass locally.