### PR TITLE
Restore auto-building when smart import fails

### DIFF
--- a/bundles/org.eclipse.ui.ide/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.ui.ide/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Plugin.name
 Bundle-SymbolicName: org.eclipse.ui.ide; singleton:=true
-Bundle-Version: 3.23.200.qualifier
+Bundle-Version: 3.23.300.qualifier
 Bundle-Activator: org.eclipse.ui.internal.ide.IDEWorkbenchPlugin
 Bundle-ActivationPolicy: lazy
 Bundle-Vendor: %Plugin.providerName

--- a/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/wizards/datatransfer/SmartImportJob.java
+++ b/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/wizards/datatransfer/SmartImportJob.java
@@ -168,13 +168,11 @@ public class SmartImportJob extends Job {
 
 	@Override
 	public IStatus run(IProgressMonitor monitor) {
+		IWorkspace workspace = ResourcesPlugin.getWorkspace();
+		boolean isAutoBuilding = workspace.isAutoBuilding();
 		try {
-			IWorkspace workspace = ResourcesPlugin.getWorkspace();
-			IWorkspaceDescription description = workspace.getDescription();
-			boolean isAutoBuilding = workspace.isAutoBuilding();
 			if (isAutoBuilding) {
-				description.setAutoBuilding(false);
-				workspace.setDescription(description);
+				setAutoBuilding(workspace, false);
 			}
 
 			if (directoriesToImport != null) {
@@ -270,19 +268,30 @@ public class SmartImportJob extends Job {
 					try {
 						project.close(monitor);
 					} catch (CoreException e) {
-						listener.errorHappened(project.getLocation(), e);
+						if (listener != null) {
+							listener.errorHappened(project.getLocation(), e);
+						}
 					}
 				});
 			}
-
-			if (isAutoBuilding) {
-				description.setAutoBuilding(true);
-				workspace.setDescription(description);
-			}
 		} catch (Exception ex) {
 			return new Status(IStatus.ERROR, IDEWorkbenchPlugin.IDE_WORKBENCH, ex.getMessage(), ex);
+		} finally {
+			if (isAutoBuilding) {
+				try {
+					setAutoBuilding(workspace, true);
+				} catch (CoreException ex) {
+					IDEWorkbenchPlugin.log("Could not restore auto-building after import", ex); //$NON-NLS-1$
+				}
+			}
 		}
 		return Status.OK_STATUS;
+	}
+
+	private static void setAutoBuilding(IWorkspace workspace, boolean autoBuilding) throws CoreException {
+		IWorkspaceDescription description = workspace.getDescription();
+		description.setAutoBuilding(autoBuilding);
+		workspace.setDescription(description);
 	}
 
 	protected boolean rootProjectWorthBeingRemoved() {

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/datatransfer/SmartImportTests.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/datatransfer/SmartImportTests.java
@@ -572,4 +572,20 @@ public class SmartImportTests {
 			org.eclipse.core.tests.harness.FileSystemHelper.clear(tempDir.toFile());
 		}
 	}
+
+	@Test
+	public void testAutoBuildingRestoredAfterFailedImport() throws Exception {
+		assertTrue("Test expects auto-building to be enabled", ResourcesPlugin.getWorkspace().isAutoBuilding());
+		// a regular file as import root makes the project creation fail
+		java.nio.file.Path notADirectory = Files.createTempFile("smartImportFailure", ".txt");
+		try {
+			SmartImportJob job = new SmartImportJob(notADirectory.toFile(), Collections.emptySet(), true, true);
+			IStatus status = job.run(new NullProgressMonitor());
+			assertEquals("Import was expected to fail", IStatus.ERROR, status.getSeverity());
+			assertTrue("Auto-building must be restored after a failed import",
+					ResourcesPlugin.getWorkspace().isAutoBuilding());
+		} finally {
+			Files.deleteIfExists(notADirectory);
+		}
+	}
 }


### PR DESCRIPTION
The smart import job disables workspace auto-building while it runs and re-enables it as the last statement of its try block. If a project configurator throws or the import is cancelled, that statement is skipped and the workspace is left with auto-building permanently off, which is confusing because nothing points back at the failed import.

Restoring the setting in a finally block fixes this, and the optional import listener is now null checked when projects are closed after the import. The new test asserts both that the failing import reports an error status and that auto-building survives it.