### PR TITLE
Report per operation timings in OpenMultipleEditorTest

### DIFF
--- a/tests/org.eclipse.ui.tests.performance/src/org/eclipse/ui/tests/performance/OpenMultipleEditorTest.java
+++ b/tests/org.eclipse.ui.tests.performance/src/org/eclipse/ui/tests/performance/OpenMultipleEditorTest.java
@@ -17,15 +17,24 @@ package org.eclipse.ui.tests.performance;
 import static org.eclipse.ui.tests.harness.util.UITestUtil.openTestWindow;
 import static org.eclipse.ui.tests.harness.util.UITestUtil.processEvents;
 import static org.eclipse.ui.tests.performance.UIPerformanceTestRule.getTestProject;
+import static org.eclipse.ui.tests.performance.UIPerformanceTestUtil.exercise;
+import static org.eclipse.ui.tests.performance.UIPerformanceTestUtil.reportTimings;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.List;
 
 import org.eclipse.core.resources.IFile;
-import org.eclipse.test.performance.PerformanceTestCaseJunit4;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.ui.IEditorPart;
 import org.eclipse.ui.IEditorReference;
 import org.eclipse.ui.IWorkbenchPage;
 import org.eclipse.ui.IWorkbenchWindow;
+import org.eclipse.ui.PartInitException;
 import org.eclipse.ui.ide.IDE;
 import org.eclipse.ui.tests.harness.util.CloseTestWindowsRule;
 import org.junit.ClassRule;
@@ -36,10 +45,31 @@ import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
 
 /**
- * @since 3.1
+ * Measures how long it takes to fill the editor area with many editors and to
+ * tear it down again.
+ * <p>
+ * The opens are reported for the start and for the end of the batch separately,
+ * because the cost of an open grows with the number of editors already open and
+ * a single distribution over the whole batch would hide that.
  */
 @RunWith(Parameterized.class)
-public class OpenMultipleEditorTest extends PerformanceTestCaseJunit4 {
+public class OpenMultipleEditorTest {
+
+	/** Number of files the {@link UIPerformanceTestRule} creates per extension. */
+	private static final int EDITOR_COUNT = 100;
+
+	/**
+	 * How many opens at each end of the batch are reported. The ones in between
+	 * only interpolate.
+	 */
+	private static final int EDGE = 25;
+
+	/** A closeAll round yields a single sample, so a few rounds are the minimum. */
+	private static final int MIN_ROUNDS = 3;
+
+	private static final int MAX_ROUNDS = 10;
+
+	private static final int MAX_MEASURE_TIME_MS = 10000;
 
 	@ClassRule
 	public static final UIPerformanceTestRule uiPerformanceTestRule = new UIPerformanceTestRule();
@@ -50,7 +80,7 @@ public class OpenMultipleEditorTest extends PerformanceTestCaseJunit4 {
 	private final String extension;
 	private final boolean closeAll;
 
-	@Parameters(name = "{index}: closeAll: {0} - closeEach: {1}")
+	@Parameters(name = "{index}: {0} - closeAll: {1}")
 	public static Collection<Object[]> data() {
 		return Arrays.asList(new Object[][] { { "perf_basic", true }, { "perf_outline", true }, { "perf_text", true },
 				{ "perf_basic", false }, { "perf_outline", false }, { "perf_text", false } });
@@ -62,29 +92,74 @@ public class OpenMultipleEditorTest extends PerformanceTestCaseJunit4 {
 	}
 
 	@Test
-	public void test() throws Throwable {
+	public void test() throws CoreException {
 		IWorkbenchWindow window = openTestWindow(UIPerformanceTestRule.PERSPECTIVE1);
-		IWorkbenchPage activePage = window.getActivePage();
+		final IWorkbenchPage activePage = window.getActivePage();
 
-		startMeasuring();
+		// Class loading and JIT warm-up of the editor implementation would otherwise
+		// end up in the reported times.
+		openAndCloseAll(activePage, null);
+		EditorTestHelper.calmDown(500, 30000, 500);
 
-		for (int i = 0; i < 100; i++) {
-			IFile file = getTestProject().getFile(i + "." + extension);
-			IDE.openEditor(activePage, file, true);
-			processEvents();
-		}
-		if (closeAll) {
-			activePage.closeAllEditors(false);
-		}
-		else {
-			IEditorReference[] parts = activePage.getEditorReferences();
-			for (IEditorReference part : parts) {
-				activePage.closeEditor(part.getEditor(false), false);
-			}
-		}
-		stopMeasuring();
-		commitMeasurements();
-		assertPerformance();
+		Timings timings = new Timings();
+		exercise(() -> openAndCloseAll(activePage, timings), MIN_ROUNDS, MAX_ROUNDS, MAX_MEASURE_TIME_MS);
+
+		String label = "OpenMultipleEditor[" + extension + "]";
+		reportTimings(label + " open 1.." + EDGE, timings.earlyOpens);
+		reportTimings(label + " open " + (EDITOR_COUNT - EDGE + 1) + ".." + EDITOR_COUNT, timings.lateOpens);
+		reportTimings(label + (closeAll ? " closeAll of " + EDITOR_COUNT : " close each"), timings.closes);
 	}
 
+	/**
+	 * Opens an editor for every test file of the extension under test and closes
+	 * them all again, recording the individual operations when the given timings
+	 * are not {@code null}.
+	 */
+	private void openAndCloseAll(IWorkbenchPage page, Timings timings) throws PartInitException {
+		for (int i = 0; i < EDITOR_COUNT; i++) {
+			IFile file = getTestProject().getFile(i + "." + extension);
+			assertTrue("Missing test file " + file.getName(), file.exists());
+
+			long before = System.nanoTime();
+			IEditorPart part = IDE.openEditor(page, file, true);
+			processEvents();
+			long elapsed = System.nanoTime() - before;
+			assertNotNull("No editor opened for " + file.getName(), part);
+
+			if (timings != null) {
+				if (i < EDGE) {
+					timings.earlyOpens.add(elapsed);
+				} else if (i >= EDITOR_COUNT - EDGE) {
+					timings.lateOpens.add(elapsed);
+				}
+			}
+		}
+
+		if (closeAll) {
+			long before = System.nanoTime();
+			page.closeAllEditors(false);
+			processEvents();
+			long elapsed = System.nanoTime() - before;
+			if (timings != null) {
+				timings.closes.add(elapsed);
+			}
+		} else {
+			for (IEditorReference reference : page.getEditorReferences()) {
+				long before = System.nanoTime();
+				page.closeEditor(reference.getEditor(false), false);
+				processEvents();
+				long elapsed = System.nanoTime() - before;
+				if (timings != null) {
+					timings.closes.add(elapsed);
+				}
+			}
+		}
+		assertEquals("Editors left open", 0, page.getEditorReferences().length);
+	}
+
+	private static final class Timings {
+		final List<Long> earlyOpens = new ArrayList<>();
+		final List<Long> lateOpens = new ArrayList<>();
+		final List<Long> closes = new ArrayList<>();
+	}
 }

--- a/tests/org.eclipse.ui.tests.performance/src/org/eclipse/ui/tests/performance/UIPerformanceTestUtil.java
+++ b/tests/org.eclipse.ui.tests.performance/src/org/eclipse/ui/tests/performance/UIPerformanceTestUtil.java
@@ -46,7 +46,7 @@ public final class UIPerformanceTestUtil {
 			return;
 		}
 		long[] sorted = nanos.stream().mapToLong(Long::longValue).sorted().toArray();
-		System.out.printf(Locale.ROOT, "%-44s n=%-4d min=%8.2f  p50=%8.2f  p90=%8.2f  max=%8.2f (ms)%n", label,
+		System.out.printf(Locale.ROOT, "%-48s n=%-4d min=%8.2f  p50=%8.2f  p90=%8.2f  max=%8.2f (ms)%n", label,
 				sorted.length, sorted[0] / 1e6, sorted[sorted.length / 2] / 1e6,
 				sorted[(int) (sorted.length * 0.9)] / 1e6, sorted[sorted.length - 1] / 1e6);
 	}


### PR DESCRIPTION
Applies the same treatment to `OpenMultipleEditorTest` that `OpenCloseEditorTest` and `EditorSwitchTest` already received: it drops `org.eclipse.test.performance`, whose measurements went nowhere because the performance database has not been configured for years, and times the individual operations instead.

Each of the 100 opens is now timed on its own and the close phase is timed per variant. Since this test is about the accumulation of editors, the first and last 25 opens are reported as separate distributions, so it is visible whether an open gets more expensive as the editor area fills up. The test warms up before measuring and is bounded by time rather than a single fixed round.

The practical gain is that the test can now fail and can now report something. It asserts that every editor really opened and that none are left behind, and a manual run prints min, median, 90th percentile and maximum per operation. The first numbers already show that closing 100 editors one by one costs noticeably more than `closeAllEditors`, and that the per open cost does not grow at the floor as editors accumulate.

Also fixes the parameterized display name, which labelled the extension as `closeAll` and the `closeAll` flag as `closeEach`.