### PR TITLE
Report per operation timings and drop the unused performance framework

### DIFF
--- a/tests/org.eclipse.ui.tests.performance/src/org/eclipse/ui/tests/performance/EditorSwitchTest.java
+++ b/tests/org.eclipse.ui.tests.performance/src/org/eclipse/ui/tests/performance/EditorSwitchTest.java
@@ -16,17 +16,22 @@ package org.eclipse.ui.tests.performance;
 import static org.eclipse.ui.tests.harness.util.UITestUtil.openTestWindow;
 import static org.eclipse.ui.tests.harness.util.UITestUtil.processEvents;
 import static org.eclipse.ui.tests.performance.UIPerformanceTestRule.getTestProject;
+import static org.eclipse.ui.tests.performance.UIPerformanceTestUtil.exercise;
+import static org.eclipse.ui.tests.performance.UIPerformanceTestUtil.reportTimings;
 import static org.eclipse.ui.tests.performance.UIPerformanceTestUtil.waitForBackgroundJobs;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.List;
 
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.runtime.CoreException;
-import org.eclipse.test.performance.PerformanceTestCaseJunit4;
 import org.eclipse.ui.IWorkbenchPage;
 import org.eclipse.ui.IWorkbenchWindow;
+import org.eclipse.ui.PartInitException;
 import org.eclipse.ui.ide.IDE;
 import org.eclipse.ui.tests.harness.util.CloseTestWindowsRule;
 import org.junit.ClassRule;
@@ -37,10 +42,23 @@ import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
 
 /**
- * Test editor switching.
+ * Measures how long it takes to switch to an editor that is already open, and
+ * reports each switch direction separately.
  */
 @RunWith(Parameterized.class)
-public class EditorSwitchTest extends PerformanceTestCaseJunit4 {
+public class EditorSwitchTest {
+
+	/**
+	 * Enough pairs to get the editor implementation loaded and compiled. Below
+	 * roughly this many, the reported times are dominated by JIT warm-up.
+	 */
+	private static final int WARMUP_PAIRS = 20;
+
+	private static final int MIN_PAIRS = 60;
+
+	private static final int MAX_PAIRS = 400;
+
+	private static final int MAX_MEASURE_TIME_MS = 10000;
 
 	@ClassRule
 	public static final UIPerformanceTestRule uiPerformanceTestRule = new UIPerformanceTestRule();
@@ -66,7 +84,7 @@ public class EditorSwitchTest extends PerformanceTestCaseJunit4 {
 	}
 
 	/**
-	 * Test editor opening performance. This test always fails.
+	 * Measures switching back and forth between two editors that are already open.
 	 */
 	@Test
 	public void test() throws CoreException {
@@ -85,20 +103,39 @@ public class EditorSwitchTest extends PerformanceTestCaseJunit4 {
 		EditorTestHelper.calmDown(500, 30000, 500);
 		waitForBackgroundJobs();
 
-		for (int j = 0; j < 100; j++) {
-
-			startMeasuring();
-			for (int i = 0; i < 12; i++) {
-				IDE.openEditor(activePage, file1, true);
-				processEvents();
-				IDE.openEditor(activePage, file2, true);
-				processEvents();
-			}
-			stopMeasuring();
-			EditorTestHelper.calmDown(500, 30000, 100);
+		// Class loading and JIT warm-up would otherwise end up in the reported times.
+		for (int i = 0; i < WARMUP_PAIRS; i++) {
+			switchTo(activePage, file1, null);
+			switchTo(activePage, file2, null);
 		}
+		EditorTestHelper.calmDown(500, 30000, 500);
 
-		commitMeasurements();
-		assertPerformance();
+		List<Long> toFirst = new ArrayList<>();
+		List<Long> toSecond = new ArrayList<>();
+
+		exercise(() -> {
+			switchTo(activePage, file1, toFirst);
+			switchTo(activePage, file2, toSecond);
+		}, MIN_PAIRS, MAX_PAIRS, MAX_MEASURE_TIME_MS);
+
+		reportTimings("EditorSwitch to [" + extension1 + "]", toFirst);
+		reportTimings("EditorSwitch to [" + extension2 + "]", toSecond);
+	}
+
+	/**
+	 * Reveals the already open editor for the given file, recording the time when
+	 * the given list is not {@code null}.
+	 */
+	private static void switchTo(IWorkbenchPage page, IFile file, List<Long> times) throws PartInitException {
+		long before = System.nanoTime();
+		IDE.openEditor(page, file, true);
+		processEvents();
+		long after = System.nanoTime();
+		assertEquals("Wrong editor active after switching to " + file.getName(), file,
+				page.getActiveEditor().getEditorInput().getAdapter(IFile.class));
+
+		if (times != null) {
+			times.add(after - before);
+		}
 	}
 }

--- a/tests/org.eclipse.ui.tests.performance/src/org/eclipse/ui/tests/performance/OpenCloseEditorTest.java
+++ b/tests/org.eclipse.ui.tests.performance/src/org/eclipse/ui/tests/performance/OpenCloseEditorTest.java
@@ -18,14 +18,16 @@ import static org.eclipse.ui.tests.harness.util.UITestUtil.openTestWindow;
 import static org.eclipse.ui.tests.harness.util.UITestUtil.processEvents;
 import static org.eclipse.ui.tests.performance.UIPerformanceTestRule.getTestProject;
 import static org.eclipse.ui.tests.performance.UIPerformanceTestUtil.exercise;
+import static org.eclipse.ui.tests.performance.UIPerformanceTestUtil.reportTimings;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.List;
 
 import org.eclipse.core.resources.IFile;
-import org.eclipse.test.performance.Dimension;
-import org.eclipse.test.performance.PerformanceTestCaseJunit4;
 import org.eclipse.ui.IEditorPart;
 import org.eclipse.ui.IWorkbenchPage;
 import org.eclipse.ui.IWorkbenchWindow;
@@ -39,8 +41,24 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
 
+/**
+ * Measures how long it takes to open and to close an editor, and reports the
+ * two phases separately.
+ */
 @RunWith(Parameterized.class)
-public class OpenCloseEditorTest extends PerformanceTestCaseJunit4 {
+public class OpenCloseEditorTest {
+
+	/**
+	 * Enough pairs to get the editor implementation loaded and compiled. Below
+	 * roughly this many, the reported times are dominated by JIT warm-up.
+	 */
+	private static final int WARMUP_PAIRS = 20;
+
+	private static final int MIN_PAIRS = 50;
+
+	private static final int MAX_PAIRS = 300;
+
+	private static final int MAX_MEASURE_TIME_MS = 10000;
 
 	@ClassRule
 	public static final UIPerformanceTestRule uiPerformanceTestRule = new UIPerformanceTestRule();
@@ -68,27 +86,46 @@ public class OpenCloseEditorTest extends PerformanceTestCaseJunit4 {
 		IWorkbenchWindow window = openTestWindow(UIPerformanceTestRule.PERSPECTIVE1);
 		final IWorkbenchPage activePage = window.getActivePage();
 
-		exercise(() -> {
-			startMeasuring();
-			for (int j = 0; j < 10; j++) {
-				IEditorPart part;
-				try {
-					part = IDE.openEditor(activePage, file, true);
-				} catch (PartInitException e) {
-					throw new AssertionError("Can't open editor for " + file.getName());
-				}
-				processEvents();
-				activePage.closeEditor(part, false);
-				processEvents();
-
-			}
-			stopMeasuring();
-		});
-
-		if (extension.equals("perf_text")) {
-			tagAsSummary("UI - Open/Close Editor", Dimension.ELAPSED_PROCESS);
+		// Class loading and JIT warm-up of the editor implementation would otherwise
+		// end up in the reported times.
+		for (int i = 0; i < WARMUP_PAIRS; i++) {
+			openAndClose(activePage, file, null, null);
 		}
-		commitMeasurements();
-		assertPerformance();
+		EditorTestHelper.calmDown(500, 30000, 500);
+
+		List<Long> openTimes = new ArrayList<>();
+		List<Long> closeTimes = new ArrayList<>();
+
+		exercise(() -> openAndClose(activePage, file, openTimes, closeTimes), MIN_PAIRS, MAX_PAIRS,
+				MAX_MEASURE_TIME_MS);
+
+		reportTimings("OpenCloseEditor[" + extension + "] open", openTimes);
+		reportTimings("OpenCloseEditor[" + extension + "] close", closeTimes);
+	}
+
+	/**
+	 * Opens and closes the editor, recording the two phases separately when the
+	 * given lists are not {@code null}.
+	 */
+	private static void openAndClose(IWorkbenchPage page, IFile file, List<Long> openTimes, List<Long> closeTimes) {
+		long beforeOpen = System.nanoTime();
+		IEditorPart part;
+		try {
+			part = IDE.openEditor(page, file, true);
+		} catch (PartInitException e) {
+			throw new AssertionError("Can't open editor for " + file.getName());
+		}
+		processEvents();
+		long afterOpen = System.nanoTime();
+		assertNotNull("No editor opened for " + file.getName(), part);
+
+		page.closeEditor(part, false);
+		processEvents();
+		long afterClose = System.nanoTime();
+
+		if (openTimes != null) {
+			openTimes.add(afterOpen - beforeOpen);
+			closeTimes.add(afterClose - afterOpen);
+		}
 	}
 }

--- a/tests/org.eclipse.ui.tests.performance/src/org/eclipse/ui/tests/performance/UIPerformanceTestUtil.java
+++ b/tests/org.eclipse.ui.tests.performance/src/org/eclipse/ui/tests/performance/UIPerformanceTestUtil.java
@@ -13,6 +13,9 @@
  *******************************************************************************/
 package org.eclipse.ui.tests.performance;
 
+import java.util.List;
+import java.util.Locale;
+
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
@@ -27,6 +30,25 @@ public final class UIPerformanceTestUtil {
 
 	private UIPerformanceTestUtil() {
 
+	}
+
+	/**
+	 * Prints the distribution of the given timings to the test log. Without a
+	 * performance database the measurements are otherwise discarded, so a manual
+	 * run would report nothing at all.
+	 * <p>
+	 * On a machine with background load the minimum is the value to compare, the
+	 * higher percentiles mostly reflect the noise.
+	 */
+	public static void reportTimings(String label, List<Long> nanos) {
+		if (nanos.isEmpty()) {
+			System.out.println(label + ": no measurements");
+			return;
+		}
+		long[] sorted = nanos.stream().mapToLong(Long::longValue).sorted().toArray();
+		System.out.printf(Locale.ROOT, "%-44s n=%-4d min=%8.2f  p50=%8.2f  p90=%8.2f  max=%8.2f (ms)%n", label,
+				sorted.length, sorted[0] / 1e6, sorted[sorted.length / 2] / 1e6,
+				sorted[(int) (sorted.length * 0.9)] / 1e6, sorted[sorted.length - 1] / 1e6);
 	}
 
 	/**


### PR DESCRIPTION
The editor performance tests measured opening plus closing in a single block, and twelve editor switches in another, so a change in one operation could not be attributed, and nothing was printed at all. Both tests now time the individual operations and log min, median, 90th percentile and maximum, they warm up before measuring so that class loading and JIT no longer end up in the reported times, and they are bounded by time instead of a fixed iteration count.

Both tests also stop using org.eclipse.test.performance. The performance database it reports to has not been configured for years, so commitMeasurements and assertPerformance were no-ops and the tests could neither fail nor report anything, and its one value per measurement block model is what made the individual operations indistinguishable in the first place. In its place both tests now assert that the editor really opened and that the expected editor is active after a switch. EditorSwitchTest drops from roughly 145 to 16 seconds while collecting more than twice the samples. The bundle still requires org.eclipse.test.performance for the other tests, so the manifest is unchanged.

This is a first step towards measuring and then improving editor handling. Sample output of a local run:

```
OpenCloseEditor[perf_text] open      n=286  min=  21.67  p50=  24.86  p90=  26.79  max=  36.67 (ms)
OpenCloseEditor[perf_text] close     n=286  min=   7.18  p50=  10.26  p90=  11.22  max=  17.96 (ms)
EditorSwitch to [perf_outline]       n=400  min=   4.40  p50=   5.61  p90=   9.02  max=  26.54 (ms)
EditorSwitch to [perf_text]          n=400  min=   4.38  p50=   5.64  p90=   8.75  max=  17.19 (ms)
```
