### PR TITLE
Resolve editor and view references without repeated linear scans

### DIFF
--- a/bundles/org.eclipse.e4.ui.workbench.renderers.swt/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.e4.ui.workbench.renderers.swt/META-INF/MANIFEST.MF
@@ -1,7 +1,7 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-SymbolicName: org.eclipse.e4.ui.workbench.renderers.swt;singleton:=true
-Bundle-Version: 0.18.100.qualifier
+Bundle-Version: 0.18.200.qualifier
 Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/bundles/org.eclipse.e4.ui.workbench.renderers.swt/src/org/eclipse/e4/ui/workbench/renderers/swt/ToolItemUpdater.java
+++ b/bundles/org.eclipse.e4.ui.workbench.renderers.swt/src/org/eclipse/e4/ui/workbench/renderers/swt/ToolItemUpdater.java
@@ -47,11 +47,13 @@ public class ToolItemUpdater implements Runnable {
 	}
 
 	public void updateContributionItems(Selector selector) {
+		boolean queued = false;
 		boolean doRunNow = false;
 		for (final AbstractContributionItem ci : itemsToCheck) {
 			if (ci.getModel() != null && ci.getModel().getParent() != null) {
 				if (selector.select(ci.getModel())) {
 					itemsToUpdateLater.add(ci);
+					queued = true;
 					if (timestampOfEarliestQueuedUpdate == 0) {
 						timestampOfEarliestQueuedUpdate = System.nanoTime();
 					}
@@ -61,13 +63,15 @@ public class ToolItemUpdater implements Runnable {
 						// again and again in less than given DELAY frequency. TimerExec would then
 						// never be executed.
 						doRunNow = true;
-					} else {
-						Display.getDefault().timerExec(DELAY, this);
 					}
 				}
 			} else {
 				orphanedToolItems.add(ci);
 			}
+		}
+		if (queued && !doRunNow) {
+			// one timer for the whole batch, rescheduling it per item only costs time
+			Display.getDefault().timerExec(DELAY, this);
 		}
 		if (!orphanedToolItems.isEmpty()) {
 			itemsToCheck.removeAll(orphanedToolItems);

--- a/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/WorkbenchPage.java
+++ b/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/WorkbenchPage.java
@@ -42,6 +42,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.IdentityHashMap;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
@@ -1061,12 +1062,14 @@ public class WorkbenchPage implements IWorkbenchPage {
 	private List<EditorReference> getOrderedEditorReferences() {
 
 		List<EditorReference> editorRefs = new ArrayList<>();
+		Set<EditorReference> seen = new HashSet<>();
+		Map<MPart, EditorReference> referencesByModel = getEditorReferencesByModel();
 		List<MPart> visibleEditors = modelService.findElements(window, CompatibilityEditor.MODEL_ELEMENT_ID,
 				MPart.class);
 		for (MPart editor : visibleEditors) {
 			if (editor.isToBeRendered()) {
-				EditorReference ref = getEditorReference(editor);
-				if (ref != null && !editorRefs.contains(ref)) {
+				EditorReference ref = referencesByModel.get(editor);
+				if (ref != null && seen.add(ref)) {
 					editorRefs.add(ref);
 				}
 			}
@@ -1075,23 +1078,36 @@ public class WorkbenchPage implements IWorkbenchPage {
 		return editorRefs;
 	}
 
+	/**
+	 * Maps the model element of every editor reference of this page to its
+	 * reference, so that callers can resolve many parts without rescanning the
+	 * reference list for each one.
+	 */
+	private Map<MPart, EditorReference> getEditorReferencesByModel() {
+		Map<MPart, EditorReference> referencesByModel = new IdentityHashMap<>(editorReferences.size());
+		for (EditorReference ref : editorReferences) {
+			referencesByModel.putIfAbsent(ref.getModel(), ref);
+		}
+		return referencesByModel;
+	}
+
 	List<EditorReference> getSortedEditorReferences() {
 		return getSortedEditorReferences(false);
 	}
 
 	private List<EditorReference> getSortedEditorReferences(boolean allPerspectives) {
+		Map<MPart, EditorReference> referencesByModel = getEditorReferencesByModel();
 		List<EditorReference> sortedReferences = new ArrayList<>();
+		Set<EditorReference> seen = new HashSet<>();
 		for (MPart part : activationList) {
-			for (EditorReference ref : editorReferences) {
-				if (ref.getModel() == part) {
-					sortedReferences.add(ref);
-					break;
-				}
+			EditorReference ref = referencesByModel.get(part);
+			if (ref != null && seen.add(ref)) {
+				sortedReferences.add(ref);
 			}
 		}
 
 		for (EditorReference ref : editorReferences) {
-			if (!sortedReferences.contains(ref)) {
+			if (seen.add(ref)) {
 				sortedReferences.add(ref);
 			}
 		}
@@ -1101,13 +1117,17 @@ public class WorkbenchPage implements IWorkbenchPage {
 			int scope = allPerspectives ? WINDOW_SCOPE : EModelService.PRESENTATION;
 			List<MPart> placeholders = modelService.findElements(window, CompatibilityEditor.MODEL_ELEMENT_ID,
 					MPart.class, null, scope);
+			// only rendered placeholders are valid references
+			Set<MPart> rendered = Collections.newSetFromMap(new IdentityHashMap<>(placeholders.size()));
+			for (MPart placeholder : placeholders) {
+				if (placeholder.isToBeRendered()) {
+					rendered.add(placeholder);
+				}
+			}
 			List<EditorReference> visibleReferences = new ArrayList<>();
 			for (EditorReference reference : sortedReferences) {
-				for (MPart placeholder : placeholders) {
-					if (reference.getModel() == placeholder && placeholder.isToBeRendered()) {
-						// only rendered placeholders are valid references
-						visibleReferences.add(reference);
-					}
+				if (rendered.contains(reference.getModel())) {
+					visibleReferences.add(reference);
 				}
 			}
 
@@ -2318,32 +2338,36 @@ public class WorkbenchPage implements IWorkbenchPage {
 		}
 
 		List<IWorkbenchPartReference> sortedReferences = new ArrayList<>();
+		Set<IWorkbenchPartReference> seen = new HashSet<>();
 		IViewReference[] viewReferences = getViewReferences(allPerspectives);
 		List<EditorReference> editorReferences = getSortedEditorReferences(allPerspectives);
 
-		activationLoop: for (MPart part : activationList) {
-			if (views) {
-				for (IViewReference ref : viewReferences) {
-					if (((ViewReference) ref).getModel() == part) {
-						sortedReferences.add(ref);
-						continue activationLoop;
-					}
-				}
+		Map<MPart, IWorkbenchPartReference> viewsByModel = new IdentityHashMap<>(viewReferences.length);
+		if (views) {
+			for (IViewReference ref : viewReferences) {
+				viewsByModel.putIfAbsent(((ViewReference) ref).getModel(), ref);
 			}
+		}
+		Map<MPart, IWorkbenchPartReference> editorsByModel = new IdentityHashMap<>(editorReferences.size());
+		if (editors) {
+			for (EditorReference ref : editorReferences) {
+				editorsByModel.putIfAbsent(ref.getModel(), ref);
+			}
+		}
 
-			if (editors) {
-				for (EditorReference ref : editorReferences) {
-					if (ref.getModel() == part) {
-						sortedReferences.add(ref);
-						break;
-					}
-				}
+		for (MPart part : activationList) {
+			IWorkbenchPartReference ref = viewsByModel.get(part);
+			if (ref == null) {
+				ref = editorsByModel.get(part);
+			}
+			if (ref != null && seen.add(ref)) {
+				sortedReferences.add(ref);
 			}
 		}
 
 		if (views) {
 			for (IViewReference ref : viewReferences) {
-				if (!sortedReferences.contains(ref)) {
+				if (seen.add(ref)) {
 					sortedReferences.add(ref);
 				}
 			}
@@ -2351,7 +2375,7 @@ public class WorkbenchPage implements IWorkbenchPage {
 
 		if (editors) {
 			for (EditorReference ref : editorReferences) {
-				if (!sortedReferences.contains(ref)) {
+				if (seen.add(ref)) {
 					sortedReferences.add(ref);
 				}
 			}


### PR DESCRIPTION
Two cleanups found while profiling the editor open and switch paths, offered as code quality rather than as a speedup.

getOrderedEditorReferences, getSortedEditorReferences and getSortedParts resolved every model element by scanning the reference list from the start and then guarded against duplicates with List.contains, so both parts grew quadratically with the number of open editors and views. They now build an identity map once per call and use a set for the duplicate check, with the resulting order unchanged. ToolItemUpdater.updateContributionItems rescheduled the same runnable through Display.timerExec once per matching item, cancelling and recreating the timer on every iteration although only the last call has any effect, so it is now scheduled once per batch.

Neither change is measurable in the existing tests. I compared both variants with interleaved runs of the editor open, close and switch tests and the difference stayed within the noise, which is expected: the nested scans only matter with many open parts and the redundant timer scheduling only with many contributed tool items, and those tests have neither. Please take them on readability and complexity grounds, not on performance.

Verified with org.eclipse.ui.tests, org.eclipse.e4.ui.tests, org.eclipse.e4.ui.workbench.addons.swt.test and org.eclipse.jface.tests: 1719 tests, no failures.
