### PR TITLE
Do not block IDE startup to enable Close Unrelated Projects

### DIFF
--- a/bundles/org.eclipse.ui.ide/extensions/org/eclipse/ui/actions/CloseUnrelatedProjectsAction.java
+++ b/bundles/org.eclipse.ui.ide/extensions/org/eclipse/ui/actions/CloseUnrelatedProjectsAction.java
@@ -17,21 +17,24 @@
  *******************************************************************************/
 package org.eclipse.ui.actions;
 
+import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IResource;
 import org.eclipse.core.resources.IResourceChangeEvent;
 import org.eclipse.core.resources.IResourceDelta;
 import org.eclipse.core.resources.ResourcesPlugin;
-import org.eclipse.core.runtime.CoreException;
 import org.eclipse.jface.dialogs.IDialogConstants;
 import org.eclipse.jface.dialogs.MessageDialogWithToggle;
 import org.eclipse.jface.preference.IPreferenceStore;
 import org.eclipse.jface.window.IShellProvider;
 import org.eclipse.osgi.util.NLS;
+import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Shell;
 import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.ide.IDEActionFactory;
@@ -39,7 +42,7 @@ import org.eclipse.ui.internal.ide.IDEInternalPreferences;
 import org.eclipse.ui.internal.ide.IDEWorkbenchMessages;
 import org.eclipse.ui.internal.ide.IDEWorkbenchPlugin;
 import org.eclipse.ui.internal.ide.IIDEHelpContextIds;
-import org.eclipse.ui.internal.ide.misc.DisjointSet;
+import org.eclipse.ui.internal.ide.misc.ProjectReferenceGraph;
 
 /**
  * This action closes all projects that are unrelated to the selected projects. A
@@ -66,38 +69,8 @@ public class CloseUnrelatedProjectsAction extends CloseResourceAction {
 
 	private List<? extends IResource> oldSelection = Collections.emptyList();
 
-
-	/**
-	 * Builds the connected component set for the input projects.
-	 * The result is a DisjointSet where all related projects belong
-	 * to the same set.
-	 */
-	private static DisjointSet<IProject> buildConnectedComponents(IProject[] projects) {
-		//initially each vertex is in a set by itself
-		DisjointSet<IProject> set = new DisjointSet<>();
-		for (IProject project : projects) {
-			set.makeSet(project);
-		}
-		for (IProject project : projects) {
-			try {
-				IProject[] references = project.getReferencedProjects();
-				//each reference represents an edge in the project reference
-				//digraph from projects[i] -> references[j]
-				for (IProject reference : references) {
-					IProject setOne = set.findSet(project);
-					//note that referenced projects may not exist in the workspace
-					IProject setTwo = set.findSet(reference);
-					//these two projects are related, so join their sets
-					if (setOne != null && setTwo != null && setOne != setTwo) {
-						set.union(setOne, setTwo);
-					}
-				}
-			} catch (CoreException e) {
-				//assume inaccessible projects have no references
-			}
-		}
-		return set;
-	}
+	/** Kept in a field so repeated requests register the same callback. */
+	private final Runnable enablementRefresher = this::updateEnablementInUIThread;
 
 	/**
 	 * Creates this action.
@@ -132,9 +105,41 @@ public class CloseUnrelatedProjectsAction extends CloseResourceAction {
 
 	@Override
 	public void run() {
+		if (!refreshProjectGraph()) {
+			return;
+		}
 		if (promptForConfirmation()) {
 			super.run();
 		}
+	}
+
+	/**
+	 * Rebuilds the project graph before the projects to close are computed from it.
+	 * Enablement may answer from a stale graph, but closing projects should not. A
+	 * workspace that keeps changing can still leave the graph one rebuild behind;
+	 * that graph is used rather than refusing to close anything while a build runs,
+	 * and it is far closer to the current state than the one the action ran on
+	 * before.
+	 *
+	 * @return <code>false</code> if the user cancelled or the rebuild failed
+	 */
+	private boolean refreshProjectGraph() {
+		try {
+			// waits for the background job rather than computing here, so a slow
+			// reference provider cannot freeze the workbench
+			PlatformUI.getWorkbench().getProgressService()
+					.busyCursorWhile(monitor -> ProjectReferenceGraph.getInstance().refresh(monitor));
+		} catch (InterruptedException e) {
+			// how the progress service reports that the user cancelled, so the
+			// calling thread was never interrupted and must not be marked as such
+			return false;
+		} catch (InvocationTargetException e) {
+			IDEWorkbenchPlugin.log("Failed to compute the project reference graph", e); //$NON-NLS-1$
+			return false;
+		}
+		// drop the projects computed from the previous graph
+		clearCache();
+		return true;
 	}
 
 	/**
@@ -203,19 +208,33 @@ public class CloseUnrelatedProjectsAction extends CloseResourceAction {
 		if (selection.contains(ResourcesPlugin.getWorkspace().getRoot())) {
 			return new ArrayList<>();
 		}
-		//build the connected component set for all projects in the workspace
-		DisjointSet<IProject> set = buildConnectedComponents(ResourcesPlugin.getWorkspace().getRoot().getProjects());
-		//remove the connected components that the selected projects are in
+		Set<IProject> selectedProjects = new HashSet<>();
 		for (IResource resource : selection) {
 			IProject project = resource.getProject();
 			if (project != null) {
-				set.removeSet(project);
+				selectedProjects.add(project);
 			}
 		}
-		//the remainder of the projects in the disjoint set are unrelated to the selection
+		// a component without a selected project is unrelated, so all of it can be
+		// closed; the components come from the cache and resolve no references here
 		List<IResource> projects = new ArrayList<>();
-		set.toList(projects);
+		for (List<IProject> component : ProjectReferenceGraph.getInstance().getComponents(enablementRefresher)) {
+			if (Collections.disjoint(component, selectedProjects)) {
+				projects.addAll(component);
+			}
+		}
 		return projects;
+	}
+
+	private void updateEnablementInUIThread() {
+		if (!PlatformUI.isWorkbenchRunning()) {
+			return;
+		}
+		Display display = PlatformUI.getWorkbench().getDisplay();
+		if (display == null || display.isDisposed()) {
+			return;
+		}
+		display.asyncExec(() -> selectionChanged(getStructuredSelection()));
 	}
 
 	@Override

--- a/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/ide/IDEWorkbenchMessages.java
+++ b/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/ide/IDEWorkbenchMessages.java
@@ -345,6 +345,8 @@ public class IDEWorkbenchMessages extends NLS {
 	public static String CloseUnrelatedProjectsAction_AlwaysClose;
 	public static String CloseUnrelatedProjectsAction_AlwaysCloseWithoutPrompt;
 
+	public static String ProjectReferenceGraph_jobName;
+
 	public static String BuildAction_text;
 	public static String BuildAction_text_plural;
 	public static String BuildAction_toolTip;

--- a/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/ide/messages.properties
+++ b/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/ide/messages.properties
@@ -304,6 +304,8 @@ CloseUnrelatedProjectsAction_AlwaysCloseWithoutPrompt= Always &close unrelated p
 CloseUnrelatedProjectsAction_confirmMsg1 = Close all projects that are not related to ''{0}''?
 CloseUnrelatedProjectsAction_confirmMsgN = Close all projects that are not related to these {0} projects?
 
+ProjectReferenceGraph_jobName = Computing project references
+
 BuildAction_text = &Build Project
 BuildAction_text_plural = &Build Projects
 BuildAction_toolTip = Incremental Build of Selected Projects

--- a/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/ide/misc/ProjectReferenceGraph.java
+++ b/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/ide/misc/ProjectReferenceGraph.java
@@ -1,0 +1,237 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Lars Vogel and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Lars Vogel <Lars.Vogel@vogella.com> - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.ui.internal.ide.misc;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IResourceChangeEvent;
+import org.eclipse.core.resources.ResourcesPlugin;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.SafeRunner;
+import org.eclipse.core.runtime.Status;
+import org.eclipse.core.runtime.jobs.Job;
+import org.eclipse.ui.internal.ide.IDEWorkbenchMessages;
+
+/**
+ * Workspace-wide cache of the connected components of the project reference
+ * graph. Two projects are in the same component if one references the other,
+ * directly or transitively, in either direction.
+ * <p>
+ * Building it calls {@link IProject#getReferencedProjects()} for every project,
+ * which runs the dynamic reference providers and can take minutes. It therefore
+ * runs in a background job, never on the calling thread.
+ * </p>
+ */
+public class ProjectReferenceGraph {
+
+	/** Job family of the background rebuild. */
+	public static final Object FAMILY_REBUILD = new Object();
+
+	private static final int MAX_REFRESH_ATTEMPTS = 3;
+
+	/** Delay of the rebuild that follows one invalidated while it was running. */
+	private static final long RETRY_DELAY = 200;
+
+	private static ProjectReferenceGraph instance;
+
+	private final Object lock = new Object();
+
+	private List<List<IProject>> components = Collections.emptyList();
+
+	/** Incremented whenever a resource change may have altered the graph. */
+	private int requestedGeneration = 1;
+
+	/** Generation {@link #components} was built from. Equal means up to date. */
+	private int builtGeneration;
+
+	private final Set<Runnable> rebuildCallbacks = new LinkedHashSet<>();
+
+	private final Job rebuildJob = new Job(IDEWorkbenchMessages.ProjectReferenceGraph_jobName) {
+		@Override
+		protected IStatus run(IProgressMonitor monitor) {
+			rebuild();
+			return Status.OK_STATUS;
+		}
+
+		@Override
+		public boolean belongsTo(Object family) {
+			return FAMILY_REBUILD == family;
+		}
+	};
+
+	public static synchronized ProjectReferenceGraph getInstance() {
+		if (instance == null) {
+			instance = new ProjectReferenceGraph();
+		}
+		return instance;
+	}
+
+	private ProjectReferenceGraph() {
+		rebuildJob.setSystem(true);
+		ResourcesPlugin.getWorkspace().addResourceChangeListener(this::invalidateOnResourceChange,
+				IResourceChangeEvent.POST_CHANGE);
+	}
+
+	/**
+	 * Returns the components known so far, which may be stale or empty. If they
+	 * are stale, a background rebuild is started and <code>whenRebuilt</code> is
+	 * run on the job's thread once it completed.
+	 *
+	 * @param whenRebuilt may be <code>null</code>
+	 */
+	public List<List<IProject>> getComponents(Runnable whenRebuilt) {
+		List<List<IProject>> known;
+		boolean stale;
+		synchronized (lock) {
+			known = components;
+			stale = requestedGeneration != builtGeneration;
+			if (stale && whenRebuilt != null) {
+				rebuildCallbacks.add(whenRebuilt);
+			}
+		}
+		if (stale) {
+			rebuildJob.schedule();
+		}
+		return known;
+	}
+
+	/**
+	 * Waits for a rebuild instead of computing the components on the calling
+	 * thread, and returns whether they ended up current. Retries are bounded: a
+	 * running build keeps invalidating them, and blocking a user gesture until the
+	 * workspace goes quiet would be worse than answering from components that are
+	 * one rebuild old.
+	 */
+	public boolean refresh(IProgressMonitor monitor) throws InterruptedException {
+		for (int attempt = 0; attempt < MAX_REFRESH_ATTEMPTS; attempt++) {
+			synchronized (lock) {
+				if (requestedGeneration == builtGeneration) {
+					return true;
+				}
+			}
+			rebuildJob.schedule();
+			Job.getJobManager().join(FAMILY_REBUILD, monitor);
+		}
+		synchronized (lock) {
+			return requestedGeneration == builtGeneration;
+		}
+	}
+
+	private void rebuild() {
+		int generation;
+		synchronized (lock) {
+			generation = requestedGeneration;
+		}
+		// the generation is read before building, so a change arriving during the
+		// build leaves the result marked stale instead of being lost
+		List<List<IProject>> built = buildComponents(ResourcesPlugin.getWorkspace().getRoot().getProjects());
+		List<Runnable> callbacks;
+		boolean retry;
+		synchronized (lock) {
+			components = built;
+			builtGeneration = generation;
+			if (requestedGeneration != generation) {
+				// stale again: notifying now would report components that are already
+				// outdated, so leave the callbacks registered for the rebuild that
+				// converges
+				retry = !rebuildCallbacks.isEmpty();
+				callbacks = List.of();
+			} else {
+				retry = false;
+				callbacks = new ArrayList<>(rebuildCallbacks);
+				rebuildCallbacks.clear();
+			}
+		}
+		if (retry) {
+			// nothing else would start that rebuild, because invalidating only marks
+			// the components stale; the delay keeps the job from running back to back
+			// while the workspace keeps changing
+			rebuildJob.schedule(RETRY_DELAY);
+			return;
+		}
+		for (Runnable callback : callbacks) {
+			SafeRunner.run(callback::run);
+		}
+	}
+
+	/**
+	 * Invalidates the components on any workspace change. Filtering by delta kind
+	 * would miss that a dynamic reference provider can derive its references from
+	 * any file of a project, such as a plug-in manifest or a class path.
+	 */
+	private void invalidateOnResourceChange(IResourceChangeEvent event) {
+		if (event.getDelta() == null) {
+			return;
+		}
+		synchronized (lock) {
+			requestedGeneration++;
+		}
+	}
+
+	private static List<List<IProject>> buildComponents(IProject[] projects) {
+		DisjointSet<IProject> set = buildDisjointSet(projects);
+		Map<IProject, List<IProject>> componentsByRepresentative = new LinkedHashMap<>();
+		for (IProject project : projects) {
+			IProject representative = set.findSet(project);
+			if (representative != null) {
+				componentsByRepresentative.computeIfAbsent(representative, key -> new ArrayList<>()).add(project);
+			}
+		}
+		List<List<IProject>> result = new ArrayList<>(componentsByRepresentative.size());
+		for (List<IProject> component : componentsByRepresentative.values()) {
+			result.add(List.copyOf(component));
+		}
+		return List.copyOf(result);
+	}
+
+	/**
+	 * Builds the connected component set for the input projects. The result is a
+	 * DisjointSet where all related projects belong to the same set.
+	 */
+	private static DisjointSet<IProject> buildDisjointSet(IProject[] projects) {
+		// initially each vertex is in a set by itself
+		DisjointSet<IProject> set = new DisjointSet<>();
+		for (IProject project : projects) {
+			set.makeSet(project);
+		}
+		for (IProject project : projects) {
+			try {
+				IProject[] references = project.getReferencedProjects();
+				// each reference represents an edge in the project reference
+				// digraph from projects[i] -> references[j]
+				for (IProject reference : references) {
+					IProject setOne = set.findSet(project);
+					// note that referenced projects may not exist in the workspace
+					IProject setTwo = set.findSet(reference);
+					// these two projects are related, so join their sets
+					if (setOne != null && setTwo != null && setOne != setTwo) {
+						set.union(setOne, setTwo);
+					}
+				}
+			} catch (CoreException e) {
+				// assume inaccessible projects have no references
+			}
+		}
+		return set;
+	}
+}

--- a/tests/org.eclipse.ui.tests.navigator/plugin.xml
+++ b/tests/org.eclipse.ui.tests.navigator/plugin.xml
@@ -1704,7 +1704,17 @@
          </selectionEnablement>
       </linkHelper>
    </extension>
-   
+
+   <extension
+         id="blockingReferenceProvider"
+         point="org.eclipse.core.resources.builders">
+      <builder hasNature="false">
+         <dynamicReference
+               class="org.eclipse.ui.tests.navigator.resources.BlockingReferenceProvider"/>
+         <run
+               class="org.eclipse.ui.tests.navigator.resources.BlockingReferenceProvider"/>
+      </builder>
+   </extension>
 
 
 </plugin>

--- a/tests/org.eclipse.ui.tests.navigator/src/org/eclipse/ui/tests/navigator/resources/BlockingReferenceProvider.java
+++ b/tests/org.eclipse.ui.tests.navigator/src/org/eclipse/ui/tests/navigator/resources/BlockingReferenceProvider.java
@@ -1,0 +1,89 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Lars Vogel and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.ui.tests.navigator.resources;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+
+import org.eclipse.core.resources.IBuildConfiguration;
+import org.eclipse.core.resources.ICommand;
+import org.eclipse.core.resources.IDynamicReferenceProvider;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IProjectDescription;
+import org.eclipse.core.resources.IncrementalProjectBuilder;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IProgressMonitor;
+
+/**
+ * Dynamic reference provider that a test can hold inside a reference lookup, so
+ * that the workspace can be changed while the project reference graph is being
+ * built. It contributes no references and builds nothing.
+ */
+public class BlockingReferenceProvider extends IncrementalProjectBuilder implements IDynamicReferenceProvider {
+
+	private static final String BUILDER_ID = "org.eclipse.ui.tests.navigator.blockingReferenceProvider"; //$NON-NLS-1$
+
+	private record Gate(CountDownLatch entered, CountDownLatch released) {
+	}
+
+	private static volatile Gate gate;
+
+	/**
+	 * Adds this provider to the project, so that a reference lookup on it can be
+	 * held. Reference lookups are cached, so a lookup only reaches the provider
+	 * again after {@link IProject#clearCachedDynamicReferences()}.
+	 */
+	public static void addTo(IProject project) throws CoreException {
+		IProjectDescription description = project.getDescription();
+		ICommand command = description.newCommand();
+		command.setBuilderName(BUILDER_ID);
+		description.setBuildSpec(new ICommand[] { command });
+		project.setDescription(description, null);
+	}
+
+	/** Makes the next reference lookup block until {@link #release()}. */
+	public static void arm() {
+		gate = new Gate(new CountDownLatch(1), new CountDownLatch(1));
+	}
+
+	public static void awaitBlocked() throws InterruptedException {
+		gate.entered().await();
+	}
+
+	/** Lets a blocked lookup continue. Does nothing if none is blocked. */
+	public static void release() {
+		Gate blocked = gate;
+		gate = null;
+		if (blocked != null) {
+			blocked.released().countDown();
+		}
+	}
+
+	@Override
+	public List<IProject> getDependentProjects(IBuildConfiguration buildConfiguration) {
+		Gate blocked = gate;
+		if (blocked != null) {
+			blocked.entered().countDown();
+			try {
+				blocked.released().await();
+			} catch (InterruptedException e) {
+				Thread.currentThread().interrupt();
+			}
+		}
+		return List.of();
+	}
+
+	@Override
+	protected IProject[] build(int kind, Map<String, String> args, IProgressMonitor monitor) {
+		return null;
+	}
+}

--- a/tests/org.eclipse.ui.tests.navigator/src/org/eclipse/ui/tests/navigator/resources/CloseUnrelatedProjectsActionTest.java
+++ b/tests/org.eclipse.ui.tests.navigator/src/org/eclipse/ui/tests/navigator/resources/CloseUnrelatedProjectsActionTest.java
@@ -13,6 +13,9 @@ package org.eclipse.ui.tests.navigator.resources;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Stream;
+
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IProjectDescription;
 import org.eclipse.core.resources.IWorkspace;
@@ -25,6 +28,8 @@ import org.eclipse.swt.widgets.Shell;
 import org.eclipse.ui.actions.CloseUnrelatedProjectsAction;
 import org.eclipse.ui.internal.ide.IDEInternalPreferences;
 import org.eclipse.ui.internal.ide.IDEWorkbenchPlugin;
+import org.eclipse.ui.internal.ide.misc.ProjectReferenceGraph;
+import org.eclipse.ui.tests.harness.util.DisplayHelper;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -65,6 +70,7 @@ public class CloseUnrelatedProjectsActionTest {
 
 	@AfterEach
 	public void tearDown() throws CoreException {
+		BlockingReferenceProvider.release();
 		if (shell != null && !shell.isDisposed()) {
 			shell.dispose();
 		}
@@ -77,147 +83,271 @@ public class CloseUnrelatedProjectsActionTest {
 		}
 	}
 
+	/**
+	 * Selects the given projects and waits until enablement reflects an up-to-date
+	 * project reference graph. The graph is computed in a background job, so the
+	 * first selection change may still answer from the previous graph.
+	 */
+	private static void select(CloseUnrelatedProjectsAction action, Object... selected) throws InterruptedException {
+		refreshGraph();
+		action.selectionChanged(new StructuredSelection(selected));
+	}
+
+	/**
+	 * Rebuilds the shared graph and fails if it did not end up current, so that a
+	 * later enablement assertion cannot fail for that reason instead.
+	 */
+	private static void refreshGraph() throws InterruptedException {
+		assertTrue(ProjectReferenceGraph.getInstance().refresh(null),
+				"the project reference graph did not become current");
+	}
+
+	/**
+	 * Waits for the background job that {@link CloseUnrelatedProjectsAction#run()}
+	 * starts. While it runs, the workspace defers its change notifications, and the
+	 * graph would not see projects the test creates in the meantime.
+	 */
+	private static void waitForClosed(IProject... projects) {
+		assertTrue(DisplayHelper.waitForCondition(Display.getDefault(), 10000,
+				() -> Stream.of(projects).noneMatch(IProject::isOpen)), "projects were not closed");
+	}
+
+	private static void processUIEvents() {
+		Display display = Display.getDefault();
+		while (display.readAndDispatch()) {
+			// drain the queue so asynchronous enablement updates are applied
+		}
+	}
+
 	@Test
-	public void testDisabledAfterAllUnrelatedProjectsClosedAndSelectionChanges() throws CoreException {
+	public void testDisabledAfterAllUnrelatedProjectsClosedAndSelectionChanges() throws Exception {
 		CloseUnrelatedProjectsAction action = new CloseUnrelatedProjectsAction(() -> shell);
 
-		action.selectionChanged(new StructuredSelection(a));
+		select(action, a);
 		assertTrue(action.isEnabled(), "action must be enabled while unrelated open project C exists");
 
 		c.close(null);
 
-		action.selectionChanged(new StructuredSelection(b));
+		select(action, b);
 		assertFalse(action.isEnabled(), "action must be disabled when no unrelated open project remains");
 	}
 
 	@Test
-	public void testDisabledAfterAllUnrelatedProjectsAreDeleted() throws CoreException {
+	public void testDisabledAfterAllUnrelatedProjectsAreDeleted() throws Exception {
 		CloseUnrelatedProjectsAction action = new CloseUnrelatedProjectsAction(() -> shell);
 
-		action.selectionChanged(new StructuredSelection(a));
+		select(action, a);
 		assertTrue(action.isEnabled(), "action must be enabled while unrelated open project C exists");
 
 		c.delete(true, true, null);
 
-		action.selectionChanged(new StructuredSelection(a));
+		select(action, a);
 		assertFalse(action.isEnabled(), "action must be disabled when no unrelated open project remains");
 	}
 
 	@Test
-	public void testDoNotCloseDeleted() throws CoreException {
+	public void testDoNotCloseDeleted() throws Exception {
 		CloseUnrelatedProjectsAction action = new CloseUnrelatedProjectsAction(() -> shell);
 
-		action.selectionChanged(new StructuredSelection(a));
+		select(action, a);
 		assertTrue(action.isEnabled(), "action must be enabled while unrelated open project C exists");
 
 		c.delete(true, true, null);
 
-		action.selectionChanged(new StructuredSelection(a));
+		select(action, a);
 		assertFalse(action.isEnabled(), "action must be disabled when no unrelated open project remains");
 		action.run(); // should not throw
 	}
 
 	@Test
-	public void testDisabledAfterUnrelatedProjectCreated() throws CoreException {
+	public void testDisabledAfterUnrelatedProjectCreated() throws Exception {
 		CloseUnrelatedProjectsAction action = new CloseUnrelatedProjectsAction(() -> shell);
 		c.close(null);
-		action.selectionChanged(new StructuredSelection(b));
+		select(action, b);
 		assertFalse(action.isEnabled(), "action must be disabled when no unrelated open project remains");
 
 		d.create(null);
 		d.open(null);
 
-		action.selectionChanged(new StructuredSelection(b));
+		select(action, b);
 		assertTrue(action.isEnabled(), "action must be enabled unrelated project is created");
 	}
 
 	@Test
-	public void testEnabledAfterDeleteAndReopen() throws CoreException {
+	public void testEnabledAfterDeleteAndReopen() throws Exception {
 		CloseUnrelatedProjectsAction action = new CloseUnrelatedProjectsAction(() -> shell);
-		action.selectionChanged(new StructuredSelection(b));
+		select(action, b);
 		assertTrue(action.isEnabled(), "action must be enabled when and unrelated open project remains");
 		action.run(); // should not throw
+		waitForClosed(c);
 
 		d.create(null);
 		d.open(null);
 
-		action.selectionChanged(new StructuredSelection(b));
+		select(action, b);
 		assertTrue(action.isEnabled(), "action must be enabled when unrelated project is created");
 
 		d.delete(true, true, null);
 		c.open(null);
 
-		action.selectionChanged(new StructuredSelection(b));
+		select(action, b);
 		assertTrue(action.isEnabled(), "action must be enabled when unrelated project is reopened");
 		action.run(); // should not throw
 	}
 
 	@Test
-	public void testDisabledAfterRunAndUnrelatedProjectCreated() throws CoreException {
+	public void testDisabledAfterRunAndUnrelatedProjectCreated() throws Exception {
 		CloseUnrelatedProjectsAction action = new CloseUnrelatedProjectsAction(() -> shell);
-		action.selectionChanged(new StructuredSelection(b));
+		select(action, b);
 		assertTrue(action.isEnabled(), "action must be enabled while unrelated open projects exist");
 		action.run();
+		waitForClosed(c);
 
 		d.create(null);
 		d.open(null);
 
-		action.selectionChanged(new StructuredSelection(b));
+		select(action, b);
 		assertTrue(action.isEnabled(), "action must be enabled unrelated project is created");
 	}
 
 	@Test
-	public void testDisabledAfterAllUnrelatedProjectsClosed() throws CoreException {
+	public void testDisabledAfterAllUnrelatedProjectsClosed() throws Exception {
 		CloseUnrelatedProjectsAction action = new CloseUnrelatedProjectsAction(() -> shell);
 
-		action.selectionChanged(new StructuredSelection(a));
-		assertTrue(action.isEnabled(),
-				"action must be enabled while unrelated open project C exists");
+		select(action, a);
+		assertTrue(action.isEnabled(), "action must be enabled while unrelated open project C exists");
 
 		c.close(null);
 
-		action.selectionChanged(new StructuredSelection(b));
-		assertFalse(action.isEnabled(),
-				"action must be disabled when no unrelated open project remains");
+		select(action, b);
+		assertFalse(action.isEnabled(), "action must be disabled when no unrelated open project remains");
 	}
 
 	@Test
-	public void testEnabledWhenUnrelatedOpenProjectExists() {
+	public void testEnabledWhenUnrelatedOpenProjectExists() throws Exception {
 		CloseUnrelatedProjectsAction action = new CloseUnrelatedProjectsAction(() -> shell);
 
-		action.selectionChanged(new StructuredSelection(a));
+		select(action, a);
 		assertTrue(action.isEnabled(), "expected enabled when unrelated open project C exists");
 
-		action.selectionChanged(new StructuredSelection(b));
-		assertTrue(action.isEnabled(),
-				"expected enabled when unrelated open project C exists (selection B)");
+		select(action, b);
+		assertTrue(action.isEnabled(), "expected enabled when unrelated open project C exists (selection B)");
 	}
 
 	@Test
-	public void testDisabledWhenSelectionCoversAllOpenProjects() throws CoreException {
+	public void testDisabledWhenSelectionCoversAllOpenProjects() throws Exception {
 		c.close(null);
 		CloseUnrelatedProjectsAction action = new CloseUnrelatedProjectsAction(() -> shell);
-		action.selectionChanged(new StructuredSelection(new Object[] { a, b }));
+		select(action, a, b);
 		assertFalse(action.isEnabled(),
 				"action must be disabled when selection plus its references covers all open projects");
 	}
 
+	/**
+	 * A selection change must never resolve project references itself: it answers
+	 * from the shared graph and corrects enablement once the background rebuild
+	 * finished.
+	 */
 	@Test
-	public void testListenerInvalidatesGraphOnProjectClose() throws CoreException {
+	public void testEnablementCorrectedAfterBackgroundRebuild() throws Exception {
+		c.close(null);
+		CloseUnrelatedProjectsAction action = new CloseUnrelatedProjectsAction(() -> shell);
+		select(action, b);
+		assertFalse(action.isEnabled(), "action must be disabled when no unrelated open project remains");
+
+		d.create(null);
+		d.open(null);
+
+		// A single selection change, without waiting for the graph first: it sees the
+		// previous graph, which still has no open unrelated project.
+		action.selectionChanged(new StructuredSelection(b));
+		assertFalse(action.isEnabled(), "enablement must answer from the cached graph without blocking");
+
+		refreshGraph();
+		processUIEvents();
+		assertTrue(action.isEnabled(), "enablement must be corrected once the graph rebuild finished");
+	}
+
+	/**
+	 * Mirrors the RCPTT test CloseUnrelatedProjectsInQ7Explorer, which broke when
+	 * enablement was made optimistic in the past: add a project reference, close the
+	 * unrelated projects, then check that the action is disabled for both related
+	 * projects. Nothing here refreshes the shared graph, so the action has to reach
+	 * the right answer on its own.
+	 */
+	@Test
+	public void testCloseUnrelatedAfterProjectReferenceAdded() throws Exception {
+		d.create(null);
+		d.open(null);
+		CloseUnrelatedProjectsAction action = new CloseUnrelatedProjectsAction(() -> shell);
+		select(action, c);
+
+		// C now references D, so closing what is unrelated to C must spare D. A graph
+		// that still predates this change would close D as well.
+		IProjectDescription cDesc = c.getDescription();
+		cDesc.setReferencedProjects(new IProject[] { d });
+		c.setDescription(cDesc, null);
+
+		action.selectionChanged(new StructuredSelection(c));
+		assertTrue(action.isEnabled(), "action must be enabled while unrelated open projects A and B exist");
+		action.run();
+
+		assertTrue(DisplayHelper.waitForCondition(Display.getDefault(), 10000, () -> !a.isOpen() && !b.isOpen()),
+				"the unrelated projects A and B must be closed");
+		assertTrue(c.isOpen(), "selected project C must stay open");
+		assertTrue(d.isOpen(), "project D referenced by C must stay open");
+
+		action.selectionChanged(new StructuredSelection(c));
+		assertFalse(action.isEnabled(), "action must be disabled once no unrelated open project remains");
+
+		action.selectionChanged(new StructuredSelection(d));
+		assertFalse(action.isEnabled(), "action must be disabled for the referenced project as well");
+	}
+
+	/**
+	 * A workspace change while the rebuild runs leaves it with components that are
+	 * stale on arrival. The graph has to start the rebuild that converges, because
+	 * invalidating it only marks the components stale, and the caller is waiting
+	 * for the callback rather than asking again.
+	 */
+	@Test
+	public void testCallbackRunsWhenGraphInvalidatedDuringRebuild() throws Exception {
+		BlockingReferenceProvider.addTo(a);
+		refreshGraph();
+
+		AtomicInteger callbackRuns = new AtomicInteger();
+		ProjectReferenceGraph graph = ProjectReferenceGraph.getInstance();
+
+		BlockingReferenceProvider.arm();
+		a.clearCachedDynamicReferences();
+		d.create(null);
+		d.open(null);
+		graph.getComponents(callbackRuns::incrementAndGet);
+
+		// the rebuild now sits in the reference lookup of A, so this change reaches
+		// the graph before the rebuild publishes what it computed without it
+		BlockingReferenceProvider.awaitBlocked();
+		c.close(null);
+		BlockingReferenceProvider.release();
+
+		assertTrue(DisplayHelper.waitForCondition(Display.getDefault(), 10000, () -> callbackRuns.get() > 0),
+				"the callback must run even when the graph is invalidated while the rebuild is running");
+	}
+
+	/**
+	 * Closing a project invalidates the shared graph, so the next selection change
+	 * schedules a rebuild rather than reusing the stale components.
+	 */
+	@Test
+	public void testGraphInvalidatedOnProjectClose() throws Exception {
 		CloseUnrelatedProjectsAction action = new CloseUnrelatedProjectsAction(() -> shell);
 
-		action.selectionChanged(new StructuredSelection(a));
-		assertTrue(action.isEnabled(),
-				"action must be enabled while unrelated open project C exists");
+		select(action, a);
+		assertTrue(action.isEnabled(), "action must be enabled while unrelated open project C exists");
 
-		// Closing C fires a POST_CHANGE event; the registered listener
-		// invalidates the cached graph and re-evaluates enablement.
 		c.close(null);
 
-		// Re-select A without manually calling selectionChanged first —
-		// the graph must already be invalidated by the listener.
-		action.selectionChanged(new StructuredSelection(a));
-		assertFalse(action.isEnabled(),
-				"action must be disabled after listener-driven graph invalidation");
+		select(action, a);
+		assertFalse(action.isEnabled(), "action must be disabled after the graph was rebuilt without open C");
 	}
 }


### PR DESCRIPTION
Close Unrelated Projects computed its enablement eagerly: every selection change walked the whole workspace and called `IProject.getReferencedProjects()` for every project, which runs the registered dynamic reference providers. With PDE and a large target platform that blocked the UI thread for over a minute during startup, while the Project Explorer restored its selection (#2636).

The connected components of the project graph now live in a shared `ProjectReferenceGraph` that computes them in a background job, so a selection change only looks up the components it already has and enablement is corrected once the job finished. Most of that class is the existing `DisjointSet` walk moved out of the action unchanged; the caching, the invalidation and the job are new, and nothing in `org.eclipse.ui.actions` changes as API.

Worth knowing for review: enablement is now eventually exact rather than synchronously exact, so right after a workspace change one selection change can still answer from the previous graph. Running the action always waits for a fresh computation first, so it still closes exactly the unrelated projects and names the right ones in its prompt. That is the deliberate difference to #3871, which was reverted because it left the action enabled with nothing to do and never corrected itself; a test mirroring the RCPTT case that caught that regression is included.

The same shape applies to any property tester behind `enabledWhen` that resolves something expensive, where `IEvaluationService.requestEvaluation` plays the role of the callback used here.
