### PR TITLE
Unify test case names in FontRegistryTest

### DIFF
--- a/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/resources/FontRegistryTest.java
+++ b/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/resources/FontRegistryTest.java
@@ -78,7 +78,7 @@ public class FontRegistryTest {
 	}
 
 	@Test
-	public void multipleDisplay_italicFont() {
+	public void multipleDisplayDispose_italicFont() {
 		assumeTrue(OS.isWindows(), "multiple Display instance only allowed on Windows");
 
 		FontRegistry fontRegistry = new FontRegistry();


### PR DESCRIPTION
Two test cases for the same behavior of retrieving bold/italic fonts had inconsistent names.