### PR TITLE
Scope FontRegistry font caching and disposal to the Display that created each font

### DIFF
--- a/bundles/org.eclipse.jface/src/org/eclipse/jface/resource/FontRegistry.java
+++ b/bundles/org.eclipse.jface/src/org/eclipse/jface/resource/FontRegistry.java
@@ -18,13 +18,14 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Enumeration;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.MissingResourceException;
+import java.util.Queue;
 import java.util.ResourceBundle;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentLinkedQueue;
 
 import org.eclipse.core.runtime.Assert;
 import org.eclipse.jface.util.Policy;
@@ -67,13 +68,16 @@ public class FontRegistry extends ResourceRegistry {
 	 * FontRecord is a private helper class that holds onto a font
 	 * and can be used to generate its bold and italic version.
 	 */
-	private class FontRecord {
+	private static class FontRecord {
 
-		Font baseFont;
+		// volatile: a caller without a display of its own is handed the record of
+		// the display owning it, so it reads these fields while that display's
+		// thread may still be writing the lazily realized styles
+		volatile Font baseFont;
 
-		Font boldFont;
+		volatile Font boldFont;
 
-		Font italicFont;
+		volatile Font italicFont;
 
 		FontData[] baseData;
 
@@ -119,9 +123,12 @@ public class FontRegistry extends ResourceRegistry {
 				return boldFont;
 			}
 
+			// only the display owning this record, or a caller without a display of
+			// its own, ever reaches this point; either way the font is realized on
+			// the display the record belongs to
+			Assert.isTrue(Display.getCurrent() == null || Display.getCurrent() == baseFont.getDevice());
 			FontData[] boldData = getModifiedFontData(SWT.BOLD);
-			Display display = getDisplayAndHookForDisposal();
-			boldFont = new Font(display, boldData);
+			boldFont = new Font(baseFont.getDevice(), boldData);
 			return boldFont;
 		}
 
@@ -156,9 +163,12 @@ public class FontRegistry extends ResourceRegistry {
 				return italicFont;
 			}
 
+			// only the display owning this record, or a caller without a display of
+			// its own, ever reaches this point; either way the font is realized on
+			// the display the record belongs to
+			Assert.isTrue(Display.getCurrent() == null || Display.getCurrent() == baseFont.getDevice());
 			FontData[] italicData = getModifiedFontData(SWT.ITALIC);
-			Display display = getDisplayAndHookForDisposal();
-			italicFont = new Font(display, italicData);
+			italicFont = new Font(baseFont.getDevice(), italicData);
 			return italicFont;
 		}
 
@@ -182,12 +192,66 @@ public class FontRegistry extends ResourceRegistry {
 		}
 	}
 
+	private final Map<Display, DisplayFontRecords> displayToFontRecords = new ConcurrentHashMap<>();
+
 	/**
-	 * Table of known fonts, keyed by symbolic font name
-	 * (key type: <code>String</code>,
-	 *  value type: <code>FontRecord</code>.
+	 * Table of known fonts realized on one particular display, keyed by symbolic
+	 * font name (key type: <code>String</code>, value type:
+	 * <code>FontRecord</code>). There is one such table per {@link Display} the
+	 * registry has been used from, since a {@link Font} is only valid on the
+	 * display that created it. Also keeps that display's fonts that were
+	 * replaced by {@link FontRegistry#put(String, FontData[])} but may still be
+	 * in use elsewhere, so their disposal is deferred until the display itself
+	 * is disposed.
+	 * <p>
+	 * Both collections are concurrent: a display's records are read and written
+	 * by its own thread, but {@link FontRegistry#put(String, FontData[])}
+	 * invalidates the records of <em>every</em> display from whichever thread it
+	 * is called on, and may do so while that display is disposing itself.
+	 * </p>
 	 */
-	private final Map<String, FontRecord> stringToFontRecord = new HashMap<>(7);
+	private static class DisplayFontRecords {
+
+		private final Map<String, FontRecord> records = new ConcurrentHashMap<>();
+
+		private final Queue<Font> staleFonts = new ConcurrentLinkedQueue<>();
+
+		FontRecord get(String symbolicName) {
+			return records.get(symbolicName);
+		}
+
+		void put(String symbolicName, FontRecord record) {
+			records.put(symbolicName, record);
+		}
+
+		/**
+		 * Drop the record for the given symbolic name, if any, and defer
+		 * disposal of the fonts it had realized until this display is disposed,
+		 * since they may still be in use. The display's default font is kept,
+		 * as it stays in use under its own symbolic name.
+		 */
+		void invalidate(String symbolicName) {
+			FontRecord replacedRecord = records.remove(symbolicName);
+			if (replacedRecord == null) {
+				return;
+			}
+			FontRecord defaultRecord = records.get(JFaceResources.DEFAULT_FONT);
+			Font defaultFont = defaultRecord != null ? defaultRecord.getBaseFont() : null;
+			replacedRecord.getAllocatedFonts().stream().filter(font -> font != defaultFont).forEach(staleFonts::add);
+		}
+
+		void dispose() {
+			records.values().forEach(FontRecord::dispose);
+			records.clear();
+			// drained rather than iterated and cleared, so that a font enqueued by a
+			// concurrent put() is either disposed here or still queued afterwards,
+			// but never dropped undisposed
+			for (Font staleFont = staleFonts.poll(); staleFont != null; staleFont = staleFonts.poll()) {
+				staleFont.dispose();
+			}
+		}
+
+	}
 
 	/**
 	 * Table of known font data, keyed by symbolic font name
@@ -197,20 +261,18 @@ public class FontRegistry extends ResourceRegistry {
 	private final Map<String, FontData[]> stringToFontData = new ConcurrentHashMap<>(7);
 
 	/**
-	 * Collection of Fonts that are now stale to be disposed
-	 * when it is safe to do so (i.e. on shutdown).
-	 * @see List
-	 */
-	private final List<Font> staleFonts = new ArrayList<>();
-
-	/**
 	 * Runnable that cleans up the manager on disposal of the display.
 	 */
 	protected Runnable displayRunnable = this::clearCaches;
 
-	private final Set<Display> displayDisposeHooked = ConcurrentHashMap.newKeySet();
-
 	private final boolean cleanOnDisplayDisposal;
+
+	/**
+	 * The display this registry was created for. It is assumed to outlive every
+	 * other display the registry is used from, so its fonts can serve as a
+	 * fallback for callers that have no display of their own.
+	 */
+	private final Display mainDisplay;
 
 	/**
 	 * Creates an empty font registry.
@@ -282,14 +344,14 @@ public class FontRegistry extends ResourceRegistry {
 	 */
 	public FontRegistry(String location, ClassLoader loader)
 			throws MissingResourceException {
-		Display display = Display.getCurrent();
-		Assert.isNotNull(display);
+		mainDisplay = Display.getCurrent();
+		Assert.isNotNull(mainDisplay);
 		// FIXE: need to respect loader
 		//readResourceBundle(location, loader);
 		readResourceBundle(location);
-
 		cleanOnDisplayDisposal = true;
-		hookDisplayDispose(display);
+		displayToFontRecords.put(mainDisplay, new DisplayFontRecords());
+		hookMainDisplayDispose(mainDisplay);
 	}
 
 	/**
@@ -368,15 +430,17 @@ public class FontRegistry extends ResourceRegistry {
 	 *            whether all fonts allocated by this <code>FontRegistry</code>
 	 *            should be disposed when the display is disposed. If
 	 *            <code>false</code>, this registry never disposes a font by
-	 *            itself; the fonts it allocated are retained until
-	 *            {@link #clearCaches()} disposes them
+	 *            itself; the fonts it allocated for any display are retained
+	 *            until {@link #clearCaches()} disposes them
 	 * @since 3.1
 	 */
 	public FontRegistry(Display display, boolean cleanOnDisplayDisposal) {
 		Assert.isNotNull(display);
+		this.mainDisplay = display;
+		displayToFontRecords.put(display, new DisplayFontRecords());
 		this.cleanOnDisplayDisposal = cleanOnDisplayDisposal;
 		if (cleanOnDisplayDisposal) {
-			hookDisplayDispose(display);
+			hookMainDisplayDispose(display);
 		}
 	}
 
@@ -503,23 +567,22 @@ public class FontRegistry extends ResourceRegistry {
 			return null;
 		}
 
-		//Do not fire the update from creation as it is not a property change
+		// Do not fire the update from creation as it is not a property change.
+		// Note that this drops any record other displays had realized for this
+		// name, should filterData() have narrowed the registered data. That is
+		// intended: the registered data is shared by all displays, so a record
+		// built from outdated data must not survive on any of them.
 		put(symbolicName, validData, false);
 		Font newFont = new Font(display, validData);
-		FontRecord newRecord = new FontRecord(newFont, validData);
-		stringToFontRecord.put(symbolicName, newRecord);
-		return newRecord;
-	}
-
-	private Display getDisplayAndHookForDisposal() {
-		Display display = Display.getCurrent();
-		if (display == null) {
-			return null;
+		FontRecord record = new FontRecord(newFont, validData);
+		// the display's records may have been torn down concurrently, e.g. by
+		// clearCaches() running on another display's thread, in which case there is
+		// nothing left to cache the record in and the next lookup realizes it again
+		DisplayFontRecords displayRecords = displayToFontRecords.get(display);
+		if (displayRecords != null) {
+			displayRecords.put(symbolicName, record);
 		}
-		if (cleanOnDisplayDisposal && !displayDisposeHooked.contains(display)) {
-			hookDisplayDispose(display);
-		}
-		return display;
+		return record;
 	}
 
 	/**
@@ -570,7 +633,18 @@ public class FontRegistry extends ResourceRegistry {
 	 * Returns the default font record.
 	 */
 	private FontRecord defaultFontRecord() {
-		FontRecord record = stringToFontRecord.get(JFaceResources.DEFAULT_FONT);
+		FontRecord record = getExistingFontRecord(JFaceResources.DEFAULT_FONT);
+		if (record == null && Display.getCurrent() == null) {
+			// No display for the current thread, so there is none to scope the
+			// lookup to and none to create a font on. Fall back to the default
+			// font already realized on the main display, which outlives every
+			// other display, rather than fail outright. Reached e.g. from
+			// getFontRecord()'s non-UI-thread fallback.
+			DisplayFontRecords mainDisplayRecords = displayToFontRecords.get(mainDisplay);
+			if (mainDisplayRecords != null) {
+				record = mainDisplayRecords.get(JFaceResources.DEFAULT_FONT);
+			}
+		}
 		if (record != null) {
 			return record;
 		}
@@ -586,6 +660,20 @@ public class FontRegistry extends ResourceRegistry {
 			defaultFont.dispose();
 		}
 		return record;
+	}
+
+	/**
+	 * Looks up an already-realized font record for the given symbolic name on
+	 * the current display. Returns <code>null</code> if there is none, in which
+	 * case the caller is responsible for creating one on the current display.
+	 */
+	private FontRecord getExistingFontRecord(String symbolicName) {
+		Display currentDisplay = Display.getCurrent();
+		if (currentDisplay == null) {
+			return null;
+		}
+		DisplayFontRecords currentDisplayRecords = displayToFontRecords.get(currentDisplay);
+		return currentDisplayRecords != null ? currentDisplayRecords.get(symbolicName) : null;
 	}
 
 	/**
@@ -680,7 +768,7 @@ public class FontRegistry extends ResourceRegistry {
 	 */
 	private FontRecord getFontRecord(String symbolicName) {
 		Assert.isNotNull(symbolicName);
-		FontRecord existingRecord = stringToFontRecord.get(symbolicName);
+		FontRecord existingRecord = getExistingFontRecord(symbolicName);
 		if (existingRecord != null) {
 			return existingRecord;
 		}
@@ -718,20 +806,42 @@ public class FontRegistry extends ResourceRegistry {
 
 	@Override
 	protected void clearCaches() {
-		stringToFontRecord.values().forEach(FontRecord::dispose);
-		stringToFontRecord.clear();
-		staleFonts.forEach(Font::dispose);
-		staleFonts.clear();
-
-		displayDisposeHooked.remove(Display.getCurrent());
+		// disposes every display's fonts, not only the current display's: the
+		// contract is to dispose all allocated resources, and this also runs on
+		// disposal of the main display, which outlives all other displays
+		for (Display display : displayToFontRecords.keySet()) {
+			unhookDisplayAndDisposeFonts(display);
+		}
 	}
 
 	/**
-	 * Hook a dispose listener on the SWT display.
+	 * Hook a dispose listener on the SWT display this registry was created for.
+	 * Since that display outlives all others, its disposal tears down the whole
+	 * registry, not just its own fonts.
 	 */
-	private void hookDisplayDispose(Display display) {
-		displayDisposeHooked.add(display);
+	private void hookMainDisplayDispose(Display display) {
 		display.disposeExec(displayRunnable);
+	}
+
+	private Display getDisplayAndHookForDisposal() {
+		Display display = Display.getCurrent();
+		if (display == null) {
+			return null;
+		}
+		displayToFontRecords.computeIfAbsent(display, newDisplay -> {
+			if (cleanOnDisplayDisposal) {
+				newDisplay.disposeExec(() -> unhookDisplayAndDisposeFonts(newDisplay));
+			}
+			return new DisplayFontRecords();
+		});
+		return display;
+	}
+
+	private void unhookDisplayAndDisposeFonts(Display display) {
+		DisplayFontRecords records = displayToFontRecords.remove(display);
+		if (records != null) {
+			records.dispose();
+		}
 	}
 
 	/**
@@ -789,7 +899,7 @@ public class FontRegistry extends ResourceRegistry {
 	 *
 	 * @param symbolicName the symbolic font name
 	 * @param fontData an Array of FontData
-	 * @param update - fire a font mapping changed if true. False
+	 * @param update - fire a property change if true. False
 	 * 	if this method is called from the get method as no setting
 	 *  has changed.
 	 */
@@ -805,26 +915,17 @@ public class FontRegistry extends ResourceRegistry {
 			return;
 		}
 
-		invalidate(symbolicName);
+		// the font data is shared by all displays, so the font has to be
+		// invalidated on all of them. Stale fonts are queued per display, so
+		// each display disposes its own replaced fonts when it is itself
+		// disposed, instead of every display's replaced fonts only being
+		// disposed together with one particular display
+		for (DisplayFontRecords records : displayToFontRecords.values()) {
+			records.invalidate(symbolicName);
+		}
 		if (update) {
 			fireMappingChanged(symbolicName, existing, fontData);
 		}
-	}
-
-	/**
-	 * Drop the realized font record for the given symbolic name, if any, and
-	 * defer disposal of the fonts it had allocated until it is safe to dispose
-	 * them, since they may still be in use. The default font is kept, as it
-	 * stays in use under its own symbolic name.
-	 */
-	private void invalidate(String symbolicName) {
-		FontRecord replacedRecord = stringToFontRecord.remove(symbolicName);
-		if (replacedRecord == null) {
-			return;
-		}
-		FontRecord defaultRecord = stringToFontRecord.get(JFaceResources.DEFAULT_FONT);
-		Font defaultFont = defaultRecord != null ? defaultRecord.getBaseFont() : null;
-		replacedRecord.getAllocatedFonts().stream().filter(font -> font != defaultFont).forEach(staleFonts::add);
 	}
 
 	/**

--- a/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/resources/FontRegistryTest.java
+++ b/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/resources/FontRegistryTest.java
@@ -61,6 +61,17 @@ public class FontRegistryTest {
 	}
 
 	@Test
+	public void multipleDisplayDispose_noDisposeOtherThreadFonts() {
+		assumeTrue(OS.isWindows(), "multiple Display instance only allowed on Windows");
+
+		FontRegistry fontRegistry = new FontRegistry();
+		fontRegistry.put("myfont", new FontData[] { new FontData("Arial", 12, SWT.NORMAL) });
+		Font mainFont = fontRegistry.get("myfont");
+		testMultipleDisplayDispose(fontRegistry::defaultFont);
+		assertFalse(mainFont.isDisposed(), "FontRegistry should not dispose fonts on other displays");
+	}
+
+	@Test
 	public void multipleDisplayDispose() {
 		assumeTrue(OS.isWindows(), "multiple Display instance only allowed on Windows");
 
@@ -86,6 +97,65 @@ public class FontRegistryTest {
 		testMultipleDisplayDispose(() -> fontRegistry.getItalic(JFaceResources.DEFAULT_FONT));
 	}
 
+	@Test
+	public void put_invalidatesCachedFont_onAllDisplays() {
+		assumeTrue(OS.isWindows(), "multiple Display instance only allowed on Windows");
+
+		FontRegistry fontRegistry = new FontRegistry();
+		fontRegistry.put("myfont", new FontData[] { new FontData("Arial", 12, SWT.NORMAL) });
+		fontRegistry.get("myfont"); // only realizes the NORMAL style on the main display
+
+		Display secondDisplay = initializeDisplayInSeparateThread();
+		try {
+			// a style the main display has not realized, so the second display is
+			// guaranteed to hold a font record of its own; only then does this
+			// actually cover invalidation across displays
+			Font boldFontOnSecondDisplay = secondDisplay.syncCall(() -> fontRegistry.getBold("myfont"));
+			assertEquals(secondDisplay, boldFontOnSecondDisplay.getDevice(),
+					"the second display must have realized a font of its own");
+
+			// changing the font data must invalidate the cached font on every display, not just the main one
+			fontRegistry.put("myfont", new FontData[] { new FontData("Arial", 20, SWT.NORMAL) });
+
+			Font updatedBoldFontOnSecondDisplay = secondDisplay.syncCall(() -> fontRegistry.getBold("myfont"));
+			assertNotEquals(boldFontOnSecondDisplay, updatedBoldFontOnSecondDisplay,
+					"put() must invalidate the cached font on the second display too");
+			assertEquals(20, updatedBoldFontOnSecondDisplay.getFontData()[0].getHeight());
+		} finally {
+			secondDisplay.syncExec(secondDisplay::dispose);
+		}
+	}
+
+	@Test
+	public void cleanOnDisplayDisposalFalse_cachesFontAcrossRepeatedCalls() {
+		FontRegistry fontRegistry = new FontRegistry(Display.getCurrent(), false);
+		fontRegistry.put("myfont", new FontData[] { new FontData("Arial", 12, SWT.NORMAL) });
+
+		Font first = fontRegistry.get("myfont");
+		Font second = fontRegistry.get("myfont");
+
+		assertEquals(first, second,
+				"repeated get() calls must return the cached font, not a new one, when cleanOnDisplayDisposal is false");
+	}
+
+	@Test
+	public void cleanOnDisplayDisposalFalse_doesNotAutoDisposeFontsOnSecondDisplay() {
+		assumeTrue(OS.isWindows(), "multiple Display instance only allowed on Windows");
+
+		FontRegistry fontRegistry = new FontRegistry(Display.getCurrent(), false);
+		fontRegistry.put("myfont", new FontData[] { new FontData("Arial", 12, SWT.NORMAL) });
+
+		Display secondDisplay = initializeDisplayInSeparateThread();
+		Font fontOnSecondDisplay = secondDisplay.syncCall(() -> fontRegistry.get("myfont"));
+		Font sameFontOnSecondDisplay = secondDisplay.syncCall(() -> fontRegistry.get("myfont"));
+		assertEquals(fontOnSecondDisplay, sameFontOnSecondDisplay,
+				"font must be cached per display even when cleanOnDisplayDisposal is false");
+
+		secondDisplay.syncExec(secondDisplay::dispose);
+		assertFalse(fontOnSecondDisplay.isDisposed(),
+				"fonts must not be disposed automatically when cleanOnDisplayDisposal is false");
+	}
+
 	private static void testMultipleDisplayDispose(Supplier<Font> fontSupplier) {
 		assumeTrue(OS.isWindows(), "multiple Display instance only allowed on Windows");
 
@@ -94,9 +164,8 @@ public class FontRegistryTest {
 
 		Font fontOnThisDisplayBeforeSecondDisplayDispose = fontSupplier.get();
 		Device displayOfFontOnSecondDisplay = fontOnSecondDisplay.getDevice();
-		// font registry returns same font for every display
 		assertEquals(secondDisplay, displayOfFontOnSecondDisplay);
-		assertEquals(fontOnThisDisplayBeforeSecondDisplayDispose, fontOnSecondDisplay);
+		assertNotEquals(fontOnThisDisplayBeforeSecondDisplayDispose, fontOnSecondDisplay);
 
 		// after disposing font's display, registry should reinitialize the font
 		secondDisplay.syncExec(secondDisplay::dispose);
@@ -162,23 +231,24 @@ public class FontRegistryTest {
 		fontRegistry.put("myfont", new FontData[] { new FontData("Arial", 12, SWT.NORMAL) });
 		Font defaultFont = fontRegistry.get(JFaceResources.DEFAULT_FONT);
 
-		AtomicReference<Font> fontFromNonUIThread = new AtomicReference<>();
-		AtomicReference<Throwable> failureFromNonUIThread = new AtomicReference<>();
-		Thread nonUiThread = new Thread(() -> {
-			try {
-				fontFromNonUIThread.set(fontRegistry.get("myfont"));
-			} catch (Throwable t) {
-				failureFromNonUIThread.set(t);
-			}
-		});
-		nonUiThread.start();
-		nonUiThread.join();
+		Font fontFromNonUIThread = callOnNonUIThread(() -> fontRegistry.get("myfont"));
 
-		if (failureFromNonUIThread.get() != null) {
-			throw failureFromNonUIThread.get();
-		}
-		assertSame(defaultFont, fontFromNonUIThread.get());
+		assertSame(defaultFont, fontFromNonUIThread);
 		assertSame(defaultFont, fontRegistry.get(JFaceResources.DEFAULT_FONT));
+	}
+
+	@Test
+	public void getBold_fromNonUIThreadFallback_reusesMainDisplaysBoldDefaultFont() throws Throwable {
+		FontRegistry fontRegistry = new FontRegistry();
+		fontRegistry.put("myfont", new FontData[] { new FontData("Arial", 12, SWT.NORMAL) });
+		// a thread without a display of its own can neither create a font nor scope a
+		// lookup, so the main display's default font record is all it can fall back to
+		Font defaultBold = fontRegistry.getBold(JFaceResources.DEFAULT_FONT);
+
+		Font boldFromNonUIThread = callOnNonUIThread(() -> fontRegistry.getBold("myfont"));
+
+		assertSame(defaultBold, boldFromNonUIThread);
+		assertSame(defaultBold, fontRegistry.getBold(JFaceResources.DEFAULT_FONT));
 	}
 
 	@Test


### PR DESCRIPTION
> [!IMPORTANT]
> This PR is based on five preparatory PRs, which make up its first five commits. They should be reviewed and merged first — **only the last commit, `Scope FontRegistry font caching and disposal to the Display that created each font`, is what this PR actually covers.**
>
> - #4266
> - #4267
> - #4265
> - #4263
> - #4268

### The problem

`FontRegistry` keeps its realized fonts in a single, display-agnostic table, and hooks disposal on every `Display` it has been used from. Whichever of those Displays is disposed **first** runs `clearCaches()` and tears down the *entire* table — including the fonts owned by every other, still-live Display. Those Displays are then left holding disposed fonts, and which Display triggers this is arbitrary; typically it is not the one the registry was created for.

Fonts replaced via `put()` have the same problem from the other side: they are queued in one global list of stale fonts and disposed together with whichever Display happens to go first, rather than with the Display that owns them.

None of this is observable in a single-display application, which is nearly every Eclipse application. It becomes observable as soon as a second `Display` exists, which is possible on Windows.

### The solution

The registry keeps **one font cache per `Display`**, populated and disposed independently. A `Display` realizes and owns its own fonts, and disposing it disposes exactly those, leaving every other `Display` untouched. Replaced fonts are likewise queued as stale per display and disposed with the display that owns them.

Note this is about **ownership and lifetime, not about which `Display` a font may be used on**. Handing a font realized on one `Display` to another is not by itself a problem; having it disposed underneath that other `Display` is.

The `Display` the registry was created for is kept as the *main display* and assumed to outlive all others, which makes its fonts the ones that are always safe to fall back to. Two things build on that:

- A thread with no `Display` of its own can neither scope a lookup nor create a font, so it falls back to the default font realized on the main display instead of failing outright.
- Disposing the main display still disposes the whole registry, so `clearCaches()` keeps the *"disposes all currently allocated resources"* contract it inherits from `ResourceRegistry`.

The per-display caches are concurrent, since Displays run on their own threads and `put()` invalidates the records of every display from whichever thread it is called on.

For a single-display application this is behaviour-preserving: the per-display cache then holds exactly what the global one did, and that `Display` is the main display.

### The verification

Tests were added on both sides of the line:

- **Four fail before this commit and pass after.** `multipleDisplayDispose`, `multipleDisplayDispose_boldFont` and `multipleDisplayDispose_italicFont` are existing tests whose expectation is corrected from *"the same font on every Display"* to *"a Display that has to realize a font owns it"*; `multipleDisplayDispose_noDisposeOtherThreadFonts` is new and covers the defect above directly.
- **The remaining new tests pass before and after.** They pin behaviour this change must *not* alter: that `put()` invalidates the cached font on every Display, that `cleanOnDisplayDisposal == false` still caches and still never disposes automatically, and that a thread without a `Display` still falls back to the default font.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
