### PR TITLE
Fix misleading "showing X of Y matches" label in File Search

### DIFF
--- a/bundles/org.eclipse.search/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.search/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.search; singleton:=true
-Bundle-Version: 3.19.0.qualifier
+Bundle-Version: 3.19.100.qualifier
 Bundle-Activator: org.eclipse.search.internal.ui.SearchPlugin
 Bundle-ActivationPolicy: lazy
 Bundle-Vendor: %providerName

--- a/bundles/org.eclipse.search/search/org/eclipse/search/internal/ui/SearchMessages.java
+++ b/bundles/org.eclipse.search/search/org/eclipse/search/internal/ui/SearchMessages.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2023 IBM Corporation and others.
+ * Copyright (c) 2000, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -176,6 +176,7 @@ public final class SearchMessages extends NLS {
 	public static String FileSearchPage_sort_by_label;
 	public static String FileSearchPage_limited_format_files;
 	public static String FileSearchPage_limited_format_matches;
+	public static String FileSearchPage_matches_on_lines_format;
 	public static String FileSearchPage_filtered_message;
 	public static String FileSearchPage_filteredWithCount_message;
 	public static String WorkspaceScope;

--- a/bundles/org.eclipse.search/search/org/eclipse/search/internal/ui/SearchMessages.properties
+++ b/bundles/org.eclipse.search/search/org/eclipse/search/internal/ui/SearchMessages.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2000, 2023 IBM Corporation and others.
+# Copyright (c) 2000, 2026 IBM Corporation and others.
 #
 # This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
@@ -182,6 +182,7 @@ FileSearchPage_error_marker=Could not create marker
 FileSearchPage_sort_by_label=Sort By
 FileSearchPage_limited_format_files={0} (showing {1} of {2} files)
 FileSearchPage_limited_format_matches={0} (showing {1} of {2} matches)
+FileSearchPage_matches_on_lines_format={0} (found on {1} lines)
 FileSearchPage_open_file_dialog_title=Open File
 FileSearchPage_filtered_message={0} (Filtered)
 FileSearchPage_filteredWithCount_message={0} ({1} matches filtered from view)

--- a/bundles/org.eclipse.search/search/org/eclipse/search/internal/ui/text/FileSearchPage.java
+++ b/bundles/org.eclipse.search/search/org/eclipse/search/internal/ui/text/FileSearchPage.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2023 IBM Corporation and others.
+ * Copyright (c) 2000, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -450,9 +450,15 @@ public class FileSearchPage extends AbstractTextSearchViewPage implements IAdapt
 			int itemCount = fContentProvider.getLeafCount(result);
 			if (showLineMatches()) {
 				int matchCount = result.getMatchCount();
-				if (itemCount < matchCount) {
+				int visibleMatchCount = getVisibleMatchCount(result);
+				if (visibleMatchCount < matchCount) {
+					// real truncation happened so some matches are not represented at all
 					msg = Messages.format(SearchMessages.FileSearchPage_limited_format_matches,
-							new Object[] { label, Integer.valueOf(itemCount), Integer.valueOf(matchCount) });
+							new Object[] { label, Integer.valueOf(visibleMatchCount), Integer.valueOf(matchCount) });
+				} else if (itemCount < matchCount) {
+					// all matches shown, just spread across fewer lines
+					msg = Messages.format(SearchMessages.FileSearchPage_matches_on_lines_format,
+							new Object[] { label, Integer.valueOf(itemCount) });
 				}
 			} else {
 				int fileCount = result.getElementsCount();
@@ -474,6 +480,27 @@ public class FileSearchPage extends AbstractTextSearchViewPage implements IAdapt
 			}
 		}
 		return msg;
+	}
+
+	private int getVisibleMatchCount(AbstractTextSearchResult result) {
+		StructuredViewer viewer = getViewer();
+		if (viewer instanceof TreeViewer treeViewer) {
+			ITreeContentProvider cp = (ITreeContentProvider) treeViewer.getContentProvider();
+			return getVisibleMatchCount(cp, getRootElements(treeViewer), result);
+		}
+		return result.getMatchCount();
+	}
+
+	private int getVisibleMatchCount(ITreeContentProvider cp, Object[] elements, AbstractTextSearchResult result) {
+		int count = 0;
+		for (Object element : elements) {
+			if (element instanceof LineElement lineElement) {
+				count += lineElement.getNumberOfMatches(result);
+			} else {
+				count += getVisibleMatchCount(cp, cp.getChildren(element), result);
+			}
+		}
+		return count;
 	}
 
 	private int getFilteredMatchCount() {


### PR DESCRIPTION
## Problem
Create a text file with the following 3 lines:
ABC
ABCBC
ABCDCDC

When a File Search match spans multiple occurrences on the same line (e.g. searching for "B" in a file containing "ABCBC"), the Search view label incorrectly reports matches as hidden:

    'B' - 4 matches in workspace (*.txt) (showing 3 of 4 matches)

even though every line is fully visible and no matches are actually left out/skipped. This happens because `FileSearchPage.getLabel()` compares the number of visible tree *leaves* (lines) against the total *match* count and one line can legitimately hold several matches, so `itemCount < matchCount` fires any time a line has more than one hit, regardless of real truncation.

## Fix
- Added a live, filter-independent recount of matches actually represented in the currently visible tree (respecting the existing
  element-limit truncation in `FileTreeContentProvider#getChildren`), using the already-existing   `LineElement#getNumberOfMatches(result)`.
- The "showing X of Y matches" label now only appears when this recount is genuinely lower than the total match count - i.e. when matches are truly missing from view (real truncation).
- When all matches are present but simply grouped across fewer lines, a new label is shown instead: `(found on N lines)`, avoiding the false implication that something is hidden/skipped/missed.

## Changes
- `FileSearchPage.java`: reworked the line-match branch of `getLabel()`; added `getVisibleMatchCount(...)` helpers.
- `SearchMessages.properties` / `SearchMessages.java`: added `FileSearchPage_matches_on_lines_format` message key.

## Testing
Verified against the repro from #3720 (search "A"/"B"/"C" in a filecontaining `ABC`, `ABCBC`, `ABCDCDC`):
- "A" → 3 matches, 3 lines → no qualifier shown (unchanged, correct).
- "B" → previously "showing 3 of 4 matches"; now "found on 3 lines".
- "C" → previously "showing 3 of 6 matches"; now "found on 3 lines".
- "BC" → previously "showing 3 of 4 matches"; now "found on 3 lines".

Fixes #3720