### PR TITLE
Make FontRegistry's table of font data thread safe

### DIFF
--- a/bundles/org.eclipse.jface/src/org/eclipse/jface/resource/FontRegistry.java
+++ b/bundles/org.eclipse.jface/src/org/eclipse/jface/resource/FontRegistry.java
@@ -196,7 +196,7 @@ public class FontRegistry extends ResourceRegistry {
 	 * (key type: <code>String</code>,
 	 *  value type: <code>org.eclipse.swt.graphics.FontData[]</code>).
 	 */
-	private final Map<String, FontData[]> stringToFontData = new HashMap<>(7);
+	private final Map<String, FontData[]> stringToFontData = new ConcurrentHashMap<>(7);
 
 	/**
 	 * Collection of Fonts that are now stale to be disposed
@@ -816,14 +816,15 @@ public class FontRegistry extends ResourceRegistry {
 		Assert.isNotNull(symbolicName);
 		Assert.isNotNull(fontData);
 
-		FontData[] existing = stringToFontData.get(symbolicName);
+		// single atomic read-modify-write; replacing an equal mapping with the
+		// given, content-equal one is a no-op for every reader
+		FontData[] existing = stringToFontData.put(symbolicName, fontData);
 		if (Arrays.equals(existing, fontData)) {
 			return;
 		}
 
 		FontRecord oldFont = stringToFontRecord
 				.remove(symbolicName);
-		stringToFontData.put(symbolicName, fontData);
 		if (update) {
 			fireMappingChanged(symbolicName, existing, fontData);
 		}


### PR DESCRIPTION
`FontRegistry` keeps its symbolic-name-to-`FontData` mapping in a plain `HashMap` that is read and written from arbitrary threads:

- `put(String, FontData[])` is public and carries no UI-thread restriction, unlike the methods handing out `Font` instances.
- `getFontData()`, `getDescriptor()`, `getKeySet()` and `hasValueFor()` read it and are likewise unrestricted — `getKeySet()` even hands out a live view.
- `createFont()` writes to it from whichever thread realizes a font, i.e. from any `Display`'s thread.

Unsynchronized `HashMap` mutation from several threads can corrupt the table itself, not merely produce stale reads. Use a `ConcurrentHashMap`, so concurrent access is safe and `getKeySet()` returns a weakly-consistent view rather than one that may fail arbitrarily while being iterated.

Also folds the internal `put()`'s read-compare-write of that table into a single atomic `Map#put`: the previous `get()`/`put()` pair could interleave so that two threads both concluded the mapping was unchanged, or that the mapping they replaced had already been overwritten. Storing the given array when it is content-equal to the existing one is a no-op for every reader, so behaviour is unchanged.

The table of realized `FontRecord`s and the stale-font list are deliberately left alone. They are not fully protected either — `put()` mutates them and carries no UI-thread restriction — but that race is pre-existing and unchanged here. It is addressed in follow-up changes that this one prepares for, where those structures get restructured anyway.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

