### PR TITLE
Retitle the shutdown progress dialog and drop its info icon

### DIFF
--- a/bundles/org.eclipse.ui.ide.application/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.ui.ide.application/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Plugin.name
 Bundle-SymbolicName: org.eclipse.ui.ide.application;singleton:=true
-Bundle-Version: 1.6.200.qualifier
+Bundle-Version: 1.6.300.qualifier
 Bundle-Vendor: %Plugin.providerName
 Bundle-Localization: plugin
 Require-Bundle: org.eclipse.ui.ide;bundle-version="[3.21.0,4.0.0)",

--- a/bundles/org.eclipse.ui.ide.application/src/org/eclipse/ui/internal/ide/application/IDEWorkbenchAdvisor.java
+++ b/bundles/org.eclipse.ui.ide.application/src/org/eclipse/ui/internal/ide/application/IDEWorkbenchAdvisor.java
@@ -58,6 +58,7 @@ import org.eclipse.jface.util.Policy;
 import org.eclipse.jface.window.Window;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.custom.BusyIndicator;
+import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.graphics.Resource;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Listener;
@@ -485,7 +486,18 @@ public class IDEWorkbenchAdvisor extends WorkbenchAdvisor {
 		final MultiStatus status = new MultiStatus(IDEWorkbenchPlugin.IDE_WORKBENCH, 1,
 				IDEWorkbenchMessages.ProblemSavingWorkbench);
 
-		final ProgressMonitorJobsDialog dialog = new ProgressMonitorJobsDialog(null);
+		final ProgressMonitorJobsDialog dialog = new ProgressMonitorJobsDialog(null) {
+			@Override
+			protected void configureShell(Shell shell) {
+				super.configureShell(shell);
+				shell.setText(IDEWorkbenchMessages.ShutdownInProgress);
+			}
+
+			@Override
+			protected Image getImage() {
+				return null;
+			}
+		};
 		dialog.setOpenOnRun(false);
 
 		IRunnableWithProgress runnable = monitor -> {

--- a/bundles/org.eclipse.ui.ide/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.ui.ide/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Plugin.name
 Bundle-SymbolicName: org.eclipse.ui.ide; singleton:=true
-Bundle-Version: 3.23.200.qualifier
+Bundle-Version: 3.23.300.qualifier
 Bundle-Activator: org.eclipse.ui.internal.ide.IDEWorkbenchPlugin
 Bundle-ActivationPolicy: lazy
 Bundle-Vendor: %Plugin.providerName

--- a/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/ide/IDEWorkbenchMessages.java
+++ b/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/ide/IDEWorkbenchMessages.java
@@ -946,6 +946,7 @@ public class IDEWorkbenchMessages extends NLS {
 
 	public static String ProblemSavingWorkbench;
 	public static String ProblemsSavingWorkspace;
+	public static String ShutdownInProgress;
 
 	public static String Problems_Opening_Page;
 

--- a/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/ide/messages.properties
+++ b/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/ide/messages.properties
@@ -965,6 +965,7 @@ FatalError = {0}\nYou are recommended to exit the workbench.\nSubsequent errors 
 
 ProblemSavingWorkbench = Problems occurred while trying to save the state of the workbench.
 ProblemsSavingWorkspace = Problems saving workspace
+ShutdownInProgress = Shutdown in progress
 
 Problems_Opening_Page = Problems Opening Page
 


### PR DESCRIPTION
The progress dialog shown while the workspace is saved on shutdown used the generic "Progress Information" title and the big info icon, which looks misplaced in custom themes. The dialog now uses "Shutdown in progress" as its title and no icon, while the message area keeps showing the task and any blocked reason as before.

Fixes #4299
