### PR TITLE
Let idle reconciler workers wait without a timeout

### DIFF
--- a/bundles/org.eclipse.jface.text/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.jface.text/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.jface.text
-Bundle-Version: 3.31.200.qualifier
+Bundle-Version: 3.32.0.qualifier
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Export-Package: 

--- a/bundles/org.eclipse.jface.text/src/org/eclipse/jface/text/reconciler/AbstractReconciler.java
+++ b/bundles/org.eclipse.jface.text/src/org/eclipse/jface/text/reconciler/AbstractReconciler.java
@@ -13,6 +13,9 @@
  *******************************************************************************/
 package org.eclipse.jface.text.reconciler;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.eclipse.core.runtime.Assert;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
@@ -61,8 +64,8 @@ abstract public class AbstractReconciler implements IReconciler {
 	 */
 	class BackgroundWorker implements Runnable {
 
-		/** Has the reconciler been canceled. */
-		private boolean fCanceled;
+		/** Has the reconciler been canceled. Set under this worker's lock. */
+		private volatile boolean fCanceled;
 		/** Has the reconciler been reset. */
 		private boolean fReset;
 		/** Some changes need to be processed. */
@@ -71,6 +74,10 @@ abstract public class AbstractReconciler implements IReconciler {
 		private boolean fIsActive;
 
 		private boolean fStarted;
+
+		private volatile boolean fInitialProcessDone;
+		/** Is initialProcess() or process() running. */
+		private volatile boolean fIsProcessing;
 
 		private final String fName;
 
@@ -105,7 +112,9 @@ abstract public class AbstractReconciler implements IReconciler {
 		 * Cancels the background thread.
 		 */
 		public void cancel() {
-			fCanceled= true;
+			synchronized (this) {
+				fCanceled= true;
+			}
 			IProgressMonitor pm= fProgressMonitor;
 			if (pm != null) {
 				pm.setCanceled(true);
@@ -173,7 +182,7 @@ abstract public class AbstractReconciler implements IReconciler {
 			try {
 				while (!fCanceled) {
 
-					delay();
+					waitForWork();
 
 					if (fCanceled) {
 						break;
@@ -196,11 +205,18 @@ abstract public class AbstractReconciler implements IReconciler {
 						r= fDirtyRegionQueue.removeNextDirtyRegion();
 					}
 
+					if (!startProcessing()) {
+						break;
+					}
 					fIsActive= true;
 
 					fProgressMonitor.setCanceled(false);
 
-					process(r);
+					try {
+						process(r);
+					} finally {
+						fIsProcessing= false;
+					}
 
 					synchronized (fDirtyRegionQueue) {
 						if (fDirtyRegionQueue.isEmpty()) {
@@ -222,6 +238,48 @@ abstract public class AbstractReconciler implements IReconciler {
 		}
 
 		/**
+		 * Marks this worker as processing unless it has been canceled, atomically with
+		 * {@link #cancel()} so that a worker reported idle never starts a strategy afterwards.
+		 */
+		private synchronized boolean startProcessing() {
+			if (fCanceled) {
+				return false;
+			}
+			fIsProcessing= true;
+			return true;
+		}
+
+		synchronized boolean isIdle() {
+			if (fCanceled) {
+				return !fIsProcessing;
+			}
+			if (fStarted && !fInitialProcessDone) {
+				return false;
+			}
+			return !isDirty() && !fIsProcessing;
+		}
+
+		/**
+		 * Blocks until there is work. Idle workers wait untimed, dirty workers wait for the delay so
+		 * further changes coalesce.
+		 */
+		private void waitForWork() {
+			synchronized (fDirtyRegionQueue) {
+				if (waitFinish || fCanceled) {
+					return;
+				}
+				try {
+					if (isDirty()) {
+						fDirtyRegionQueue.wait(fDelay);
+					} else {
+						fDirtyRegionQueue.wait();
+					}
+				} catch (InterruptedException x) {
+				}
+			}
+		}
+
+		/**
 		 * Star the reconciling if not running (and calls
 		 * {@link AbstractReconciler#initialProcess()}) or {@link #reset()} otherwise.
 		 */
@@ -233,10 +291,15 @@ abstract public class AbstractReconciler implements IReconciler {
 					//Until we process some code from the job, the reconciler thread is the current thread
 					fThread= Thread.currentThread();
 					delay();
-					if (fCanceled) {
+					if (!startProcessing()) {
 						return Status.CANCEL_STATUS;
 					}
-					initialProcess();
+					try {
+						initialProcess();
+					} finally {
+						fIsProcessing= false;
+					}
+					fInitialProcessDone= true;
 					if (fCanceled) {
 						return Status.CANCEL_STATUS;
 					}
@@ -341,6 +404,8 @@ abstract public class AbstractReconciler implements IReconciler {
 	private DirtyRegionQueue fDirtyRegionQueue;
 	/** The background thread. */
 	private BackgroundWorker fWorker;
+	/** Workers canceled by uninstall() whose strategy may still be running. */
+	private final List<BackgroundWorker> fCanceledWorkers= new ArrayList<>();
 	/** Internal document and text input listener. */
 	private Listener fListener;
 	/** The background thread delay. */
@@ -529,6 +594,8 @@ abstract public class AbstractReconciler implements IReconciler {
 				BackgroundWorker bt= fWorker;
 				fWorker= null;
 				bt.cancel();
+				fCanceledWorkers.removeIf(BackgroundWorker::isIdle);
+				fCanceledWorkers.add(bt);
 			}
 		}
 	}
@@ -680,6 +747,19 @@ abstract public class AbstractReconciler implements IReconciler {
 			return false;
 		}
 		return Thread.currentThread() == fWorker.fThread;
+	}
+
+	/**
+	 * Tells whether this reconciler has nothing to do: no initial process is pending or running,
+	 * no changes wait to be processed and no strategy is running. A reconciler without a document
+	 * is idle. Lets tests wait for the reconciler.
+	 *
+	 * @return <code>true</code> if this reconciler is idle
+	 * @since 3.32
+	 */
+	public synchronized boolean isIdle() {
+		fCanceledWorkers.removeIf(BackgroundWorker::isIdle);
+		return fCanceledWorkers.isEmpty() && (fWorker == null || fWorker.isIdle());
 	}
 
 	private static class ReconcilerJob extends Job {

--- a/tests/org.eclipse.jface.text.tests/src/org/eclipse/jface/text/tests/reconciler/AbstractReconcilerTest.java
+++ b/tests/org.eclipse.jface.text.tests/src/org/eclipse/jface/text/tests/reconciler/AbstractReconcilerTest.java
@@ -28,6 +28,7 @@ import org.junit.jupiter.api.Test;
 
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.NullProgressMonitor;
+import org.eclipse.core.runtime.jobs.Job;
 
 import org.eclipse.text.tests.Accessor;
 
@@ -35,6 +36,7 @@ import org.eclipse.jface.text.BadLocationException;
 import org.eclipse.jface.text.Document;
 import org.eclipse.jface.text.IDocument;
 import org.eclipse.jface.text.ITextViewer;
+import org.eclipse.jface.internal.text.reconciler.ReconcilerJobFamilies;
 import org.eclipse.jface.text.reconciler.AbstractReconciler;
 import org.eclipse.jface.text.reconciler.DirtyRegion;
 import org.eclipse.jface.text.reconciler.IReconcilingStrategy;
@@ -367,6 +369,104 @@ public class AbstractReconcilerTest {
 //		fBarrier.await();
 //		assertEquals("process", fCallLog.remove(0));
 //		fBarrier.wakeAll();
+	}
+
+	@Test
+	public void testIdleWorkerWaitsWithoutTimeout() throws InterruptedException {
+		installDocument();
+		Thread thread= workerThread();
+
+		// a timed wait would show up as TIMED_WAITING, i.e. the worker wakes up periodically for nothing
+		long start= System.currentTimeMillis();
+		while (thread.getState() != Thread.State.WAITING) {
+			if (System.currentTimeMillis() > start + 5000)
+				fail("idle reconciler thread is " + thread.getState() + " instead of WAITING");
+			Thread.sleep(10);
+		}
+	}
+
+	@Test
+	public void testUninstallStopsIdleWorker() throws InterruptedException {
+		installDocument();
+		Thread thread= workerThread();
+		assertTrue(thread.isAlive());
+
+		fReconciler.uninstall();
+		thread.join(5000);
+		assertFalse(thread.isAlive());
+	}
+
+	@Test
+	public void testIsIdle() throws InterruptedException, BadLocationException {
+		assertTrue(fReconciler.isIdle());
+
+		fDocument= new Document("foo");
+		fViewer.setDocument(fDocument);
+		assertFalse(fReconciler.isIdle()); // initial process pending
+		fBarrier.await();
+		assertFalse(fReconciler.isIdle()); // initial process running
+		fBarrier.wakeAll();
+		pollUntilIdle();
+
+		dirty();
+		assertFalse(fReconciler.isIdle()); // change queued
+		fBarrier.await();
+		assertFalse(fReconciler.isIdle()); // process running
+		fBarrier.wakeAll();
+		pollUntilIdle();
+
+		fReconciler.uninstall();
+		assertTrue(fReconciler.isIdle());
+	}
+
+	@Test
+	public void testIsIdleAfterUninstallWhileProcessing() throws InterruptedException, BadLocationException {
+		installDocument();
+		dirty();
+		fBarrier.await();
+		fReconciler.uninstall();
+		assertFalse(fReconciler.isIdle()); // the canceled worker is still inside process()
+		fBarrier.wakeAll();
+		pollUntilIdle();
+	}
+
+	@Test
+	public void testIsIdleAfterUninstallWhileInitialProcessing() throws InterruptedException {
+		fDocument= new Document("foo");
+		fViewer.setDocument(fDocument);
+		fBarrier.await();
+		fReconciler.uninstall();
+		assertFalse(fReconciler.isIdle()); // the canceled worker is still inside initialProcess()
+		fBarrier.wakeAll();
+		pollUntilIdle();
+	}
+
+	@Test
+	public void testIsIdleTracksEveryCanceledWorker() throws InterruptedException, BadLocationException {
+		installDocument();
+		dirty();
+		fBarrier.await();
+		fReconciler.uninstall();
+		fReconciler.install(fViewer);
+		fReconciler.uninstall();
+		assertFalse(fReconciler.isIdle()); // the first worker is still inside process()
+		fBarrier.wakeAll();
+		pollUntilIdle();
+	}
+
+	void pollUntilIdle() throws InterruptedException {
+		long start= System.currentTimeMillis();
+		while (!fReconciler.isIdle()) {
+			if (System.currentTimeMillis() > start + 5000)
+				fail("waited > 5s for reconciler to become idle");
+			Thread.sleep(10);
+		}
+	}
+
+	/** The startup job hands over to the worker thread only once it is done. */
+	Thread workerThread() throws InterruptedException {
+		Job.getJobManager().join(ReconcilerJobFamilies.FAMILY_RECONCILER, null);
+		return (Thread) fAccessor.get("fThread");
 	}
 
 	void installDocument() throws InterruptedException {


### PR DESCRIPTION
The background worker of AbstractReconciler used the same timed wait for idling as for debouncing edits, so every open text editor woke its reconciler thread twice a second with nothing to do. The worker now waits untimed while it is clean and keeps the timed wait only after a change, where it lets further edits coalesce; the startup job keeps its initial delay, and the dirty and canceled checks sit under the queue lock that reset() and cancel() notify on, so no wake-up can be lost.

Measured with 100 installed idle reconcilers over 10 seconds, the worker threads went from 2000 voluntary context switches and 55 ms of CPU time to none, while the edit-to-process latency stayed at the configured 500 ms delay.

The steady state also becomes observable from outside: the new AbstractReconciler#isIdle() reports whether the initial process has run, no change waits and no strategy is active. The reconciler job family only covers startup, so tests (JDT's EditorTestHelper among them) so far reflected into BackgroundWorker for this. Three tests cover the change: an idle worker must be in WAITING rather than TIMED_WAITING, uninstalling an idle reconciler must end its thread, and isIdle() must flip at each stage from startup to uninstall.