### PR TITLE
Do not paint stale line ranges in the line number ruler

### DIFF
--- a/bundles/org.eclipse.jface.text/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.jface.text/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.jface.text
-Bundle-Version: 3.31.100.qualifier
+Bundle-Version: 3.31.200.qualifier
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Export-Package: 

--- a/bundles/org.eclipse.jface.text/src/org/eclipse/jface/text/source/LineNumberRulerColumn.java
+++ b/bundles/org.eclipse.jface.text/src/org/eclipse/jface/text/source/LineNumberRulerColumn.java
@@ -698,18 +698,23 @@ public class LineNumberRulerColumn implements IVerticalRulerColumn {
 		}
 
 		if (fBuffer == null) {
-			newFullBufferImage(visibleLines, size);
+			newFullBufferImage(size);
 		} else {
 			doPaint(visibleLines, size);
 		}
 		dest.drawImage(fBuffer, 0, 0);
 	}
 
-	private void newFullBufferImage(ILineRange visibleLines, Point size) {
+	private void newFullBufferImage(Point size) {
 		ImageGcDrawer imageGcDrawer= (gc, imageWidth, imageHeight) -> {
 			// We redraw everything; paint directly into the buffer
 			initializeGC(gc, 0, 0, imageWidth, imageHeight);
-			doPaint(gc, visibleLines);
+			// SWT may run this again long after the buffer was created, so the range
+			// captured at creation time can be stale by then
+			ILineRange lines= fCachedTextViewer != null ? JFaceTextUtil.getVisibleModelLines(fCachedTextViewer) : null;
+			if (lines != null) {
+				doPaint(gc, lines);
+			}
 		};
 		fBuffer= new Image(fCanvas.getDisplay(), imageGcDrawer, size.x, size.y);
 	}
@@ -859,10 +864,15 @@ public class LineNumberRulerColumn implements IVerticalRulerColumn {
 		boolean isWrapActive= fCachedTextWidget.getWordWrap();
 
 		int lastLine= end(visibleLines);
+		int widgetLineCount= fCachedTextWidget.getLineCount();
 		for (int line= visibleLines.getStartLine(); line < lastLine; line++) {
 			int widgetLine= JFaceTextUtil.modelLineToWidgetLine(fCachedTextViewer, line);
 			if (widgetLine == -1) {
 				continue;
+			}
+			if (widgetLine >= widgetLineCount) {
+				// the range predates a document change that removed these lines
+				break;
 			}
 
 			final int offsetAtLine= fCachedTextWidget.getOffsetAtLine(widgetLine);

--- a/tests/org.eclipse.jface.text.tests/src/org/eclipse/jface/text/tests/source/LineNumberRulerColumnTest.java
+++ b/tests/org.eclipse.jface.text.tests/src/org/eclipse/jface/text/tests/source/LineNumberRulerColumnTest.java
@@ -13,16 +13,26 @@
  *******************************************************************************/
 package org.eclipse.jface.text.tests.source;
 
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import org.eclipse.swt.SWT;
+import org.eclipse.swt.graphics.GC;
+import org.eclipse.swt.layout.FillLayout;
 import org.eclipse.swt.widgets.Shell;
 
+import org.eclipse.text.tests.Accessor;
+
+import org.eclipse.jface.text.Document;
+import org.eclipse.jface.text.JFaceTextUtil;
 import org.eclipse.jface.text.source.CompositeRuler;
+import org.eclipse.jface.text.source.ILineRange;
 import org.eclipse.jface.text.source.LineNumberRulerColumn;
 import org.eclipse.jface.text.source.SourceViewer;
+import org.eclipse.jface.text.source.projection.ProjectionViewer;
 
 public class LineNumberRulerColumnTest {
 
@@ -49,6 +59,46 @@ public class LineNumberRulerColumnTest {
 		sourceViewer.getTextWidget().dispose();
 
 		lineNumberRulerColumn.redraw();
+	}
+
+	/**
+	 * Painting a line range that outlived a document shrink must not ask the widget for lines it
+	 * no longer has.
+	 */
+	@Test
+	public void testPaintStaleRangeAfterDocumentShrank() {
+		LineNumberRulerColumn lineNumberRulerColumn= new LineNumberRulerColumn();
+		CompositeRuler ruler= new CompositeRuler();
+		ruler.addDecorator(0, lineNumberRulerColumn);
+		fParent.setLayout(new FillLayout());
+		ProjectionViewer viewer= new ProjectionViewer(fParent, ruler, null, false, SWT.V_SCROLL) {
+			@Override
+			public int modelLine2WidgetLine(int modelLine) {
+				// a mapping that still knows the lines the widget has already lost
+				return modelLine;
+			}
+		};
+		Document document= new Document("line\n".repeat(200));
+		viewer.setDocument(document);
+		fParent.setSize(300, 200);
+		fParent.open();
+		fParent.layout(true, true);
+		viewer.getTextWidget().setTopIndex(150);
+
+		Accessor accessor= new Accessor(lineNumberRulerColumn, LineNumberRulerColumn.class);
+		GC gc= new GC(lineNumberRulerColumn.getControl());
+		try {
+			accessor.invoke("doubleBufferPaint", new Class<?>[] { GC.class }, gc);
+			assertNotNull(accessor.get("fBuffer"));
+			ILineRange staleRange= JFaceTextUtil.getVisibleModelLines(viewer);
+
+			document.set("line\n".repeat(3));
+
+			// what the buffer's drawer does when SWT runs it again now
+			accessor.invoke("doPaint", new Class<?>[] { GC.class, ILineRange.class }, gc, staleRange);
+		} finally {
+			gc.dispose();
+		}
 	}
 
 }


### PR DESCRIPTION
The line number ruler keeps its paint buffer as an image whose drawer captured the visible line range at creation time. SWT runs that drawer again whenever it needs the image at a zoom it has not rendered yet, which on GTK at 200 percent is every paint. Once lines were removed, a projection viewer can still map such a stale line to a widget line that no longer exists, and StyledText.getOffsetAtLine throws `IllegalArgumentException: Index out of bounds` inside the paint listener. The Error Log records it as "Unhandled event loop exception" on every repaint and the column is left blank.

The drawer now asks the viewer for the visible lines when it runs, and doPaint stops at the widget's last line. A test with a projection viewer whose mapping outlives a document shrink reproduces the exception without the fix.