### PR TITLE
allow skipping projection regions in "Collapse All" actions

### DIFF
--- a/bundles/org.eclipse.jface.text/projection/org/eclipse/jface/text/source/projection/ProjectionAnnotation.java
+++ b/bundles/org.eclipse.jface.text/projection/org/eclipse/jface/text/source/projection/ProjectionAnnotation.java
@@ -159,6 +159,16 @@ public class ProjectionAnnotation extends Annotation implements IAnnotationPrese
 	}
 
 	/**
+	 * Whether this annotation should be included in the "Collapse All" action of the editor.
+	 *
+	 * @return {@code true} if the annotation participates in "Collapse All" actions
+	 * @since 3.32
+	 */
+	protected boolean includeInCollapseAll() {
+		return true;
+	}
+
+	/**
 	 * Returns the state of this annotation.
 	 *
 	 * @return <code>true</code> if collapsed

--- a/bundles/org.eclipse.jface.text/projection/org/eclipse/jface/text/source/projection/ProjectionAnnotationModel.java
+++ b/bundles/org.eclipse.jface.text/projection/org/eclipse/jface/text/source/projection/ProjectionAnnotationModel.java
@@ -116,7 +116,7 @@ public class ProjectionAnnotationModel extends AnnotationModel {
 		Iterator<Annotation> iterator= getAnnotationIterator();
 		while (iterator.hasNext()) {
 			ProjectionAnnotation annotation= (ProjectionAnnotation) iterator.next();
-			if (!annotation.isCollapsed()) {
+			if (!annotation.isCollapsed() && annotation.includeInCollapseAll()) {
 				Position position= getPosition(annotation);
 				if (position != null && position.overlapsWith(offset, length) /* || is a delete at the boundary */ ) {
 					annotation.markCollapsed();

--- a/tests/org.eclipse.jface.text.tests/src/org/eclipse/jface/text/tests/ProjectionViewerTest.java
+++ b/tests/org.eclipse.jface.text.tests/src/org/eclipse/jface/text/tests/ProjectionViewerTest.java
@@ -102,6 +102,93 @@ public class ProjectionViewerTest {
 	}
 
 	@Test
+	void testCollapseAllProjectionAnnotations() {
+		Shell shell= new Shell();
+		try {
+			String content= """
+				before
+				hidden
+				after\
+				""";
+			TestProjectionViewer viewer= setupWithProjections(shell, content);
+			ProjectionAnnotation annotation= new ProjectionAnnotation(false);
+			int start= content.indexOf('\n');
+			viewer.getProjectionAnnotationModel().addAnnotation(annotation, new Position(start, content.lastIndexOf('\n') + 1 - start));
+			viewer.getTextOperationTarget().doOperation(ProjectionViewer.COLLAPSE_ALL);
+			assertTrue(annotation.isCollapsed());
+			assertEquals("""
+				before
+				after\
+				""", viewer.getVisibleDocument().get());
+		} finally {
+			shell.dispose();
+		}
+	}
+
+	@Test
+	void testOptOutOfCollapseAllProjectionAnnotations() {
+		Shell shell= new Shell();
+		try {
+			String content= """
+					before
+					hidden
+					after\
+					""";
+			TestProjectionViewer viewer= setupWithProjections(shell, content);
+			ProjectionAnnotation annotation= new ProjectionAnnotation(false) {
+				@Override
+				protected boolean includeInCollapseAll() {
+					return false;
+				}
+			};
+			int start= content.indexOf('\n');
+			viewer.getProjectionAnnotationModel().addAnnotation(annotation, new Position(start, content.lastIndexOf('\n') + 1 - start));
+			viewer.getTextOperationTarget().doOperation(ProjectionViewer.COLLAPSE_ALL);
+			assertFalse(annotation.isCollapsed());
+			assertEquals("""
+					before
+					hidden
+					after\
+					""", viewer.getVisibleDocument().get());
+		} finally {
+			shell.dispose();
+		}
+	}
+
+	@Test
+	void testExpandAllProjectionAnnotations() {
+		Shell shell= new Shell();
+		try {
+			String content= """
+					before
+					hidden
+					after\
+					""";
+			TestProjectionViewer viewer= setupWithProjections(shell, content);
+			ProjectionAnnotation annotation= new ProjectionAnnotation(true);
+			int start= content.indexOf('\n');
+			viewer.getProjectionAnnotationModel().addAnnotation(annotation, new Position(start, content.lastIndexOf('\n') + 1 - start));
+			viewer.getTextOperationTarget().doOperation(ProjectionViewer.EXPAND_ALL);
+			assertFalse(annotation.isCollapsed());
+			assertEquals("""
+					before
+					hidden
+					after\
+					""", viewer.getVisibleDocument().get());
+		} finally {
+			shell.dispose();
+		}
+	}
+
+	private TestProjectionViewer setupWithProjections(Shell shell, String content) {
+		TestProjectionViewer viewer= new TestProjectionViewer(shell, null, null, false, SWT.NONE);
+		Document document= new Document(content);
+		viewer.setDocument(document, new AnnotationModel());
+		viewer.enableProjection();
+		return viewer;
+	}
+
+	@Test
 	public void testVisibleRegionDoesNotChangeWithProjections() {
 		Shell shell= new Shell();
 		shell.setLayout(new FillLayout());


### PR DESCRIPTION
This PR adds an API to allow for individual projection regions to mark themselves as not being included in the ~~"Expand All"/~~"Collapse All" editor actions.

This would be used to allow skipping top level types in JDT's Java folding (https://github.com/eclipse-jdt/eclipse.jdt.ui/pull/3126, see also the video in that description for how this is working).

~~Technically, only the `includeInCollapseAll()` method would be needed for this change but I think it is more consistent to have this for both operations.~~ This has been removed.

~~I know that we currently have a code freeze and I'm submitting it with the intention of ideally getting this into the release afterwards (4.42).~~ Irrelevant since master is open for 4.42 now.