### PR TITLE
Force qualifier update for split packages of o.e.text and o.e.jface.text

### DIFF
--- a/bundles/org.eclipse.text/forceQualifierUpdate.txt
+++ b/bundles/org.eclipse.text/forceQualifierUpdate.txt
@@ -7,3 +7,4 @@ https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/17
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/2044
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/2595
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/3190
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/3927


### PR DESCRIPTION
https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/3927

This is needed after the changes from https://github.com/eclipse-platform/eclipse.platform.ui/pull/4238