### PR TITLE
Paint the range indicator with alpha instead of a stipple image

### DIFF
--- a/bundles/org.eclipse.ui.workbench.texteditor/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.ui.workbench.texteditor/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.ui.workbench.texteditor; singleton:=true
-Bundle-Version: 3.20.200.qualifier
+Bundle-Version: 3.20.300.qualifier
 Bundle-Activator: org.eclipse.ui.internal.texteditor.TextEditorPlugin
 Bundle-ActivationPolicy: lazy
 Bundle-Vendor: %providerName

--- a/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/texteditor/DefaultRangeIndicator.java
+++ b/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/texteditor/DefaultRangeIndicator.java
@@ -15,18 +15,11 @@
 package org.eclipse.ui.texteditor;
 
 
-import org.eclipse.swt.SWT;
 import org.eclipse.swt.graphics.Color;
 import org.eclipse.swt.graphics.GC;
-import org.eclipse.swt.graphics.Image;
-import org.eclipse.swt.graphics.ImageData;
-import org.eclipse.swt.graphics.ImageDataProvider;
-import org.eclipse.swt.graphics.PaletteData;
 import org.eclipse.swt.graphics.Point;
 import org.eclipse.swt.graphics.Rectangle;
 import org.eclipse.swt.widgets.Canvas;
-import org.eclipse.swt.widgets.Control;
-import org.eclipse.swt.widgets.Display;
 
 import org.eclipse.jface.resource.JFaceResources;
 
@@ -45,10 +38,8 @@ import org.eclipse.jface.text.source.IAnnotationPresentation;
 public class DefaultRangeIndicator extends Annotation implements IAnnotationPresentation {
 
 	private static final String RANGE_INDICATOR_COLOR= "org.eclipse.ui.editors.rangeIndicatorColor"; //$NON-NLS-1$
-	/** The image of this range indicator */
-	private Image fImage;
-	/** The color used to draw the range indicator during the last paint action. */
-	private Color fLastRangeIndicatorColor;
+	/** Alpha of the range fill, matching the coverage of the former stipple pattern. */
+	private static final int FILL_ALPHA= 128;
 
 	/**
 	 * Creates a new range indicator.
@@ -79,96 +70,20 @@ public class DefaultRangeIndicator extends Annotation implements IAnnotationPres
 			return;
 		}
 
-		Color currentRangeIndicatorColor= JFaceResources.getColorRegistry().get(RANGE_INDICATOR_COLOR);
-		Image image= getImage(canvas, currentRangeIndicatorColor);
-		gc.drawImage(image, 0, 0, w, h, x, y, w, h);
+		Color rangeIndicatorColor= JFaceResources.getColorRegistry().get(RANGE_INDICATOR_COLOR);
+		gc.setBackground(rangeIndicatorColor);
 
-		gc.setBackground(currentRangeIndicatorColor);
+		int alpha= gc.getAlpha();
+		gc.setAlpha(FILL_ALPHA);
+		gc.fillRectangle(x, y, w, h);
+		gc.setAlpha(alpha);
+
 		gc.fillRectangle(x, bounds.y, w, b);
 		gc.fillRectangle(x, bounds.y + bounds.height - b, w, b);
-
-		fLastRangeIndicatorColor= currentRangeIndicatorColor;
 	}
 
 	@Override
 	public int getLayer() {
 		return IAnnotationPresentation.DEFAULT_LAYER;
-	}
-
-	/**
-	 * Returns the image of this range indicator.
-	 *
-	 * @param control the control
-	 * @param rangeIndicatorColor the color to be used to paint the range indicator
-	 * @return an image
-	 */
-	private Image getImage(Control control, Color rangeIndicatorColor) {
-		if (fImage == null) {
-			fImage= createImage(control.getDisplay(), control.getSize(), rangeIndicatorColor);
-
-			control.addDisposeListener(e -> {
-				if (fImage != null && !fImage.isDisposed()) {
-					fImage.dispose();
-					fImage = null;
-				}
-			});
-		} else {
-			Rectangle imageRectangle= fImage.getBounds();
-			Point controlSize= control.getSize();
-
-			if (imageRectangle.width < controlSize.x || imageRectangle.height < controlSize.y
-					|| !rangeIndicatorColor.equals(fLastRangeIndicatorColor)) {
-				fImage.dispose();
-				fImage= createImage(control.getDisplay(), controlSize, rangeIndicatorColor);
-			}
-		}
-
-		return fImage;
-	}
-
-	/**
-	 * Creates and returns a new SWT image with the given size on
-	 * the given display which is used as this range indicator's image.
-	 *
-	 * @param display the display on which to create the image
-	 * @param size the image size
-	 * @param rangeIndicatorColor the color to be used to paint the range indicator
-	 * @return a new image
-	 */
-	private static Image createImage(Display display, Point size, Color rangeIndicatorColor) {
-
-		int width = size.x;
-		int height = size.y;
-
-		ImageDataProvider imageDataProvider = zoom -> {
-			float scaleFactor = zoom / 100.0f;
-			int scaledWidth = Math.round(width * scaleFactor);
-			int scaledHeight = Math.round(height * scaleFactor);
-			ImageData imageData = new ImageData(scaledWidth, scaledHeight, 1,
-					createPalette(display, rangeIndicatorColor));
-			int blockSize = Math.round(scaleFactor);
-			for (int y = 0; y < scaledHeight; y++) {
-				for (int x = 0; x < scaledWidth; x++) {
-					if (((x / blockSize) + (y / blockSize)) % 2 == 0) {
-						imageData.setPixel(x, y, 1);
-					}
-				}
-			}
-			imageData.transparentPixel = 1;
-			return imageData;
-		};
-
-		return new Image(display, imageDataProvider);
-	}
-
-	/**
-	 * Creates and returns a new color palette data.
-	 *
-	 * @param display the display
-	 * @param rangeIndicatorColor the color to be used to paint the range indicator
-	 * @return the new color palette data
-	 */
-	private static PaletteData createPalette(Display display, Color rangeIndicatorColor) {
-		return new PaletteData(rangeIndicatorColor.getRGB(), display.getSystemColor(SWT.COLOR_WIDGET_BACKGROUND).getRGB());
 	}
 }


### PR DESCRIPTION
The range indicator in the vertical ruler was drawn from a 1-bit image with every other pixel set, a stipple that fakes a 50 percent tint. On scaled displays the pattern is scaled in blocks of zoom/100 pixels, so at 200 percent the ruler shows a coarse checkerboard in the indicator colour instead of a tint.

The range is now filled with the indicator colour at half alpha, which renders as a smooth tint at every zoom level and keeps the solid one pixel lines at the top and bottom of the range. The cached image, its dispose listener and the recreation on resize or colour change go away with it, so the class shrinks from 176 to 91 lines.