### PR TITLE
Avoid eagerly creating the default font as a side effect in FontRegistry

### DIFF
--- a/bundles/org.eclipse.jface/src/org/eclipse/jface/resource/FontRegistry.java
+++ b/bundles/org.eclipse.jface/src/org/eclipse/jface/resource/FontRegistry.java
@@ -829,7 +829,9 @@ public class FontRegistry extends ResourceRegistry {
 		}
 
 		if (oldFont != null) {
-			oldFont.addAllocatedFontsToStale(defaultFontRecord().getBaseFont());
+			FontRecord defaultRecord = stringToFontRecord.get(JFaceResources.DEFAULT_FONT);
+			Font defaultFont = defaultRecord != null ? defaultRecord.getBaseFont() : null;
+			oldFont.addAllocatedFontsToStale(defaultFont);
 		}
 	}
 

--- a/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/resources/FontRegistryTest.java
+++ b/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/resources/FontRegistryTest.java
@@ -272,6 +272,22 @@ public class FontRegistryTest {
 	}
 
 	@Test
+	public void put_replacingRealizedFont_doesNotRegisterDefaultFontAsSideEffect() {
+		FontRegistry fontRegistry = new FontRegistry();
+		fontRegistry.put("myfont", new FontData[] { new FontData("Arial", 12, SWT.NORMAL) });
+		fontRegistry.get("myfont"); // realize it, so replacing it has fonts to retire
+
+		// retiring those fonts compares them against the default font, which must not
+		// realize and register a default font that nobody has asked for yet
+		fontRegistry.put("myfont", new FontData[] { new FontData("Arial", 18, SWT.NORMAL) });
+
+		assertFalse(fontRegistry.hasValueFor(JFaceResources.DEFAULT_FONT),
+				"replacing an unrelated font must not register default font data as a side effect");
+		assertFalse(fontRegistry.getKeySet().contains(JFaceResources.DEFAULT_FONT),
+				"replacing an unrelated font must not add the default font to the key set");
+	}
+
+	@Test
 	public void hasValueForAndGetKeySet_reflectOnlyRegisteredNames() {
 		FontRegistry fontRegistry = new FontRegistry();
 		assertFalse(fontRegistry.hasValueFor("myfont"));


### PR DESCRIPTION
When `put()` replaces an already-realized font, it obtains the current default font via `defaultFontRecord()` purely to compare it against the replaced font's instances for staleness. But `defaultFontRecord()` does not just look up an already-realized default font — it also creates and caches one if none exists yet.

So replacing an unrelated symbolic name's font allocates a native default-font handle earlier than needed, merely as a side effect of an identity comparison. And because `createFont()` registers the data it used, this is directly observable: `hasValueFor(JFaceResources.DEFAULT_FONT)` flips to `true` and `getKeySet()` starts reporting the default font, purely because some other name was re-`put`.

Look up the already-cached default font record directly instead, tolerating that it may not exist yet — in which case the replaced font's instances are unconditionally treated as stale, exactly as before, since they can never equal a still-unrealized default font.

Includes a regression test asserting that replacing a realized font leaves the default font unregistered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
