### PR TITLE
Do not persist status line visibility under the perspective bar key

### DIFF
--- a/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/WorkbenchWindow.java
+++ b/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/WorkbenchWindow.java
@@ -2826,16 +2826,13 @@ public class WorkbenchWindow implements IWorkbenchWindow {
 	}
 
 	/**
-	 * @param visible whether the perspective bar should be shown. This is only
-	 *                applicable if the window configurer also wishes either the
-	 *                perspective bar to be visible.
+	 * @param visible whether the status line should be shown
 	 * @since 3.0
 	 */
 	public void setStatusLineVisible(boolean visible) {
 		boolean oldValue = statusLineVisible;
 		statusLineVisible = visible;
 		if (oldValue != statusLineVisible) {
-			getModel().getPersistedState().put(IPreferenceConstants.PERSPECTIVEBAR_VISIBLE, Boolean.toString(visible));
 			updateLayoutDataForContents();
 			firePropertyChanged(PROP_STATUS_LINE_VISIBLE, oldValue ? Boolean.TRUE : Boolean.FALSE,
 					statusLineVisible ? Boolean.TRUE : Boolean.FALSE);
@@ -2843,9 +2840,7 @@ public class WorkbenchWindow implements IWorkbenchWindow {
 	}
 
 	/**
-	 * @return whether the perspective bar should be shown. This is only applicable
-	 *         if the window configurer also wishes either the perspective bar to be
-	 *         visible.
+	 * @return whether the status line should be shown
 	 * @since 3.0
 	 */
 	public boolean getStatusLineVisible() {


### PR DESCRIPTION
`WorkbenchWindow.setStatusLineVisible` stored its value in the window's persisted state under the `perspectiveBarVisible` key. An RCP application calling `WorkbenchWindowConfigurer.setShowStatusLine(false)` therefore silently changed the perspective bar state for that window on the next start.

Nothing ever reads a status line key back, and the Window > Appearance > Hide Status Bar command persists its state through `MUIElement.visible` on the status trim, so the write is dropped rather than replaced by a new key. The Javadoc of the two accessors was copied from the perspective bar methods and is corrected as well.

The wrong key dates back to 8a8be4d8d1 (Bug 403461).