### PR TITLE
Centralize FontRegistry font-record caching in createFont

### DIFF
--- a/bundles/org.eclipse.jface/src/org/eclipse/jface/resource/FontRegistry.java
+++ b/bundles/org.eclipse.jface/src/org/eclipse/jface/resource/FontRegistry.java
@@ -505,7 +505,9 @@ public class FontRegistry extends ResourceRegistry {
 		//Do not fire the update from creation as it is not a property change
 		put(symbolicName, validData, false);
 		Font newFont = new Font(display, validData);
-		return new FontRecord(newFont, validData);
+		FontRecord newRecord = new FontRecord(newFont, validData);
+		stringToFontRecord.put(symbolicName, newRecord);
+		return newRecord;
 	}
 
 	private Display getDisplayAndHookForDisposal() {
@@ -582,7 +584,6 @@ public class FontRegistry extends ResourceRegistry {
 			record = createFont(JFaceResources.DEFAULT_FONT, defaultFont.getFontData());
 			defaultFont.dispose();
 		}
-		stringToFontRecord.put(JFaceResources.DEFAULT_FONT, record);
 		return record;
 	}
 
@@ -698,13 +699,10 @@ public class FontRegistry extends ResourceRegistry {
 			if (Display.getCurrent() == null) { // log error but don't throw an exception to preserve existing functionality
 				String msg = "Unable to create font \"" + symbolicName + "\" in a non-UI thread. Using default font instead."; //$NON-NLS-1$ //$NON-NLS-2$
 				Policy.logException(new SWTException(msg));
-				return fontRecord; // don't add it to the cache; if later asked from UI thread, a proper font will be created
 			}
 		}
 
-		stringToFontRecord.put(symbolicName, fontRecord);
 		return fontRecord;
-
 	}
 
 	@Override

--- a/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/resources/FontRegistryTest.java
+++ b/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/resources/FontRegistryTest.java
@@ -141,6 +141,22 @@ public class FontRegistryTest {
 	}
 
 	@Test
+	public void put_onNameOnlyResolvedViaDefaultFallback_doesNotStaleDefaultFontsBoldAndItalic() {
+		FontRegistry fontRegistry = new FontRegistry();
+		Font defaultBold = fontRegistry.getBold(JFaceResources.DEFAULT_FONT);
+		Font defaultItalic = fontRegistry.getItalic(JFaceResources.DEFAULT_FONT);
+
+		// never explicitly registered, so this only ever resolves via the default-font fallback
+		fontRegistry.get("neverRegisteredName");
+
+		// registering data for that name must not disturb the still-live default font record
+		fontRegistry.put("neverRegisteredName", new FontData[] { new FontData("Arial", 12, SWT.NORMAL) });
+
+		assertSame(defaultBold, fontRegistry.getBold(JFaceResources.DEFAULT_FONT));
+		assertSame(defaultItalic, fontRegistry.getItalic(JFaceResources.DEFAULT_FONT));
+	}
+
+	@Test
 	public void get_fontFromNonUIThreadFallback_doesNotOverwriteDefaultFont() throws Throwable {
 		FontRegistry fontRegistry = new FontRegistry();
 		fontRegistry.put("myfont", new FontData[] { new FontData("Arial", 12, SWT.NORMAL) });


### PR DESCRIPTION
`FontRegistry` caches the mapping from a symbolic font name to its realized `FontRecord` at each call site — in `defaultFontRecord()` and in `getFontRecord()` — instead of in `createFont()`, which is what actually creates the record.

That split is historical: `defaultFontRecord()` got its own cache write in 5bf9496e71 (bug 544026), so that replacing the default font via `put()` is picked up and the record created lazily; `getFontRecord()` kept its own. The result is two places writing the cache and one deliberately skipping it — the non-UI-thread fallback returns early with *"don't add it to the cache; if later asked from UI thread, a proper font will be created"*. That workaround exists because caching at the call site can cache the wrong record.

The general case is not covered, though. A symbolic name that was never registered and only ever resolved through the default-font fallback ends up cached as an alias for the very same `FontRecord` instance as the default font. Registering data for that name later removes only the alias, but still treats the still-live, still-cached default record as replaced and queues its already-realized bold/italic fonts for disposal — while the default font remains in active use under its own name.

Caching in `createFont()` means every symbolic name is cached exactly once, at the single place responsible for creating it. Both the aliasing and the local workaround disappear.

No externally observable change today: with one display-wide cache, disposing any display tears down the whole cache and all stale fonts together, so the aliased default font and its "stale" variants are disposed at the same moment either way. It starts to matter once caching and disposal are scoped per display — the direction of 4a9b6cf08a and 6975bad941 — where a record can be read, replaced and disposed from separate places.

Includes a characterization test pinning that `put()` on a name only ever resolved via the default-font fallback leaves the default font's bold/italic instances untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
