### PR TITLE
Allow org.eclipse.ui.monitoring to run in pure E4 applications

### DIFF
--- a/bundles/org.eclipse.ui.monitoring/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.ui.monitoring/META-INF/MANIFEST.MF
@@ -11,8 +11,8 @@ Export-Package: org.eclipse.ui.internal.monitoring;x-internal:=true,
  org.eclipse.ui.internal.monitoring.preferences;x-internal:=true,
  org.eclipse.ui.monitoring;x-internal:=true
 Require-Bundle: org.eclipse.core.runtime;bundle-version="[3.29.0,4.0.0)",
- org.eclipse.jface;bundle-version="[3.39.0,4.0.0)",
- org.eclipse.ui;bundle-version="[3.106.0,4.0.0)",
+ org.eclipse.jface;bundle-version="[3.41.0,4.0.0)",
+ org.eclipse.ui;bundle-version="[3.106.0,4.0.0)";resolution:=optional,
  org.eclipse.e4.ui.workbench;bundle-version="[1.15.300,2.0.0)"
 Service-Component: OSGI-INF/org.eclipse.ui.internal.monitoring.MonitoringStartup.xml
 Automatic-Module-Name: org.eclipse.ui.monitoring

--- a/bundles/org.eclipse.ui.monitoring/src/org/eclipse/ui/internal/monitoring/MonitoringPlugin.java
+++ b/bundles/org.eclipse.ui.monitoring/src/org/eclipse/ui/internal/monitoring/MonitoringPlugin.java
@@ -20,7 +20,7 @@ import org.eclipse.core.runtime.ILog;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.jface.preference.IPreferenceStore;
-import org.eclipse.ui.PlatformUI;
+import org.eclipse.jface.preference.ScopedPreferenceStore;
 import org.eclipse.ui.monitoring.PreferenceConstants;
 
 /**
@@ -43,7 +43,7 @@ public class MonitoringPlugin {
 
 	public static IPreferenceStore getPreferenceStore() {
 		if (store == null) {
-			store = PlatformUI.createPreferenceStore(MonitoringPlugin.class);
+			store = ScopedPreferenceStore.getInstance(MonitoringPlugin.class);
 		}
 		return store;
 	}

--- a/bundles/org.eclipse.ui.monitoring/src/org/eclipse/ui/internal/monitoring/MonitoringStartup.java
+++ b/bundles/org.eclipse.ui.monitoring/src/org/eclipse/ui/internal/monitoring/MonitoringStartup.java
@@ -20,7 +20,6 @@ import org.eclipse.core.runtime.Platform;
 import org.eclipse.e4.ui.workbench.UIEvents;
 import org.eclipse.jface.preference.IPreferenceStore;
 import org.eclipse.swt.widgets.Display;
-import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.internal.monitoring.preferences.MonitoringPreferenceListener;
 import org.eclipse.ui.monitoring.PreferenceConstants;
 import org.osgi.service.component.annotations.Component;
@@ -65,7 +64,7 @@ public class MonitoringStartup implements EventHandler {
 		}
 
 		final EventLoopMonitorThread thread = temporaryThread;
-		final Display display = PlatformUI.getWorkbench().getDisplay();
+		final Display display = Display.getDefault();
 		// Final setup and start asynchronously on the display thread.
 		display.asyncExec(() -> {
 			// If we're still running when display gets disposed, shutdown the thread.

--- a/bundles/org.eclipse.ui.monitoring/src/org/eclipse/ui/internal/monitoring/preferences/MonitoringPreferenceListener.java
+++ b/bundles/org.eclipse.ui.monitoring/src/org/eclipse/ui/internal/monitoring/preferences/MonitoringPreferenceListener.java
@@ -20,7 +20,6 @@ import org.eclipse.jface.preference.IPreferenceStore;
 import org.eclipse.jface.util.IPropertyChangeListener;
 import org.eclipse.jface.util.PropertyChangeEvent;
 import org.eclipse.swt.widgets.Display;
-import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.internal.monitoring.EventLoopMonitorThread;
 import org.eclipse.ui.internal.monitoring.MonitoringPlugin;
 import org.eclipse.ui.internal.monitoring.MonitoringStartup;
@@ -66,7 +65,7 @@ public class MonitoringPreferenceListener implements IPropertyChangeListener {
 
 			monitorThreadRestartInProgress = true;
 
-			final Display display = PlatformUI.getWorkbench().getDisplay();
+			final Display display = Display.getDefault();
 			// Schedule the event to restart the thread after all preferences have had enough time
 			// to propagate.
 			display.asyncExec(this::refreshMonitoringThread);
@@ -86,7 +85,7 @@ public class MonitoringPreferenceListener implements IPropertyChangeListener {
 			// If thread is null, the newly-defined preferences are invalid.
 			if (thread == null) {
 				MessageDialog.openError(
-						PlatformUI.getWorkbench().getActiveWorkbenchWindow().getShell(),
+						Display.getCurrent().getActiveShell(),
 						Messages.MonitoringPreferenceListener_preference_error_header,
 						Messages.MonitoringPreferenceListener_preference_error);
 				return;


### PR DESCRIPTION
The UI freeze monitoring bundle was tied to the 3.x workbench only by a handful of `PlatformUI` calls. Its startup trigger is already the E4 `UILifeCycle.APP_STARTUP_COMPLETE` event, which a plain E4 application fires as well, so very little stood in the way of using it outside the IDE.

Since #4270 moved `ScopedPreferenceStore` to JFace, the bundle can create its preference store directly instead of going through `PlatformUI.createPreferenceStore`, and the monitor thread uses the default Display rather than the workbench display. The 3.x preference page is the only remaining consumer of `org.eclipse.ui`, which is therefore an optional requirement now.

The upside is that any E4 RCP application can add this bundle and get UI freeze reporting in its error log without dragging in the compatibility layer. In the IDE nothing changes and the existing tests still pass.
