### PR TITLE
Report per operation timings in the multi editor and perspective tests

### DIFF
--- a/tests/org.eclipse.ui.tests.performance/src/org/eclipse/ui/tests/performance/OpenMultipleEditorTest.java
+++ b/tests/org.eclipse.ui.tests.performance/src/org/eclipse/ui/tests/performance/OpenMultipleEditorTest.java
@@ -55,8 +55,12 @@ import org.junit.runners.Parameterized.Parameters;
 @RunWith(Parameterized.class)
 public class OpenMultipleEditorTest {
 
-	/** Number of files the {@link UIPerformanceTestRule} creates per extension. */
-	private static final int EDITOR_COUNT = 100;
+	/**
+	 * Stays below the REUSE_EDITORS threshold, which defaults to 99. Above it the
+	 * workbench recycles the oldest editor, so further opens would measure a reuse
+	 * instead of an open.
+	 */
+	private static final int EDITOR_COUNT = 90;
 
 	/**
 	 * How many opens at each end of the batch are reported. The ones in between
@@ -134,6 +138,8 @@ public class OpenMultipleEditorTest {
 				}
 			}
 		}
+		assertEquals("Not all editors stayed open, so an open measured a reuse", EDITOR_COUNT,
+				page.getEditorReferences().length);
 
 		if (closeAll) {
 			long before = System.nanoTime();

--- a/tests/org.eclipse.ui.tests.performance/src/org/eclipse/ui/tests/performance/PerspectiveSwitchTest.java
+++ b/tests/org.eclipse.ui.tests.performance/src/org/eclipse/ui/tests/performance/PerspectiveSwitchTest.java
@@ -17,15 +17,19 @@ import static org.eclipse.ui.tests.harness.util.UITestUtil.openTestWindow;
 import static org.eclipse.ui.tests.harness.util.UITestUtil.processEvents;
 import static org.eclipse.ui.tests.performance.UIPerformanceTestRule.getTestProject;
 import static org.eclipse.ui.tests.performance.UIPerformanceTestUtil.exercise;
+import static org.eclipse.ui.tests.performance.UIPerformanceTestUtil.reportTimings;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeTrue;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.List;
 
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.runtime.CoreException;
-import org.eclipse.test.performance.PerformanceTestCaseJunit4;
 import org.eclipse.ui.IPerspectiveDescriptor;
 import org.eclipse.ui.IPerspectiveRegistry;
 import org.eclipse.ui.IWorkbenchPage;
@@ -42,10 +46,23 @@ import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
 
 /**
- * Test perspective switching.
+ * Measures switching back and forth between two perspectives, and reports each
+ * switch direction separately.
  */
 @RunWith(Parameterized.class)
-public class PerspectiveSwitchTest extends PerformanceTestCaseJunit4 {
+public class PerspectiveSwitchTest {
+
+	/**
+	 * Enough switches to get the participating parts loaded and compiled. Below
+	 * roughly this many, the reported times are dominated by JIT warm-up.
+	 */
+	private static final int WARMUP_PAIRS = 5;
+
+	private static final int MIN_PAIRS = 5;
+
+	private static final int MAX_PAIRS = 50;
+
+	private static final int MAX_MEASURE_TIME_MS = 12000;
 
 	@ClassRule
 	public static final UIPerformanceTestRule uiPerformanceTestRule = new UIPerformanceTestRule();
@@ -80,9 +97,6 @@ public class PerspectiveSwitchTest extends PerformanceTestCaseJunit4 {
 		this.activeEditor = activeEditor;
 	}
 
-	/**
-	 * Test perspective switching performance.
-	 */
 	@Test
 	public void test() throws CoreException, WorkbenchException {
 		// Get the two perspectives to switch between.
@@ -90,18 +104,11 @@ public class PerspectiveSwitchTest extends PerformanceTestCaseJunit4 {
 		final IPerspectiveDescriptor perspective1 = registry.findPerspectiveWithId(id1);
 		final IPerspectiveDescriptor perspective2 = registry.findPerspectiveWithId(id2);
 
-		// Don't fail if we reference an unknown perspective ID. This can be
-		// a normal occurrance since the test suites reference JDT perspectives, which
-		// might not exist. Just skip the test.
-		if (perspective1 == null) {
-			System.out.println("Unknown perspective ID: " + id1);
-			return;
-		}
-
-		if (perspective2 == null) {
-			System.out.println("Unknown perspective ID: " + id2);
-			return;
-		}
+		// The parameters reference JDT perspectives, which are not part of every target
+		// platform. Skip visibly rather than reporting a pass for something that was
+		// never measured.
+		assumeTrue("Perspective not available: " + id1, perspective1 != null);
+		assumeTrue("Perspective not available: " + id2, perspective2 != null);
 
 		// Open the two perspectives and the file, in a new window.
 		// Do this outside the loop so as not to include
@@ -111,25 +118,43 @@ public class PerspectiveSwitchTest extends PerformanceTestCaseJunit4 {
 		assertNotNull(page);
 		page.setPerspective(perspective2);
 
-		// IFile aFile = getProject().getFile("1." +
-		// EditorPerformanceSuite.EDITOR_FILE_EXTENSIONS[0]);
 		IFile aFile = getTestProject().getFile(activeEditor);
-		assertTrue(aFile.exists());
+		assertTrue("Missing test file " + activeEditor + ", the fixture does not create it", aFile.exists());
 
 		IDE.openEditor(page, aFile, true);
 
+		// Class loading and JIT warm-up would otherwise end up in the reported times.
+		for (int i = 0; i < WARMUP_PAIRS; i++) {
+			switchTo(page, perspective1, null);
+			switchTo(page, perspective2, null);
+		}
+		EditorTestHelper.calmDown(500, 30000, 500);
+
+		List<Long> toFirst = new ArrayList<>();
+		List<Long> toSecond = new ArrayList<>();
+
 		exercise(() -> {
-			processEvents();
+			switchTo(page, perspective1, toFirst);
+			switchTo(page, perspective2, toSecond);
+		}, MIN_PAIRS, MAX_PAIRS, MAX_MEASURE_TIME_MS);
 
-			startMeasuring();
-			page.setPerspective(perspective1);
-			processEvents();
-			page.setPerspective(perspective2);
-			processEvents();
-			stopMeasuring();
-		});
+		reportTimings("PerspectiveSwitch to [" + id1 + "]", toFirst);
+		reportTimings("PerspectiveSwitch to [" + id2 + "]", toSecond);
+	}
 
-		commitMeasurements();
-		assertPerformance();
+	/**
+	 * Switches to the given perspective, recording the time when the given list is
+	 * not {@code null}.
+	 */
+	private static void switchTo(IWorkbenchPage page, IPerspectiveDescriptor perspective, List<Long> times) {
+		long before = System.nanoTime();
+		page.setPerspective(perspective);
+		processEvents();
+		long after = System.nanoTime();
+		assertEquals("Wrong perspective active", perspective, page.getPerspective());
+
+		if (times != null) {
+			times.add(after - before);
+		}
 	}
 }


### PR DESCRIPTION
Continues #4230 for the two tests that cover the operations users feel most: opening many editors and switching perspectives. Both drop org.eclipse.test.performance, warm up before measuring, time the individual operations and print the distribution, so a change in one operation can be attributed instead of disappearing into a single number that nothing recorded.

OpenMultipleEditorTest also reports the first and the last ten editors separately, which turns it into the only test we have that shows how cost scales with the number of open editors. Opening the 90th editor currently costs 20 to 67 percent more than the 10th, and closing an editor while 90 are open costs about three times as much as when 10 remain. Because both ends come from the same run, that comparison is unaffected by machine load, which the absolute numbers very much are.

While adding assertions I found that the test never measured what it claimed: the workbench recycles the oldest editor once REUSE_EDITORS are open, defaulting to 99, so the hundredth open silently reused the first editor. The count is now 90 with an assertion explaining the threshold. PerspectiveSwitchTest had a related problem, silently returning and printing to stdout when a perspective is missing, which reported a pass for something never measured; it now skips through an assumption, so the three JDT cases show up as skipped rather than green.

Sample output of a local run:

```
openMultiple[perf_outline, closeEach] open, first 10  n=10  min= 35.52  p50= 43.01  p90= 67.45 (ms)
openMultiple[perf_outline, closeEach] open, last 10   n=10  min= 54.62  p50= 67.08  p90= 76.15 (ms)
openMultiple[perf_outline, closeEach] close, first 10 n=10  min= 25.48  p50= 30.01  p90= 39.69 (ms)
openMultiple[perf_outline, closeEach] close, last 10  n=10  min=  6.22  p50=  9.46  p90= 17.50 (ms)
openMultiple[perf_text, closeAll] closeAllEditors     n=1   1011.07 (ms, 90 editors)
PerspectiveSwitch to [org.eclipse.ui.tests.performancePerspective1] n=50 min= 16.74 p50= 18.60 (ms)
```
