### PR TITLE
Bound the event queue drain in DisplayHelper

### DIFF
--- a/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/quickaccess/QuickAccessContents.java
+++ b/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/quickaccess/QuickAccessContents.java
@@ -30,6 +30,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Objects;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -56,6 +58,7 @@ import org.eclipse.jface.util.Util;
 import org.eclipse.jface.viewers.ColumnWeightData;
 import org.eclipse.osgi.util.NLS;
 import org.eclipse.swt.SWT;
+import org.eclipse.swt.SWTException;
 import org.eclipse.swt.events.ControlAdapter;
 import org.eclipse.swt.events.ControlEvent;
 import org.eclipse.swt.events.KeyEvent;
@@ -113,6 +116,9 @@ public abstract class QuickAccessContents {
 	 * join on the streaming compute deterministically instead of polling the table.
 	 */
 	public static final Object COMPUTE_JOB_FAMILY = new Object();
+
+	/** How often a compute job re-checks cancellation while waiting for the UI thread. */
+	private static final long UI_ACCESS_POLL_INTERVAL_MS = 100;
 
 	protected Text filterText;
 
@@ -453,17 +459,50 @@ public abstract class QuickAccessContents {
 			return Collections.emptyList();
 		}
 		AtomicReference<List<QuickAccessElement>> result = new AtomicReference<>(Collections.emptyList());
-		table.getDisplay().syncExec(() -> {
-			if (monitor.isCanceled() || table.isDisposed()) {
-				return;
+		CountDownLatch queried = new CountDownLatch(1);
+		try {
+			Display display = table.getDisplay();
+			if (Display.getCurrent() == display) {
+				// Waiting on the latch below would deadlock against our own asyncExec.
+				return queryProvider(provider, filter, monitor);
 			}
-			try {
-				result.set(Arrays.asList(provider.getElementsSorted(filter, monitor)));
-			} catch (RuntimeException e) {
-				WorkbenchPlugin.log(e);
+			display.asyncExec(() -> {
+				try {
+					result.set(queryProvider(provider, filter, monitor));
+				} finally {
+					queried.countDown();
+				}
+			});
+		} catch (SWTException e) { // table or display disposed while the dialog was closing
+			return Collections.emptyList();
+		}
+		// Unlike syncExec, polling lets a cancelled compute give up on a display that
+		// never goes idle.
+		try {
+			while (!queried.await(UI_ACCESS_POLL_INTERVAL_MS, TimeUnit.MILLISECONDS)) {
+				if (monitor.isCanceled() || table.isDisposed()) {
+					return Collections.emptyList();
+				}
 			}
-		});
+		} catch (InterruptedException e) {
+			Thread.currentThread().interrupt();
+			return Collections.emptyList();
+		}
 		return result.get();
+	}
+
+	/** Queries one provider on the display thread. */
+	private List<QuickAccessElement> queryProvider(QuickAccessProvider provider, String filter,
+			IProgressMonitor monitor) {
+		if (monitor.isCanceled() || table.isDisposed()) {
+			return Collections.emptyList();
+		}
+		try {
+			return Arrays.asList(provider.getElementsSorted(filter, monitor));
+		} catch (RuntimeException e) {
+			WorkbenchPlugin.log(e);
+			return Collections.emptyList();
+		}
 	}
 
 	/**

--- a/tests/org.eclipse.ui.tests.harness/src/org/eclipse/ui/tests/harness/util/DisplayHelper.java
+++ b/tests/org.eclipse.ui.tests.harness/src/org/eclipse/ui/tests/harness/util/DisplayHelper.java
@@ -33,6 +33,10 @@ import org.eclipse.swt.widgets.Display;
  * @since 3.1
  */
 public abstract class DisplayHelper {
+
+	/** Upper bound for one drain of the event queue. */
+	private static final long DRAIN_LIMIT_MS= 500;
+
 	/**
 	 * Creates a new instance.
 	 */
@@ -132,7 +136,8 @@ public abstract class DisplayHelper {
 	 * <p>
 	 * If <code>timeout &lt; 0</code>, nothing happens and false is returned.
 	 * If <code>timeout == 0</code>, the event loop is driven exactly once,
-	 * but <code>Display.sleep()</code> is never invoked.
+	 * but <code>Display.sleep()</code> is never invoked, and it dispatches for at
+	 * most {@value #DRAIN_LIMIT_MS} ms.
 	 * </p>
 	 *
 	 * @param display the display to run the event loop of
@@ -177,9 +182,15 @@ public abstract class DisplayHelper {
 	 *         <code>true</code> at least once
 	 */
 	private static boolean driveEventQueue(Display display) {
+		// A display that never stops producing events would never let readAndDispatch
+		// return false, making the caller's own timeout unreachable.
+		long deadline= System.nanoTime() + DRAIN_LIMIT_MS * 1_000_000L;
 		boolean events= false;
 		while (display.readAndDispatch()) {
 			events= true;
+			if (System.nanoTime() - deadline > 0) {
+				break;
+			}
 		}
 		return events;
 	}

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/quickaccess/QuickAccessDialogTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/quickaccess/QuickAccessDialogTest.java
@@ -453,9 +453,8 @@ public class QuickAccessDialogTest {
 		boolean computed = DisplayHelper.waitForCondition(display, COMPUTE_TIMEOUT,
 				() -> Job.getJobManager().find(QuickAccessContents.COMPUTE_JOB_FAMILY).length == 0);
 		assertTrue(computed, "Quick Access computation did not finish");
-		while (display.readAndDispatch()) {
-			// drain the asyncExec that renders the streamed results
-		}
+		// drain the asyncExec that renders the streamed results
+		DisplayHelper.runEventLoop(display, 0);
 	}
 
 	private boolean dialogContains(QuickAccessDialog dialog, String substring) {


### PR DESCRIPTION
The macOS `org.eclipse.ui.tests` timeouts come from an unbounded event loop in the test harness: `DisplayHelper.waitForCondition` only re-checks its deadline after `driveEventQueue` returns, and that method loops while `readAndDispatch` is true. On a display that never goes idle the timeout is unreachable, which is how a 60s wait in `QuickAccessDialogTest.setUp` swallowed the whole 2h budget of the bundle. Capping one drain at 500ms turns the hang into a bounded, diagnosable failure while a healthy queue still drains completely.

The Quick Access compute job could park for a related reason: its `Display.syncExec` from a job worker becomes pending work delivered by `asyncExec`, and SWT only runs async messages when nothing else was dispatched in that iteration, so `Job.cancel()` could not free it. It now polls for the result and gives up on cancellation instead of leaving `COMPUTE_JOB_FAMILY` non-empty forever.

This stops the bundle from consuming the harness budget; it does not by itself explain why the macOS display stops going idle, which still needs someone with a Mac to look at. Addresses #4289.