### PR TITLE
Guard FontRegistry.createFont against filterData returning null

### DIFF
--- a/bundles/org.eclipse.jface/src/org/eclipse/jface/resource/FontRegistry.java
+++ b/bundles/org.eclipse.jface/src/org/eclipse/jface/resource/FontRegistry.java
@@ -497,7 +497,7 @@ public class FontRegistry extends ResourceRegistry {
 		}
 
 		FontData[] validData = filterData(fonts, display);
-		if (validData.length == 0) {
+		if (validData == null || validData.length == 0) {
 			//Nothing specified
 			return null;
 		}

--- a/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/resources/FontRegistryTest.java
+++ b/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/resources/FontRegistryTest.java
@@ -188,6 +188,20 @@ public class FontRegistryTest {
 	}
 
 	@Test
+	public void get_forNameRegisteredWithoutAnyFontData_returnsDefaultFont() {
+		FontRegistry fontRegistry = new FontRegistry();
+		// an empty array leaves nothing to filter, so filterData() yields no usable data at all
+		fontRegistry.put("fontWithoutData", new FontData[0]);
+
+		Font first = fontRegistry.get("fontWithoutData");
+		Font second = fontRegistry.get("fontWithoutData");
+
+		assertSame(fontRegistry.get(JFaceResources.DEFAULT_FONT), first,
+				"a name that cannot be resolved to any font data must fall back to the default font");
+		assertSame(first, second);
+	}
+
+	@Test
 	public void getBoldAndGetItalic_returnSameInstanceOnRepeatedCalls() {
 		FontRegistry fontRegistry = new FontRegistry();
 		fontRegistry.put("myfont", new FontData[] { new FontData("Arial", 12, SWT.NORMAL) });


### PR DESCRIPTION
`filterData()` is documented to return `null` for an empty font list, and does so, but `createFont()` dereferences its result unconditionally to check for a zero length. Registering an empty `FontData[]` under a symbolic name and then looking that name up therefore fails with

```
java.lang.NullPointerException:
    Cannot read the array length because "validData" is null
```

instead of falling back to the default font the way an unresolvable name otherwise does.

Treat `null` like the empty result it stands for. Note that `filterData()` never actually returns a zero-length array — it falls back to the first entry when nothing matches — so the existing length check alone was dead code.

Includes a regression test registering an empty `FontData[]` and asserting the default-font fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
