### PR TITLE
Keep marker attribute access off the UI thread in the markers view

### DIFF
--- a/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/views/markers/ExtendedMarkersView.java
+++ b/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/views/markers/ExtendedMarkersView.java
@@ -167,6 +167,9 @@ public class ExtendedMarkersView extends ViewPart {
 	 */
 	private static final String TAG_SHOW_FILTER_TEXT = "showFilterText"; //$NON-NLS-1$
 
+	private static final MessageFormat SUMMARY_BREAKDOWN = new MessageFormat(
+			MarkerMessages.errorsAndWarningsSummaryBreakdown);
+
 	private final IMarker[] noMarkers = new IMarker[0];
 
 	private MarkerContentGenerator generator;
@@ -973,9 +976,7 @@ public class ExtendedMarkersView extends ViewPart {
 			}
 			return status;
 		}
-		String message= MessageFormat.format(
-				MarkerMessages.errorsAndWarningsSummaryBreakdown,
-				counts[0], counts[1], /* combine infos and others */ counts[2] + counts[3]);
+		String message = formatSummaryBreakdown(counts);
 		if (filteredCount < 0 || filteredCount >= totalCount) {
 			return message;
 		}
@@ -1506,8 +1507,15 @@ public class ExtendedMarkersView extends ViewPart {
 		}
 		return MessageFormat.format(MarkerMessages.marker_statusSummarySelected, entries.length,
 				/* combine infos and others */
-				MessageFormat.format(MarkerMessages.errorsAndWarningsSummaryBreakdown, counts[0], counts[1],
-						counts[2] + counts[3]));
+				formatSummaryBreakdown(counts));
+	}
+
+	/**
+	 * Formats the "n errors, n warnings, n others" summary; the parsed pattern is
+	 * reused since it is needed on every update.
+	 */
+	private static String formatSummaryBreakdown(Integer[] counts) {
+		return SUMMARY_BREAKDOWN.format(new Object[] { counts[0], counts[1], counts[2] + counts[3] });
 	}
 
 	/**

--- a/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/views/markers/MarkerEntry.java
+++ b/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/views/markers/MarkerEntry.java
@@ -70,7 +70,11 @@ class MarkerEntry extends MarkerSupportItem implements IAdaptable {
 	private static final Object CACHED_NULL = new String("CACHED_NULL"); //$NON-NLS-1$
 	private MarkerCategory category;
 	private final Map<String, Object> cache = new ConcurrentHashMap<>();
+	// RuleBasedCollator.getCollationKey is synchronized, so one shared instance is safe.
+	private static final Collator COLLATOR = Collator.getInstance();
+	// Previous update's keys are kept for one round; only the update job touches these.
 	private static Map<String, CollationKey> collationCache = new ConcurrentHashMap<>();
+	private static Map<String, CollationKey> previousCollationCache = new ConcurrentHashMap<>();
 
 	/**
 	 * Set the MarkerEntry to be stale, if discovered at any point of time
@@ -207,9 +211,10 @@ class MarkerEntry extends MarkerSupportItem implements IAdaptable {
 		if (attributeValue.isEmpty()) {
 			return MarkerSupportInternalUtilities.EMPTY_COLLATION_KEY;
 		}
-		CollationKey key = collationCache.computeIfAbsent(attributeValue,
-				k -> Collator.getInstance().getCollationKey(attributeValue));
-		return key;
+		return collationCache.computeIfAbsent(attributeValue, k -> {
+			CollationKey previous = previousCollationCache.get(k);
+			return previous != null ? previous : COLLATOR.getCollationKey(k);
+		});
 	}
 
 	@Override
@@ -366,6 +371,7 @@ class MarkerEntry extends MarkerSupportItem implements IAdaptable {
 	}
 
 	static void clearCollationCache() {
+		previousCollationCache = collationCache;
 		collationCache = new ConcurrentHashMap<>();
 	}
 

--- a/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/views/markers/MarkerSortUtil.java
+++ b/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/views/markers/MarkerSortUtil.java
@@ -103,7 +103,6 @@ public class MarkerSortUtil {
 
 			++current;
 		}
-		MarkerEntry.clearCollationCache();
 	}
 
 	/**
@@ -289,7 +288,6 @@ public class MarkerSortUtil {
 			for (int i = from; i <= to; i++) {
 				entries[i].clearCache();
 			}
-			MarkerEntry.clearCollationCache();
 			return;
 		}
 

--- a/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/views/markers/Markers.java
+++ b/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/views/markers/Markers.java
@@ -59,7 +59,7 @@ class Markers {
 	// markerToEntryMap is a lazily created map from the markers to thier
 	// corresponding entry
 	private Map<IMarker, MarkerEntry> markerToEntryMap;
-	private Integer[] markerCounts;
+	private volatile Integer[] markerCounts;
 
 	Markers(CachedMarkerBuilder builder) {
 		this.builder = builder;
@@ -94,6 +94,8 @@ class Markers {
 			MarkerEntry[] markerArray = new MarkerEntry[markerEntries.size()];
 			markerEntries.toArray(markerArray);
 			markerEntryArray = markerArray;
+			// Count here, off the UI thread; this also primes the severity cache for the sort.
+			markerCounts = getMarkerCounts(markerArray);
 			if (sortAndGroup) {
 				if (monitor.isCanceled()) {
 					return false;
@@ -189,6 +191,9 @@ class Markers {
 			return false;
 		} finally {
 			inChange = initialVal;
+			// Rotate once per complete sort, not per category, so the previous
+			// update's keys are still there for every category of the next one.
+			MarkerEntry.clearCollationCache();
 		}
 	}
 
@@ -304,17 +309,7 @@ class Markers {
 	static Integer[] getMarkerCounts(MarkerEntry[] entries) {
 		int[] ints = new int[] { 0, 0, 0, 0 };
 		for (MarkerEntry entry : entries) {
-			IMarker marker = entry.getMarker();
-			int severity = -1;
-			Object value = null;
-			try {
-				value = marker.getAttribute(IMarker.SEVERITY);
-			} catch (CoreException e) {
-				entry.checkIfMarkerStale();
-			}
-			if (value instanceof Integer) {
-				severity = ((Integer) value).intValue();
-			}
+			int severity = entry.getAttributeValue(IMarker.SEVERITY) instanceof Integer value ? value.intValue() : -1;
 			if (severity >= IMarker.SEVERITY_INFO) {
 				ints[severity]++;
 			} else {
@@ -381,6 +376,7 @@ class Markers {
 		if (!inChange) {
 			markers.markerEntryArray = markerEntryArray.clone();
 			markers.categories = categories.clone();
+			markers.markerCounts = markerCounts;
 		}
 		return markers;
 	}


### PR DESCRIPTION
Profiling a Problems view rebuild (3350 markers, full build of `org.eclipse.jface` as the marker churn, in-IDE sampler plus JFR) showed three avoidable costs. The severity counts for the view title were computed on the UI thread by calling `IMarker.getAttribute` again for every entry, which throws a `ResourceException` for each marker deleted since the gather; they are now computed on the update job and carried into the clone. Collation keys for sorting were recomputed after every update with a fresh `Collator` per cache miss; one `Collator` is shared and the previous update's keys are kept for one round. The summary message pattern was re-parsed by `MessageFormat` on every title update and is now parsed once.

Measured before and after with the same workload, from the two JFR recordings:

| metric | before | after |
|---|---|---|
| exceptions thrown through `views.markers` code | 54 (`ResourceException` plus wrapped `IllegalStateException` from `Markers.getMarkerCounts` on the UI thread, `IllegalArgumentException` inside `MessageFormat`) | 0 |
| exception stacks containing `UIUpdateJob.runInUIThread` | 41 | 0 |
| allocation samples in `MarkerEntry.getCollationKey` | 96 (largest allocator of the view, about 14 MB weighted) | 0 |
| execution samples in `MarkerUpdateJob.run` | 30 | 7 |

The last row is not a like-for-like speedup: the dependent auto-build ran 53 s in the baseline and 17 s in the second run, so fewer marker updates happened. The exception and collation rows are per-update effects and hold regardless. The markers view is a small share of a rebuild overall; the point of the change is that the UI thread no longer touches marker attributes or throws for stale markers during builds.