### PR TITLE
Fail fast when a model processor prerequisite is missing

### DIFF
--- a/bundles/org.eclipse.e4.ui.workbench/src/org/eclipse/e4/ui/internal/workbench/ModelAssembler.java
+++ b/bundles/org.eclipse.e4.ui.workbench/src/org/eclipse/e4/ui/internal/workbench/ModelAssembler.java
@@ -690,7 +690,7 @@ public class ModelAssembler {
 				ContextInjectionFactory.invoke(o, Execute.class, context, localContext, null);
 			}
 		} catch (Exception e) {
-			warn("Could not run processor: {}", e); //$NON-NLS-1$
+			error("Could not run processor {}", ce.getAttribute("class"), e); //$NON-NLS-1$//$NON-NLS-2$
 		}
 	}
 
@@ -731,7 +731,9 @@ public class ModelAssembler {
 				ContextInjectionFactory.invoke(o, Execute.class, context, localContext, null);
 			}
 		} catch (Exception e) {
-			warn("Could not run processor: {}", e); //$NON-NLS-1$
+			Class<?> processorClass = processor.getProcessorClass() != null ? processor.getProcessorClass()
+					: processor.getClass();
+			error("Could not run processor {}", processorClass.getName(), e); //$NON-NLS-1$
 		}
 	}
 
@@ -825,6 +827,9 @@ public class ModelAssembler {
 		} else {
 			// fallback if no LogService is available
 			stream.println(MessageFormat.format(addIndex(message), args));
+			if (args.length > 0 && args[args.length - 1] instanceof Throwable t) {
+				t.printStackTrace(stream);
+			}
 		}
 	}
 

--- a/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/BindingToModelProcessor.java
+++ b/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/BindingToModelProcessor.java
@@ -52,7 +52,8 @@ public class BindingToModelProcessor implements IModelProcessorContribution {
 
 	// define dependencies to CommandToModelProcessor and ContextToModelProcessor to
 	// ensure these two IModelProcessorContributions are registered before this
-	// BindingToModelProcessor
+	// BindingToModelProcessor. Both fields are read in process(), removing them
+	// silently breaks that ordering.
 
 	@Reference
 	private CommandToModelProcessor commandToModelProcessor;
@@ -66,14 +67,10 @@ public class BindingToModelProcessor implements IModelProcessorContribution {
 		gatherCommands(application.getCommands());
 		gatherTables(application.getBindingTables());
 
-		CommandManager commandManager = context.get(CommandManager.class);
-		if (commandManager == null) {
-			WorkbenchPlugin.log("Command manager was null in org.eclipse.ui.internal.BindingToModelProcessor"); //$NON-NLS-1$
-		}
-		ContextManager contextManager = context.get(ContextManager.class);
-		if (contextManager == null) {
-			WorkbenchPlugin.log("Context manager was null in org.eclipse.ui.internal.BindingToModelProcessor"); //$NON-NLS-1$
-		}
+		CommandManager commandManager = requirePrerequisite(context, CommandManager.class,
+				CommandToModelProcessor.class, commandToModelProcessor);
+		ContextManager contextManager = requirePrerequisite(context, ContextManager.class,
+				ContextToModelProcessor.class, contextToModelProcessor);
 		BindingManager bindingManager = new BindingManager(contextManager, commandManager);
 		context.set(BindingManager.class, bindingManager);
 		BindingPersistence persistence = new BindingPersistence(bindingManager, commandManager);
@@ -96,6 +93,24 @@ public class BindingToModelProcessor implements IModelProcessorContribution {
 		commands.clear();
 		tables.clear();
 		keys.clear();
+	}
+
+	/**
+	 * Returns the value stored under the given key, failing with a message that
+	 * names the processor expected to have provided it. The provider instance is
+	 * the DS reference that orders this processor after that one.
+	 */
+	private static <T> T requirePrerequisite(IEclipseContext context, Class<T> key, Class<?> providerType,
+			Object provider) {
+		T value = context.get(key);
+		if (value == null || provider == null) {
+			String message = String.format(
+					"%s did not find %s in the application context. %s must run first; check that its @Reference in %s is still declared and that the OSGi component descriptors of this bundle are up to date.", //$NON-NLS-1$
+					BindingToModelProcessor.class.getName(), key.getName(), providerType.getName(),
+					BindingToModelProcessor.class.getSimpleName());
+			throw new IllegalStateException(message);
+		}
+		return value;
 	}
 
 	private void gatherTables(List<MBindingTable> bindingTables) {


### PR DESCRIPTION
`BindingToModelProcessor` logged that `CommandManager` or `ContextManager` was null and then handed those nulls to the `BindingManager` constructor, which rejects them. `ModelAssembler` swallowed the resulting NPE, so `BindingManager` never reached the application context and the failure only surfaced much later as an `InjectionException` on `BindingService` during workbench startup, several frames away from the real cause and naming none of the three processors involved.

The processor now fails immediately with a message naming the processor that should have supplied the missing value, and `ModelAssembler` reports a failing processor as an error including its class name rather than a warning that says only "Could not run processor". The two `@Reference` fields that order this processor after its two siblings are now read in `process()`, so an unused-field cleanup can no longer drop them and silently break the ordering that has carried this since the DS migration in #2402.

This came out of a real investigation: removing those two annotations is invisible to javac, to the Java builder, to CI and to every headless test, yet it leaves a dead workbench with nothing in the log connecting the symptom to the cause. Failing fast turns that into a single readable log entry.