### PR TITLE
Avoid the full ancestor chain walk when removing elements from the Project Explorer

### DIFF
--- a/bundles/org.eclipse.ui.navigator/src/org/eclipse/ui/internal/navigator/NavigatorContentServiceContentProvider.java
+++ b/bundles/org.eclipse.ui.navigator/src/org/eclipse/ui/internal/navigator/NavigatorContentServiceContentProvider.java
@@ -286,42 +286,14 @@ public class NavigatorContentServiceContentProvider implements ITreeContentProvi
 	}
 
 	@Override
-	public Object getParent(final Object anElement) {
-		final Set extensions = contentService.findContentExtensionsWithPossibleChild(anElement);
-		final Object[] parent = new Object[1];
-
-		for (Iterator itr = extensions.iterator(); itr.hasNext();) {
-			final NavigatorContentExtension foundExtension = (NavigatorContentExtension) itr.next();
-
-			SafeRunner.run(new NavigatorSafeRunnable() {
-				NavigatorContentExtension[] overridingExtensions;
-
-				@Override
-				public void run() throws Exception {
-					if (!isOverridingExtensionInSet(foundExtension.getDescriptor(), extensions)) {
-						parent[0] = foundExtension.internalGetContentProvider()
-								.getParent(anElement);
-						overridingExtensions = foundExtension
-								.getOverridingExtensionsForPossibleChild(anElement);
-						if (overridingExtensions.length > 0) {
-							parent[0] = pipelineParent(anElement, overridingExtensions, parent);
-						}
-					}
-				}
-
-				@Override
-				public void handleException(Throwable e) {
-					NavigatorPlugin.logError(0, NLS.bind(
-							CommonNavigatorMessages.Exception_Invoking_Extension, new Object[] {
-									foundExtension.getDescriptor().getId(), anElement }), e);
-				}
-			});
-
-			if (parent[0] != null) {
-				return parent[0];
-			}
+	public Object getParent(Object anElement) {
+		Set parents = findParents(anElement);
+		if (parents.isEmpty()) {
+			return null;
 		}
-		return parent[0];
+		Object parent = parents.iterator().next();
+		// an element answering itself as parent is a cycle; getParents() logs it and answers the root
+		return parent.equals(anElement) ? null : parent;
 	}
 
 	@Override
@@ -336,43 +308,6 @@ public class NavigatorContentServiceContentProvider implements ITreeContentProvi
 		return (TreePath[]) paths.toArray(new TreePath[paths.size()]);
 
 	}
-	/**
-	 * Query each of <code>theOverridingExtensions</code> for elements, and then
-	 * pipe them through the Pipeline content provider.
-	 *
-	 * @param anInputElement
-	 *            The input element in the tree
-	 * @param theOverridingExtensions
-	 *            The set of overriding extensions that should participate in
-	 *            the pipeline chain
-	 * @param theCurrentParent
-	 *            The current elements to return to the viewer (should be
-	 *            modifiable)
-	 * @return The set of elements to return to the viewer
-	 */
-	private Object pipelineParent(Object anInputElement, NavigatorContentExtension[] theOverridingExtensions,
-			Object theCurrentParent) {
-		IPipelinedTreeContentProvider pipelinedContentProvider;
-		NavigatorContentExtension[] overridingExtensions;
-		Object aSuggestedParent = null;
-		for (NavigatorContentExtension theOverridingExtension : theOverridingExtensions) {
-
-			if (theOverridingExtension.internalGetContentProvider().isPipelined()) {
-				pipelinedContentProvider = theOverridingExtension
-						.internalGetContentProvider();
-
-				aSuggestedParent = pipelinedContentProvider.getPipelinedParent(anInputElement, aSuggestedParent);
-
-				overridingExtensions = theOverridingExtension
-						.getOverridingExtensionsForTriggerPoint(anInputElement);
-				if (overridingExtensions.length > 0) {
-					aSuggestedParent = pipelineParent(anInputElement, overridingExtensions, aSuggestedParent);
-				}
-			}
-		}
-		return aSuggestedParent != null ? aSuggestedParent : theCurrentParent;
-	}
-
 	/**
 	 * Calculate hasChildren for both an element or a path.
 	 *

--- a/bundles/org.eclipse.ui.navigator/src/org/eclipse/ui/navigator/CommonViewer.java
+++ b/bundles/org.eclipse.ui.navigator/src/org/eclipse/ui/navigator/CommonViewer.java
@@ -24,6 +24,7 @@ import org.eclipse.jface.viewers.ISelection;
 import org.eclipse.jface.viewers.IStructuredSelection;
 import org.eclipse.jface.viewers.LabelProviderChangedEvent;
 import org.eclipse.jface.viewers.StructuredSelection;
+import org.eclipse.jface.viewers.TreePath;
 import org.eclipse.jface.viewers.TreeViewer;
 import org.eclipse.jface.viewers.ViewerComparator;
 import org.eclipse.jface.viewers.ViewerSorter;
@@ -39,6 +40,7 @@ import org.eclipse.swt.widgets.Widget;
 import org.eclipse.ui.internal.navigator.CommonNavigatorFrameSource;
 import org.eclipse.ui.internal.navigator.ContributorTrackingSet;
 import org.eclipse.ui.internal.navigator.NavigatorContentService;
+import org.eclipse.ui.internal.navigator.NavigatorContentServiceContentProvider;
 import org.eclipse.ui.internal.navigator.NavigatorDecoratingLabelProvider;
 import org.eclipse.ui.internal.navigator.NavigatorPipelineService;
 import org.eclipse.ui.internal.navigator.dnd.NavigatorDnDService;
@@ -240,6 +242,25 @@ public class CommonViewer extends TreeViewer {
 					.getSource(), others.toArray());
 		}
 		super.handleLabelProviderChanged(event);
+	}
+
+	@Override
+	protected Object getParentElement(Object elementOrTreePath) {
+		if (!(elementOrTreePath instanceof TreePath)
+				&& getContentProvider() instanceof NavigatorContentServiceContentProvider provider) {
+			// getParents() compiles the whole ancestor chain although only the immediate parent is used
+			boolean oldBusy = isBusy();
+			setBusy(true);
+			try {
+				Object parent = provider.getParent(elementOrTreePath);
+				if (parent != null) {
+					return parent;
+				}
+			} finally {
+				setBusy(oldBusy);
+			}
+		}
+		return super.getParentElement(elementOrTreePath);
 	}
 
 	@Override

--- a/tests/org.eclipse.ui.tests.navigator/src/org/eclipse/ui/tests/navigator/PipelineTest.java
+++ b/tests/org.eclipse.ui.tests.navigator/src/org/eclipse/ui/tests/navigator/PipelineTest.java
@@ -19,6 +19,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
+import java.io.ByteArrayInputStream;
+
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IFolder;
 import org.eclipse.core.resources.IProject;
@@ -145,6 +147,32 @@ public class PipelineTest extends NavigatorTestBase {
 
 		assertEquals(_project, contentProvider.getParent(file));
 		assertEquals(_project, TestContentProviderPipelined._lastSuggestedParent);
+	}
+
+	@Test
+	public void testRemoveOfUnexpandedElementAsksForParentOnce() throws Exception {
+		_contentService.bindExtensions(new String[] { COMMON_NAVIGATOR_RESOURCE_EXT, TEST_CONTENT_RESOURCE_OVERRIDE },
+				false);
+		_contentService.getActivationService()
+				.activateExtensions(new String[] { COMMON_NAVIGATOR_RESOURCE_EXT, TEST_CONTENT_RESOURCE_OVERRIDE }, true);
+
+		IFolder folder = _project.getFolder("a"); //$NON-NLS-1$
+		folder.create(true, true, null);
+		for (String name : new String[] { "b", "c", "d" }) { //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+			folder = folder.getFolder(name);
+			folder.create(true, true, null);
+		}
+		IFile file = folder.getFile("f.txt"); //$NON-NLS-1$
+		file.create(new ByteArrayInputStream(new byte[0]), true, null);
+
+		refreshViewer();
+
+		// the project is collapsed, so the file has no item and the viewer has to ask for its parent
+		TestContentProviderPipelined._pipelinedParentCalls = 0;
+		_viewer.remove(file);
+
+		assertEquals(1, TestContentProviderPipelined._pipelinedParentCalls,
+				"only the immediate parent should be computed, not the whole ancestor chain"); //$NON-NLS-1$
 	}
 
 	// Bug 299661 hasChildren() does not handle overrides correctly

--- a/tests/org.eclipse.ui.tests.navigator/src/org/eclipse/ui/tests/navigator/PipelineTest.java
+++ b/tests/org.eclipse.ui.tests.navigator/src/org/eclipse/ui/tests/navigator/PipelineTest.java
@@ -25,6 +25,7 @@ import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.IAdaptable;
 import org.eclipse.core.runtime.IPath;
+import org.eclipse.jface.viewers.ITreeContentProvider;
 import org.eclipse.jface.viewers.StructuredSelection;
 import org.eclipse.swt.widgets.TreeItem;
 import org.eclipse.ui.tests.navigator.extension.TestContentProviderNoChildren;
@@ -128,6 +129,22 @@ public class PipelineTest extends NavigatorTestBase {
 		// This will throw, have to look in the log to see the message
 		_viewer.add(_project, new Object[] { f });
 
+	}
+
+	@Test
+	public void testGetParentWithPipelinedOverride() throws Exception {
+		_contentService.bindExtensions(new String[] { COMMON_NAVIGATOR_RESOURCE_EXT, TEST_CONTENT_RESOURCE_OVERRIDE },
+				false);
+		_contentService.getActivationService()
+				.activateExtensions(new String[] { COMMON_NAVIGATOR_RESOURCE_EXT, TEST_CONTENT_RESOURCE_OVERRIDE }, true);
+
+		refreshViewer();
+
+		ITreeContentProvider contentProvider = (ITreeContentProvider) _viewer.getContentProvider();
+		IFile file = _project.getFile(".project"); //$NON-NLS-1$
+
+		assertEquals(_project, contentProvider.getParent(file));
+		assertEquals(_project, TestContentProviderPipelined._lastSuggestedParent);
 	}
 
 	// Bug 299661 hasChildren() does not handle overrides correctly

--- a/tests/org.eclipse.ui.tests.navigator/src/org/eclipse/ui/tests/navigator/extension/TestContentProviderPipelined.java
+++ b/tests/org.eclipse.ui.tests.navigator/src/org/eclipse/ui/tests/navigator/extension/TestContentProviderPipelined.java
@@ -26,9 +26,11 @@ public class TestContentProviderPipelined extends ResourceExtensionContentProvid
 		IPipelinedTreeContentProvider2 {
 
 	public static boolean _throw;
+	public static Object _lastSuggestedParent;
 
 	public static void resetTest() {
 		_throw = false;
+		_lastSuggestedParent = null;
 	}
 
 	public TestContentProviderPipelined() {
@@ -61,6 +63,7 @@ public class TestContentProviderPipelined extends ResourceExtensionContentProvid
 	public Object getPipelinedParent(Object anObject, Object aSuggestedParent) {
 		if (_throw)
 			throw new RuntimeException("did not work out");
+		_lastSuggestedParent = aSuggestedParent;
 		return aSuggestedParent;
 	}
 

--- a/tests/org.eclipse.ui.tests.navigator/src/org/eclipse/ui/tests/navigator/extension/TestContentProviderPipelined.java
+++ b/tests/org.eclipse.ui.tests.navigator/src/org/eclipse/ui/tests/navigator/extension/TestContentProviderPipelined.java
@@ -27,10 +27,12 @@ public class TestContentProviderPipelined extends ResourceExtensionContentProvid
 
 	public static boolean _throw;
 	public static Object _lastSuggestedParent;
+	public static int _pipelinedParentCalls;
 
 	public static void resetTest() {
 		_throw = false;
 		_lastSuggestedParent = null;
+		_pipelinedParentCalls = 0;
 	}
 
 	public TestContentProviderPipelined() {
@@ -64,6 +66,7 @@ public class TestContentProviderPipelined extends ResourceExtensionContentProvid
 		if (_throw)
 			throw new RuntimeException("did not work out");
 		_lastSuggestedParent = aSuggestedParent;
+		_pipelinedParentCalls++;
 		return aSuggestedParent;
 	}
 


### PR DESCRIPTION
Deleting many files below a collapsed folder freezes the Project Explorer. AbstractTreeViewer.getParentElement prefers ITreePathContentProvider, so the Common Navigator answers through getParents, which compiles complete paths up to the root although only the last segment of the first path is ever used. AbstractTreeViewer.internalRemove takes that branch for every element without a widget, and with JDT enabled each ancestor level runs JavaCore.create against the workspace tree. Measured in a running IDE, deleting 2000 files ten folders deep froze the UI for 19 s; with this change the same removal is not measurable and no freeze is logged.

CommonViewer now asks getParent first and falls back to the inherited behaviour when it returns null, which confines the change to the Common Navigator. For that to be correct, getParent had to honour pipelined overrides: it resolved overriding extensions up front and called the override's plain getParent, so getPipelinedParent never ran and the pipelining code in getParent was unreachable. It now reuses findParents, the per-level routine getParents already uses, so both lookups agree. Two tests pin this: one that the override's getPipelinedParent is consulted, one that removing an unexpanded element computes exactly one parent.
