### PR TITLE
[WIP] Wake the startup event loop with queued work instead of display.wake()

### DIFF
--- a/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/application/WorkbenchAdvisor.java
+++ b/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/application/WorkbenchAdvisor.java
@@ -713,13 +713,7 @@ public abstract class WorkbenchAdvisor {
 		final Display display = PlatformUI.getWorkbench().getDisplay();
 		final boolean result[] = new boolean[1];
 
-		// spawn another init thread. For API compatibility We guarantee this method is
-		// called from
-		// the UI thread but it could take enough time to disrupt progress reporting.
-		// spawn a new thread to do the grunt work of this initialization and spin the
-		// event loop
-		// ourselves just like it's done in Workbench.
-
+		// Restore off the UI thread and spin the event loop here, it can take a while.
 		final Throwable[] error = new Throwable[1];
 		Thread initThread = new Thread() {
 			@Override
@@ -752,13 +746,14 @@ public abstract class WorkbenchAdvisor {
 					error[0] = e;
 				} finally {
 					initDone = true;
-					Thread.yield();
-					try {
-						Thread.sleep(5);
-					} catch (InterruptedException e) {
-						// this is a no-op in this case.
-					}
-					display.wake();
+					// A wake() before the UI thread reaches Display.sleep() is lost, queued
+					// work is not. Plain runnables would be deferred until the workbench is up.
+					display.asyncExec(new StartupRunnable() {
+						@Override
+						public void runWithException() {
+							// nothing to do
+						}
+					});
 				}
 			}
 		};


### PR DESCRIPTION
`WorkbenchAdvisor.openWindows()` restores the workbench state on a separate thread while the UI thread spins the event loop. A `display.wake()` sent before the UI thread reaches `Display.sleep()` is dropped, which bug 429363 papered over with a 5 ms sleep in the init thread. Queuing an empty `StartupRunnable` closes that race instead of narrowing it, because `Display.sleep()` returns immediately when the synchronizer has pending messages, on gtk, win32 and cocoa alike. It has to be a `StartupRunnable`, since `UISynchronizer` defers plain runnables until the workbench is up.

This path runs on every IDE start, `IDEWorkbenchAdvisor` does not override `openWindows()`, so it also saves the 5 ms. Draft because the lost wakeup is timing dependent and no test reproduces it, so the reasoning is what needs a second pair of eyes.