### PR TITLE
Migrate the JFace performance tests off org.eclipse.test.performance

### DIFF
--- a/tests/org.eclipse.ui.tests.performance/src/org/eclipse/jface/tests/performance/CollatorPerformanceTest.java
+++ b/tests/org.eclipse.ui.tests.performance/src/org/eclipse/jface/tests/performance/CollatorPerformanceTest.java
@@ -15,24 +15,22 @@
 
 package org.eclipse.jface.tests.performance;
 
+import static org.eclipse.ui.tests.performance.UIPerformanceTestUtil.reportTimings;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
+import java.util.List;
 
 import org.eclipse.jface.util.Policy;
-import org.eclipse.test.performance.Performance;
-import org.eclipse.test.performance.PerformanceMeter;
-import org.eclipse.ui.tests.performance.UIPerformanceTestRule;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
-import org.junit.jupiter.api.extension.RegisterExtension;
 
 /**
  * @since 3.5
  */
 public class CollatorPerformanceTest {
-
-	@RegisterExtension
-	static UIPerformanceTestRule uiPerformanceTestRule = new UIPerformanceTestRule();
 
 	private static final int ARRAYSIZE=100000;
 	private static String[] fArray;
@@ -46,23 +44,17 @@ public class CollatorPerformanceTest {
 	 */
 	@Test
 	public void testCollator(TestInfo testInfo) {
-		Performance perf = Performance.getDefault();
-		String scenarioId = this.getClass().getName() + "." + testInfo.getDisplayName();
-		PerformanceMeter meter = perf.createPerformanceMeter(scenarioId);
-
-		Comparator<Object> comparator=Policy.getComparator();
-		try {
-			for (int i = 0; i < 15; i++) {
-				String[] array=fArray.clone();
-				meter.start();
-				Arrays.sort(array, comparator);
-				meter.stop();
-			}
-			meter.commit();
-			perf.assertPerformance(meter);
-		} finally {
-			meter.dispose();
+		Comparator<Object> comparator = Policy.getComparator();
+		List<Long> timings = new ArrayList<>();
+		for (int i = 0; i < 15; i++) {
+			String[] array = fArray.clone();
+			long before = System.nanoTime();
+			Arrays.sort(array, comparator);
+			timings.add(System.nanoTime() - before);
+			assertEquals(ARRAYSIZE, array.length);
 		}
+
+		reportTimings(getClass().getSimpleName() + "." + testInfo.getDisplayName(), timings);
 	}
 
 	/**

--- a/tests/org.eclipse.ui.tests.performance/src/org/eclipse/jface/tests/performance/ComboViewerRefreshTest.java
+++ b/tests/org.eclipse.ui.tests.performance/src/org/eclipse/jface/tests/performance/ComboViewerRefreshTest.java
@@ -20,7 +20,7 @@ import static org.eclipse.ui.tests.performance.UIPerformanceTestUtil.exercise;
 import org.eclipse.jface.viewers.ComboViewer;
 import org.eclipse.jface.viewers.StructuredViewer;
 import org.eclipse.swt.widgets.Shell;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * ComboViewerRefreshTest is a test of refreshes of difference size in the combo
@@ -59,8 +59,7 @@ public class ComboViewerRefreshTest extends ViewerTest {
 			stopMeasuring();
 		}, MIN_ITERATIONS, ITERATIONS, JFacePerformanceSuite.MAX_TIME);
 
-		commitMeasurements();
-		assertPerformance();
+		reportTimings();
 	}
 
 	/**
@@ -80,8 +79,7 @@ public class ComboViewerRefreshTest extends ViewerTest {
 			stopMeasuring();
 		}, MIN_ITERATIONS, slowGTKIterations(), JFacePerformanceSuite.MAX_TIME);
 
-		commitMeasurements();
-		assertPerformance();
+		reportTimings();
 	}
 
 }

--- a/tests/org.eclipse.ui.tests.performance/src/org/eclipse/jface/tests/performance/FastTableViewerRefreshTest.java
+++ b/tests/org.eclipse.ui.tests.performance/src/org/eclipse/jface/tests/performance/FastTableViewerRefreshTest.java
@@ -17,7 +17,7 @@ import static org.eclipse.ui.tests.harness.util.UITestUtil.processEvents;
 import static org.eclipse.ui.tests.performance.UIPerformanceTestUtil.exercise;
 
 import org.eclipse.swt.widgets.TableItem;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class FastTableViewerRefreshTest extends TableViewerRefreshTest {
 
@@ -39,8 +39,7 @@ public class FastTableViewerRefreshTest extends TableViewerRefreshTest {
 		}, MIN_ITERATIONS, slowGTKIterations(),
 				JFacePerformanceSuite.MAX_TIME);
 
-		commitMeasurements();
-		assertPerformance();
+		reportTimings();
 	}
 
 	/**
@@ -68,8 +67,7 @@ public class FastTableViewerRefreshTest extends TableViewerRefreshTest {
 				}, MIN_ITERATIONS, slowGTKIterations(),
 				JFacePerformanceSuite.MAX_TIME);
 
-		commitMeasurements();
-		assertPerformance();
+		reportTimings();
 	}
 
 }

--- a/tests/org.eclipse.ui.tests.performance/src/org/eclipse/jface/tests/performance/FastTreeTest.java
+++ b/tests/org.eclipse.ui.tests.performance/src/org/eclipse/jface/tests/performance/FastTreeTest.java
@@ -15,13 +15,13 @@ package org.eclipse.jface.tests.performance;
 
 import static org.eclipse.ui.tests.harness.util.UITestUtil.processEvents;
 import static org.eclipse.ui.tests.performance.UIPerformanceTestUtil.exercise;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.ArrayList;
 import java.util.Collection;
 
 import org.eclipse.core.runtime.CoreException;
-import org.eclipse.test.performance.Dimension;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class FastTreeTest extends TreeAddTest {
 
@@ -49,9 +49,6 @@ public class FastTreeTest extends TreeAddTest {
 	 */
 	@Test
 	public void testAddHundredTenTimes() throws CoreException {
-		tagAsSummary("JFace - Add 10000 items 100 at a time TreeViewer 10 times",
-				Dimension.ELAPSED_PROCESS);
-
 		doTestAdd(100, TEST_COUNT, false);
 	}
 
@@ -91,11 +88,11 @@ public class FastTreeTest extends TreeAddTest {
 
 
 			stopMeasuring();
+			assertEquals(batchArray.length * increment, viewer.getTree().getItemCount());
 
 		}, MIN_ITERATIONS, ITERATIONS, JFacePerformanceSuite.MAX_TIME);
 
-		commitMeasurements();
-		assertPerformance();
+		reportTimings();
 
 	}
 }

--- a/tests/org.eclipse.ui.tests.performance/src/org/eclipse/jface/tests/performance/FileImageDescriptorTest.java
+++ b/tests/org.eclipse.ui.tests.performance/src/org/eclipse/jface/tests/performance/FileImageDescriptorTest.java
@@ -16,18 +16,19 @@ package org.eclipse.jface.tests.performance;
 
 import static org.eclipse.ui.tests.harness.util.UITestUtil.processEvents;
 import static org.eclipse.ui.tests.performance.UIPerformanceTestUtil.exercise;
+import static org.eclipse.ui.tests.performance.UIPerformanceTestUtil.reportTimings;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Enumeration;
 import java.util.Iterator;
+import java.util.List;
 
 import org.eclipse.core.runtime.FileLocator;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.swt.graphics.Image;
-import org.eclipse.test.performance.Performance;
-import org.eclipse.test.performance.PerformanceMeter;
 import org.eclipse.ui.tests.harness.util.CloseTestWindowsExtension;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
@@ -52,55 +53,50 @@ public class FileImageDescriptorTest {
 	@Test
 	public void testRefresh(TestInfo testInfo) throws Throwable {
 
-		Performance perf = Performance.getDefault();
-		String scenarioId = this.getClass().getName() + "." + testInfo.getDisplayName();
-		PerformanceMeter meter = perf.createPerformanceMeter(scenarioId);
+		List<Long> timings = new ArrayList<>();
 
-		try {
-			exercise(() -> {
-				Class<?> missing = null;
-				ArrayList<Image> images = new ArrayList<>();
+		exercise(() -> {
+			Class<?> missing = null;
+			ArrayList<Image> images = new ArrayList<>();
 
-				Bundle bundle = FrameworkUtil.getBundle(getClass());
-				Enumeration<String> bundleEntries = bundle.getEntryPaths(IMAGES_DIRECTORY);
+			Bundle bundle = FrameworkUtil.getBundle(getClass());
+			Enumeration<String> bundleEntries = bundle.getEntryPaths(IMAGES_DIRECTORY);
 
 
-				while (bundleEntries.hasMoreElements()) {
-					ImageDescriptor descriptor;
-					String localImagePath = bundleEntries.nextElement();
+			while (bundleEntries.hasMoreElements()) {
+				ImageDescriptor descriptor;
+				String localImagePath = bundleEntries.nextElement();
 
-					if (localImagePath.indexOf('.') < 0)
-						continue;
+				if (localImagePath.indexOf('.') < 0)
+					continue;
 
-					URL[] files = FileLocator.findEntries(bundle, IPath.fromOSString(localImagePath));
+				URL[] files = FileLocator.findEntries(bundle, IPath.fromOSString(localImagePath));
 
-					for (URL file : files) {
-						meter.start();
-						descriptor = ImageDescriptor.createFromFile(missing, FileLocator.toFileURL(file).getFile());
+				for (URL file : files) {
+					long before = System.nanoTime();
+					descriptor = ImageDescriptor.createFromFile(missing, FileLocator.toFileURL(file).getFile());
 
-						for (int j = 0; j < 10; j++) {
-							Image image = descriptor.createImage();
-							images.add(image);
-						}
-
-						processEvents();
-						meter.stop();
-
+					for (int j = 0; j < 10; j++) {
+						Image image = descriptor.createImage();
+						images.add(image);
 					}
 
+					processEvents();
+					timings.add(System.nanoTime() - before);
+
 				}
 
+			}
 
-				Iterator<Image> imageIterator = images.iterator();
-				while (imageIterator.hasNext()) {
-					imageIterator.next().dispose();
-				}
-			}, 20, 100, JFacePerformanceSuite.MAX_TIME);
 
-			meter.commit();
-			perf.assertPerformance(meter);
-		} finally {
-			meter.dispose();
-		}
+			assertFalse(images.isEmpty(), "No test images were found in " + IMAGES_DIRECTORY);
+
+			Iterator<Image> imageIterator = images.iterator();
+			while (imageIterator.hasNext()) {
+				imageIterator.next().dispose();
+			}
+		}, 20, 100, JFacePerformanceSuite.MAX_TIME);
+
+		reportTimings(getClass().getSimpleName() + "." + testInfo.getDisplayName(), timings);
 	}
 }

--- a/tests/org.eclipse.ui.tests.performance/src/org/eclipse/jface/tests/performance/JFacePerformanceSuite.java
+++ b/tests/org.eclipse.ui.tests.performance/src/org/eclipse/jface/tests/performance/JFacePerformanceSuite.java
@@ -26,6 +26,7 @@ import org.junit.platform.suite.api.SelectClasses;
 		FastTableViewerRefreshTest.class, //
 		FastTreeTest.class, //
 		TreeAddTest.class, //
+		TreeViewerExpansionTest.class, //
 		ProgressMonitorDialogPerformanceTest.class, //
 		ShrinkingTreeTest.class, //
 		CollatorPerformanceTest.class, //

--- a/tests/org.eclipse.ui.tests.performance/src/org/eclipse/jface/tests/performance/ListPopulationTest.java
+++ b/tests/org.eclipse.ui.tests.performance/src/org/eclipse/jface/tests/performance/ListPopulationTest.java
@@ -16,14 +16,16 @@ package org.eclipse.jface.tests.performance;
 
 import static org.eclipse.ui.tests.harness.util.UITestUtil.processEvents;
 import static org.eclipse.ui.tests.performance.UIPerformanceTestUtil.exercise;
+import static org.eclipse.ui.tests.performance.UIPerformanceTestUtil.reportTimings;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.ArrayList;
 
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.layout.FillLayout;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.List;
 import org.eclipse.swt.widgets.Shell;
-import org.eclipse.test.performance.Performance;
-import org.eclipse.test.performance.PerformanceMeter;
 import org.eclipse.ui.tests.harness.util.CloseTestWindowsExtension;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
@@ -98,26 +100,19 @@ public class ListPopulationTest {
 		openBrowser();
 		final String [] items = getItems(count);
 
-		Performance perf = Performance.getDefault();
-		String scenarioId = this.getClass().getName() + "." + testInfo.getDisplayName();
-		PerformanceMeter meter = perf.createPerformanceMeter(scenarioId);
+		java.util.List<Long> timings = new ArrayList<>();
+		exercise(() -> {
+			list.removeAll();
+			long before = System.nanoTime();
+			for (String item : items) {
+				list.add(item);
+			}
+			processEvents();
+			timings.add(System.nanoTime() - before);
+			assertEquals(count, list.getItemCount());
+		});
 
-		try {
-			exercise(() -> {
-				list.removeAll();
-				meter.start();
-				for (String item : items) {
-					list.add(item);
-				}
-				processEvents();
-				meter.stop();
-			});
-
-			meter.commit();
-			perf.assertPerformance(meter);
-		} finally {
-			meter.dispose();
-		}
+		reportTimings(scenario(testInfo), timings);
 	}
 
 	/**
@@ -127,24 +122,21 @@ public class ListPopulationTest {
 		openBrowser();
 		final String [] items = getItems(count);
 
-		Performance perf = Performance.getDefault();
-		String scenarioId = this.getClass().getName() + "." + testInfo.getDisplayName();
-		PerformanceMeter meter = perf.createPerformanceMeter(scenarioId);
+		java.util.List<Long> timings = new ArrayList<>();
+		exercise(() -> {
+			list.removeAll();
+			long before = System.nanoTime();
+			list.setItems(items);
+			processEvents();
+			timings.add(System.nanoTime() - before);
+			assertEquals(count, list.getItemCount());
+		});
 
-		try {
-			exercise(() -> {
-				list.removeAll();
-				meter.start();
-				list.setItems(items);
-				processEvents();
-				meter.stop();
-			});
+		reportTimings(scenario(testInfo), timings);
+	}
 
-			meter.commit();
-			perf.assertPerformance(meter);
-		} finally {
-			meter.dispose();
-		}
+	private String scenario(TestInfo testInfo) {
+		return getClass().getSimpleName() + "." + testInfo.getDisplayName();
 	}
 
 	/**

--- a/tests/org.eclipse.ui.tests.performance/src/org/eclipse/jface/tests/performance/ListViewerRefreshTest.java
+++ b/tests/org.eclipse.ui.tests.performance/src/org/eclipse/jface/tests/performance/ListViewerRefreshTest.java
@@ -20,7 +20,7 @@ import static org.eclipse.ui.tests.performance.UIPerformanceTestUtil.exercise;
 import org.eclipse.jface.viewers.ListViewer;
 import org.eclipse.jface.viewers.StructuredViewer;
 import org.eclipse.swt.widgets.Shell;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * The ListViewerRefreshTest is a test of refreshing the list viewer.
@@ -56,8 +56,7 @@ public class ListViewerRefreshTest extends ViewerTest {
 		}, MIN_ITERATIONS, ITERATIONS,
 				JFacePerformanceSuite.MAX_TIME);
 
-		commitMeasurements();
-		assertPerformance();
+		reportTimings();
 	}
 
 }

--- a/tests/org.eclipse.ui.tests.performance/src/org/eclipse/jface/tests/performance/ProgressMonitorDialogPerformanceTest.java
+++ b/tests/org.eclipse.ui.tests.performance/src/org/eclipse/jface/tests/performance/ProgressMonitorDialogPerformanceTest.java
@@ -15,15 +15,17 @@
 package org.eclipse.jface.tests.performance;
 
 import static org.eclipse.ui.tests.harness.util.UITestUtil.processEvents;
+import static org.eclipse.ui.tests.performance.UIPerformanceTestUtil.reportTimings;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.ArrayList;
+import java.util.List;
 
 import org.eclipse.jface.dialogs.ProgressMonitorDialog;
 import org.eclipse.jface.operation.IRunnableWithProgress;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Shell;
-import org.eclipse.test.performance.Performance;
-import org.eclipse.test.performance.PerformanceMeter;
 import org.eclipse.ui.tests.harness.util.CloseTestWindowsExtension;
-import org.eclipse.ui.tests.performance.UIPerformanceTestRule;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -32,9 +34,6 @@ import org.junit.jupiter.api.extension.RegisterExtension;
  * @since 3.3
  */
 public class ProgressMonitorDialogPerformanceTest {
-
-	@RegisterExtension
-	static UIPerformanceTestRule uiPerformanceTestRule = new UIPerformanceTestRule();
 
 	@RegisterExtension
 	CloseTestWindowsExtension closeTestWindows = new CloseTestWindowsExtension();
@@ -52,9 +51,7 @@ public class ProgressMonitorDialogPerformanceTest {
 		Shell shell = new Shell(display);
 		ProgressMonitorDialog dialog = new ProgressMonitorDialog(shell);
 
-		Performance perf = Performance.getDefault();
-		String scenarioId = this.getClass().getName() + "." + testInfo.getDisplayName();
-		PerformanceMeter meter = perf.createPerformanceMeter(scenarioId);
+		List<Long> timings = new ArrayList<>();
 
 		IRunnableWithProgress runnable = monitor -> {
 
@@ -70,23 +67,22 @@ public class ProgressMonitorDialogPerformanceTest {
 
 			// test
 			for (int testCounter = 0; testCounter < 20; testCounter++) {
-				meter.start();
+				long before = System.nanoTime();
 				for (int counter = 0; counter < 30; counter++) {
-				monitor.setTaskName(taskName);
+					monitor.setTaskName(taskName);
+					processEvents();
+				}
 				processEvents();
-			}
-				processEvents();
-				meter.stop();
+				timings.add(System.nanoTime() - before);
 			}
 		};
 
 		try {
 			dialog.run(false, true, runnable);
 
-			meter.commit();
-			perf.assertPerformance(meter);
+			assertEquals(20, timings.size());
+			reportTimings(getClass().getSimpleName() + "." + testInfo.getDisplayName(), timings);
 		} finally {
-			meter.dispose();
 			shell.dispose();
 		}
 	}

--- a/tests/org.eclipse.ui.tests.performance/src/org/eclipse/jface/tests/performance/SWTTreeTest.java
+++ b/tests/org.eclipse.ui.tests.performance/src/org/eclipse/jface/tests/performance/SWTTreeTest.java
@@ -15,6 +15,11 @@ package org.eclipse.jface.tests.performance;
 
 import static org.eclipse.ui.tests.harness.util.UITestUtil.processEvents;
 import static org.eclipse.ui.tests.performance.UIPerformanceTestUtil.exercise;
+import static org.eclipse.ui.tests.performance.UIPerformanceTestUtil.reportTimings;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.ArrayList;
+import java.util.List;
 
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.swt.SWT;
@@ -23,9 +28,8 @@ import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Shell;
 import org.eclipse.swt.widgets.Tree;
 import org.eclipse.swt.widgets.TreeItem;
-import org.eclipse.test.performance.Performance;
-import org.eclipse.test.performance.PerformanceMeter;
 import org.eclipse.ui.tests.harness.util.CloseTestWindowsExtension;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -50,7 +54,14 @@ public class SWTTreeTest {
 		tree = new Tree(browserShell, SWT.NONE);
 		createChildren();
 		browserShell.open();
-		// processEvents();
+	}
+
+	@AfterEach
+	public void closeBrowserShell() {
+		if (browserShell != null) {
+			browserShell.close();
+			browserShell = null;
+		}
 	}
 
 	private void createChildren() {
@@ -69,58 +80,47 @@ public class SWTTreeTest {
 	public void testGetItems(TestInfo testInfo) throws CoreException {
 		openBrowser();
 
-		Performance perf = Performance.getDefault();
-		String scenarioId = this.getClass().getName() + "." + testInfo.getDisplayName();
-		PerformanceMeter meter = perf.createPerformanceMeter(scenarioId);
-
-		try {
-			exercise(() -> {
+		List<Long> timings = new ArrayList<>();
+		exercise(() -> {
+			processEvents();
+			long before = System.nanoTime();
+			int seen = 0;
+			for (int j = 0; j < TreeAddTest.TEST_COUNT; j++) {
+				seen += tree.getItems().length;
 				processEvents();
-				meter.start();
-				for (int j = 0; j < TreeAddTest.TEST_COUNT; j++) {
-					tree.getItems();
-					processEvents();
-				}
-				meter.stop();
-			});
+			}
+			timings.add(System.nanoTime() - before);
+			assertEquals(TreeAddTest.TEST_COUNT * TreeAddTest.TEST_COUNT, seen);
+		});
 
-			meter.commit();
-			perf.assertPerformance(meter);
-		} finally {
-			meter.dispose();
-			browserShell.close();
-		}
+		reportTimings(scenario(testInfo), timings);
 	}
 
 	/**
-	 * @throws CoreException
 	 * Test the getItem API.
 	 */
 	@Test
 	public void testGetItemAt(TestInfo testInfo) throws CoreException {
 		openBrowser();
 
-		Performance perf = Performance.getDefault();
-		String scenarioId = this.getClass().getName() + "." + testInfo.getDisplayName();
-		PerformanceMeter meter = perf.createPerformanceMeter(scenarioId);
-
-		try {
-			exercise(() -> {
+		List<Long> timings = new ArrayList<>();
+		exercise(() -> {
+			processEvents();
+			long before = System.nanoTime();
+			int seen = 0;
+			for (int j = 0; j < TreeAddTest.TEST_COUNT; j++) {
+				seen += tree.getItem(j) == null ? 0 : 1;
 				processEvents();
-				meter.start();
-				for (int j = 0; j < TreeAddTest.TEST_COUNT; j++) {
-					tree.getItem(j);
-					processEvents();
-				}
-				meter.stop();
-			});
+			}
+			timings.add(System.nanoTime() - before);
+			assertEquals(TreeAddTest.TEST_COUNT, seen);
+		});
 
-			meter.commit();
-			perf.assertPerformance(meter);
-		} finally {
-			meter.dispose();
-			browserShell.close();
-		}
+		reportTimings(scenario(testInfo), timings);
+	}
+
+	private String scenario(TestInfo testInfo) {
+		return getClass().getSimpleName() + "." + testInfo.getDisplayName();
 	}
 
 }

--- a/tests/org.eclipse.ui.tests.performance/src/org/eclipse/jface/tests/performance/ShrinkingTreeTest.java
+++ b/tests/org.eclipse.ui.tests.performance/src/org/eclipse/jface/tests/performance/ShrinkingTreeTest.java
@@ -15,9 +15,10 @@ package org.eclipse.jface.tests.performance;
 
 import static org.eclipse.ui.tests.harness.util.UITestUtil.processEvents;
 import static org.eclipse.ui.tests.performance.UIPerformanceTestUtil.exercise;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.eclipse.core.runtime.CoreException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * ShrinkingTreeTest is a test to see how long it takes to refresh a tree that goes
@@ -63,11 +64,11 @@ public class ShrinkingTreeTest extends TreeTest {
 			viewer.refresh();
 
 			stopMeasuring();
+			assertEquals(smallSize, viewer.getTree().getItemCount());
 
 		}, MIN_ITERATIONS, ITERATIONS, JFacePerformanceSuite.MAX_TIME);
 
-		commitMeasurements();
-		assertPerformance();
+		reportTimings();
 
 	}
 

--- a/tests/org.eclipse.ui.tests.performance/src/org/eclipse/jface/tests/performance/TableViewerRefreshTest.java
+++ b/tests/org.eclipse.ui.tests.performance/src/org/eclipse/jface/tests/performance/TableViewerRefreshTest.java
@@ -25,7 +25,7 @@ import org.eclipse.swt.widgets.Shell;
 import org.eclipse.swt.widgets.Table;
 import org.eclipse.swt.widgets.TableItem;
 import org.eclipse.swt.widgets.Widget;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * The TableViewerRefreshTest is a test for refreshing the TableViewer.
@@ -80,8 +80,7 @@ public class TableViewerRefreshTest extends ViewerTest {
 		}, MIN_ITERATIONS, slowGTKIterations(),
 				JFacePerformanceSuite.MAX_TIME);
 
-		commitMeasurements();
-		assertPerformance();
+		reportTimings();
 	}
 
 	/**
@@ -100,8 +99,7 @@ public class TableViewerRefreshTest extends ViewerTest {
 		}, MIN_ITERATIONS, slowGTKIterations(),
 				JFacePerformanceSuite.MAX_TIME);
 
-		commitMeasurements();
-		assertPerformance();
+		reportTimings();
 	}
 
 	/**
@@ -124,8 +122,7 @@ public class TableViewerRefreshTest extends ViewerTest {
 		}, MIN_ITERATIONS, ITERATIONS,
 				JFacePerformanceSuite.MAX_TIME);
 
-		commitMeasurements();
-		assertPerformance();
+		reportTimings();
 	}
 
 	/**
@@ -152,8 +149,7 @@ public class TableViewerRefreshTest extends ViewerTest {
 		}, MIN_ITERATIONS, slowGTKIterations(),
 				JFacePerformanceSuite.MAX_TIME);
 
-		commitMeasurements();
-		assertPerformance();
+		reportTimings();
 	}
 
 }

--- a/tests/org.eclipse.ui.tests.performance/src/org/eclipse/jface/tests/performance/TreeAddTest.java
+++ b/tests/org.eclipse.ui.tests.performance/src/org/eclipse/jface/tests/performance/TreeAddTest.java
@@ -15,13 +15,13 @@ package org.eclipse.jface.tests.performance;
 
 import static org.eclipse.ui.tests.harness.util.UITestUtil.processEvents;
 import static org.eclipse.ui.tests.performance.UIPerformanceTestUtil.exercise;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.ArrayList;
 import java.util.Collection;
 
 import org.eclipse.core.runtime.CoreException;
-import org.eclipse.test.performance.Dimension;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TreeAddTest extends TreeTest {
 
@@ -45,10 +45,10 @@ public class TreeAddTest extends TreeTest {
 				processEvents();
 			}
 			stopMeasuring();
+			assertEquals(TEST_COUNT, viewer.getTree().getItemCount());
 		}
 
-		commitMeasurements();
-		assertPerformance();
+		reportTimings();
 	}
 
 	/**
@@ -110,11 +110,11 @@ public class TreeAddTest extends TreeTest {
 			}
 
 			stopMeasuring();
+			assertEquals(batchArray.length * increment, viewer.getTree().getItemCount());
 
 		}, MIN_ITERATIONS, ITERATIONS, JFacePerformanceSuite.MAX_TIME);
 
-		commitMeasurements();
-		assertPerformance();
+		reportTimings();
 
 	}
 
@@ -150,9 +150,6 @@ public class TreeAddTest extends TreeTest {
 	 */
 	@Test
 	public void testAddThousandPreSort() throws CoreException {
-		tagAsGlobalSummary("JFace - Add 2000 items in 2 blocks to TreeViewer",
-				Dimension.ELAPSED_PROCESS);
-
 		doTestAdd(1000, 2000, true);
 	}
 

--- a/tests/org.eclipse.ui.tests.performance/src/org/eclipse/jface/tests/performance/TreeViewerExpansionTest.java
+++ b/tests/org.eclipse.ui.tests.performance/src/org/eclipse/jface/tests/performance/TreeViewerExpansionTest.java
@@ -1,0 +1,253 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Vogella GmbH and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Lars Vogel <Lars.Vogel@vogella.com> - initial API and implementation
+ *******************************************************************************/
+
+package org.eclipse.jface.tests.performance;
+
+import static org.eclipse.ui.tests.harness.util.UITestUtil.processEvents;
+import static org.eclipse.ui.tests.performance.UIPerformanceTestUtil.exercise;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicLong;
+
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.jface.viewers.IElementComparer;
+import org.eclipse.jface.viewers.ILabelProvider;
+import org.eclipse.jface.viewers.ITreeContentProvider;
+import org.eclipse.jface.viewers.LabelProvider;
+import org.eclipse.jface.viewers.StructuredViewer;
+import org.eclipse.jface.viewers.TreePath;
+import org.eclipse.jface.viewers.TreeViewer;
+import org.eclipse.swt.widgets.Shell;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Measures restoring the expansion state of a tree whose elements have a
+ * recursive {@link Object#hashCode()}, the shape used by content models such as
+ * the LSP document symbols.
+ * <p>
+ * A viewer restores expansion by looking every visible item up in a hash table
+ * keyed by {@link TreePath}, and a tree path hashes all of its segments. An
+ * element that hashes its whole subtree therefore makes each lookup cost the
+ * size of the subtrees along its path, so the reported hash invocation count
+ * grows much faster than the number of elements.
+ */
+public class TreeViewerExpansionTest extends ViewerTest {
+
+	/** Children per level, from the top level down. */
+	private static final int[] BRANCHING = { 12, 12, 12 };
+
+	private TreeViewer treeViewer;
+
+	private DeepHashElement root;
+
+	private boolean useComparer;
+
+	/**
+	 * Element with a recursive hash, modelled after the generated
+	 * {@code hashCode}/{@code equals} of an LSP {@code DocumentSymbol}, which fold
+	 * in the child list.
+	 */
+	static final class DeepHashElement {
+
+		/**
+		 * Counts every visit, the recursive ones included, so it measures the total
+		 * work and not just the number of top level calls.
+		 */
+		static final AtomicLong hashVisits = new AtomicLong();
+
+		final String name;
+
+		final DeepHashElement parent;
+
+		final List<DeepHashElement> children = new ArrayList<>();
+
+		DeepHashElement(String name, DeepHashElement parent) {
+			this.name = name;
+			this.parent = parent;
+		}
+
+		@Override
+		public int hashCode() {
+			hashVisits.incrementAndGet();
+			return Objects.hash(name, children);
+		}
+
+		@Override
+		public boolean equals(Object obj) {
+			if (this == obj) {
+				return true;
+			}
+			if (!(obj instanceof DeepHashElement other)) {
+				return false;
+			}
+			return name.equals(other.name) && children.equals(other.children);
+		}
+
+		int size() {
+			int size = 1;
+			for (DeepHashElement child : children) {
+				size += child.size();
+			}
+			return size;
+		}
+	}
+
+	/**
+	 * Comparer that replaces the recursive hash by a cheap key. The generated name
+	 * is unique per element, which is what the viewer requires of elements that
+	 * share a parent.
+	 */
+	private static final IElementComparer CHEAP_COMPARER = new IElementComparer() {
+
+		@Override
+		public boolean equals(Object a, Object b) {
+			if (a instanceof DeepHashElement first && b instanceof DeepHashElement second) {
+				return first.name.equals(second.name);
+			}
+			return Objects.equals(a, b);
+		}
+
+		@Override
+		public int hashCode(Object element) {
+			if (element instanceof DeepHashElement symbol) {
+				return symbol.name.hashCode();
+			}
+			return element.hashCode();
+		}
+	};
+
+	@Override
+	protected StructuredViewer createViewer(Shell shell) {
+		treeViewer = new TreeViewer(shell);
+		if (useComparer) {
+			treeViewer.setComparer(CHEAP_COMPARER);
+		}
+		treeViewer.setContentProvider(new ITreeContentProvider() {
+
+			@Override
+			public Object[] getElements(Object inputElement) {
+				return getChildren(inputElement);
+			}
+
+			@Override
+			public Object[] getChildren(Object parentElement) {
+				return ((DeepHashElement) parentElement).children.toArray();
+			}
+
+			@Override
+			public Object getParent(Object element) {
+				return ((DeepHashElement) element).parent;
+			}
+
+			@Override
+			public boolean hasChildren(Object element) {
+				return !((DeepHashElement) element).children.isEmpty();
+			}
+		});
+		treeViewer.setLabelProvider(getLabelProvider());
+		return treeViewer;
+	}
+
+	@Override
+	public ILabelProvider getLabelProvider() {
+		return new LabelProvider() {
+			@Override
+			public String getText(Object element) {
+				return ((DeepHashElement) element).name;
+			}
+		};
+	}
+
+	@Override
+	protected Object getInitialInput() {
+		root = new DeepHashElement("root", null);
+		createChildren(root, 0);
+		return root;
+	}
+
+	private static void createChildren(DeepHashElement parent, int level) {
+		if (level >= BRANCHING.length) {
+			return;
+		}
+		for (int i = 0; i < BRANCHING[level]; i++) {
+			DeepHashElement child = new DeepHashElement(parent.name + "." + i, parent);
+			parent.children.add(child);
+			createChildren(child, level + 1);
+		}
+	}
+
+	/**
+	 * Restores the expansion state of a fully expanded tree, the operation a
+	 * content provider performs after every refresh to keep the tree from
+	 * collapsing under the user.
+	 */
+	@Test
+	public void testRestoreExpansion() throws CoreException {
+		measureRestoreExpansion();
+	}
+
+	/**
+	 * The same measurement with an {@link IElementComparer} that keys the elements
+	 * by a cheap value, which is how a client avoids the recursive hash.
+	 */
+	@Test
+	public void testRestoreExpansionWithComparer() throws CoreException {
+		useComparer = true;
+		measureRestoreExpansion();
+	}
+
+	private void measureRestoreExpansion() throws CoreException {
+		openBrowser();
+		treeViewer.expandAll();
+		processEvents();
+
+		TreePath[] expanded = treeViewer.getExpandedTreePaths();
+		assertTrue(expanded.length > 0, "The tree was not expanded");
+
+		// The first restore pays for creating the tree items and for JIT warm up.
+		treeViewer.collapseAll();
+		processEvents();
+		treeViewer.setExpandedTreePaths(expanded);
+		processEvents();
+
+		AtomicLong visits = new AtomicLong();
+		exercise(() -> {
+			treeViewer.collapseAll();
+			processEvents();
+
+			DeepHashElement.hashVisits.set(0);
+			startMeasuring();
+			treeViewer.setExpandedTreePaths(expanded);
+			stopMeasuring();
+			visits.set(DeepHashElement.hashVisits.get());
+
+			processEvents();
+			assertEquals(expanded.length, treeViewer.getExpandedTreePaths().length,
+					"The expansion state was not restored");
+		}, MIN_ITERATIONS, ITERATIONS, JFacePerformanceSuite.MAX_TIME);
+
+		int elements = root.size() - 1;
+		reportTimings("restore " + expanded.length + " of " + elements + " elements"
+				+ (useComparer ? " (comparer)" : ""));
+		System.out.printf(Locale.ROOT, "%-48s %d recursive hash visits for %d elements (%.1f per element)%n",
+				getClass().getSimpleName() + (useComparer ? " with comparer" : " without comparer"), visits.get(),
+				elements, visits.get() / (double) elements);
+	}
+
+}

--- a/tests/org.eclipse.ui.tests.performance/src/org/eclipse/jface/tests/performance/TreeViewerRefreshTest.java
+++ b/tests/org.eclipse.ui.tests.performance/src/org/eclipse/jface/tests/performance/TreeViewerRefreshTest.java
@@ -15,11 +15,12 @@
 package org.eclipse.jface.tests.performance;
 
 import static org.eclipse.ui.tests.harness.util.UITestUtil.processEvents;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.eclipse.jface.viewers.StructuredViewer;
 import org.eclipse.jface.viewers.TreeViewer;
 import org.eclipse.swt.widgets.Shell;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 
 /**
@@ -52,10 +53,10 @@ public class TreeViewerRefreshTest extends ViewerTest {
 			viewer.refresh();
 			processEvents();
 			stopMeasuring();
+			assertEquals(RefreshTestContentProvider.ELEMENT_COUNT, viewer.getTree().getItemCount());
 		}
 
-		commitMeasurements();
-		assertPerformance();
+		reportTimings();
 	}
 
 

--- a/tests/org.eclipse.ui.tests.performance/src/org/eclipse/jface/tests/performance/ViewerTest.java
+++ b/tests/org.eclipse.ui.tests.performance/src/org/eclipse/jface/tests/performance/ViewerTest.java
@@ -14,6 +14,9 @@
 
 package org.eclipse.jface.tests.performance;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.eclipse.jface.util.Util;
 import org.eclipse.jface.viewers.ILabelProvider;
 import org.eclipse.jface.viewers.LabelProvider;
@@ -21,24 +24,18 @@ import org.eclipse.jface.viewers.StructuredViewer;
 import org.eclipse.swt.layout.FillLayout;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Shell;
-import org.eclipse.test.performance.Dimension;
-import org.eclipse.test.performance.Performance;
-import org.eclipse.test.performance.PerformanceMeter;
 import org.eclipse.ui.tests.harness.util.CloseTestWindowsExtension;
-import org.eclipse.ui.tests.performance.UIPerformanceTestRule;
+import org.eclipse.ui.tests.performance.UIPerformanceTestUtil;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.extension.AfterEachCallback;
-import org.junit.jupiter.api.extension.BeforeEachCallback;
-import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 /**
- * The LinearViewerTest is a test that tests viewers.
+ * Base class for the JFace viewer performance tests. Times the measured
+ * sections and reports their distribution once the test is done.
  */
-public abstract class ViewerTest implements BeforeEachCallback, AfterEachCallback {
-
-	@RegisterExtension
-	static UIPerformanceTestRule uiPerformanceTestRule = new UIPerformanceTestRule();
+public abstract class ViewerTest {
 
 	@RegisterExtension
 	CloseTestWindowsExtension closeTestWindows = new CloseTestWindowsExtension();
@@ -48,45 +45,37 @@ public abstract class ViewerTest implements BeforeEachCallback, AfterEachCallbac
 	public static int ITERATIONS = 100;
 	public static int MIN_ITERATIONS = 20;
 
-	private PerformanceMeter performanceMeter;
+	private final List<Long> timings = new ArrayList<>();
 
-	@Override
-	public void beforeEach(ExtensionContext context) throws Exception {
-		Performance perf = Performance.getDefault();
-		String scenarioId = this.getClass().getName() + "." + context.getDisplayName();
-		performanceMeter = perf.createPerformanceMeter(scenarioId);
-	}
+	private String scenario;
 
-	@Override
-	public void afterEach(ExtensionContext context) throws Exception {
-		if (performanceMeter != null) {
-			performanceMeter.dispose();
-			performanceMeter = null;
-		}
+	private long measuringSince;
+
+	@BeforeEach
+	public void startScenario(TestInfo testInfo) {
+		scenario = getClass().getSimpleName() + "." + testInfo.getDisplayName();
+		timings.clear();
 	}
 
 	protected void startMeasuring() {
-		if (performanceMeter != null) {
-			performanceMeter.start();
-		}
+		measuringSince = System.nanoTime();
 	}
 
 	protected void stopMeasuring() {
-		if (performanceMeter != null) {
-			performanceMeter.stop();
-		}
+		timings.add(System.nanoTime() - measuringSince);
 	}
 
-	protected void commitMeasurements() {
-		if (performanceMeter != null) {
-			performanceMeter.commit();
-		}
+	/**
+	 * Reports what has been measured so far under the given suffix and drops the
+	 * measurements, so that a test with several phases can report them separately.
+	 */
+	protected void reportTimings(String suffix) {
+		UIPerformanceTestUtil.reportTimings(suffix.isEmpty() ? scenario : scenario + " " + suffix, timings);
+		timings.clear();
 	}
 
-	protected void assertPerformance() {
-		if (performanceMeter != null) {
-			Performance.getDefault().assertPerformance(performanceMeter);
-		}
+	protected void reportTimings() {
+		reportTimings("");
 	}
 
 	protected void openBrowser() {
@@ -101,7 +90,6 @@ public abstract class ViewerTest implements BeforeEachCallback, AfterEachCallbac
 		viewer.setUseHashlookup(true);
 		viewer.setInput(getInitialInput());
 		browserShell.open();
-		// processEvents();
 	}
 
 	/**
@@ -153,14 +141,6 @@ public abstract class ViewerTest implements BeforeEachCallback, AfterEachCallbac
 		if(Util.isWindows())
 			return ITERATIONS / 5;
 		return ITERATIONS;
-	}
-
-	public void tagAsSummary(String shortName, Dimension dimension) {
-		Performance.getDefault().tagAsSummary(performanceMeter, shortName, new Dimension[] { dimension });
-	}
-
-	public void tagAsGlobalSummary(String shortName, Dimension dimension) {
-		Performance.getDefault().tagAsGlobalSummary(performanceMeter, shortName, new Dimension[] { dimension });
 	}
 
 }


### PR DESCRIPTION
Applies the treatment the editor performance tests already received to the tests under `org.eclipse.jface.tests.performance`: they drop the performance meter, whose measurements went nowhere because the performance database has not been configured for years, and time the individual operations instead. Every test now asserts that the operation it measures actually did something, so a run can fail rather than silently report nothing, and a manual run prints min, median, 90th percentile and maximum per scenario.

The tests are also converted to JUnit 5 throughout, which they only partly were: `ViewerTest` declared JUnit 5 lifecycle callbacks that were never invoked for its JUnit 4 subclasses, so its measurement setup did not run at all. Dropping `UIPerformanceTestRule` from the tests that never touch the workbench spares them creating and building a 300 file project.

New in this change is `TreeViewerExpansionTest`, which covers restoring the expansion state of a tree whose elements have a recursive `hashCode`, the shape of an LSP document symbol. Restoring expansion looks every item up in a table keyed by `TreePath`, and `TreePath` hashes all of its segments, so such an element gets hashed once per descendant on every lookup. It reports 361056 recursive hash visits for 1884 elements, roughly 192 per element, while the same measurement with an `IElementComparer` supplying a cheap key reports none. That is the cost a large outline pays on every refresh, and it was not covered by any existing test.

The bundle stays excluded from the default test run, so verification times are unaffected.