### PR TITLE
Index marker subtypes and look up listened marker types in a set

### DIFF
--- a/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/views/markers/MarkersChangeListener.java
+++ b/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/views/markers/MarkersChangeListener.java
@@ -14,6 +14,10 @@
 
 package org.eclipse.ui.internal.views.markers;
 
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
 import org.eclipse.core.resources.IMarkerDelta;
 import org.eclipse.core.resources.IResourceChangeEvent;
 import org.eclipse.core.resources.IResourceChangeListener;
@@ -32,7 +36,7 @@ class MarkersChangeListener implements IResourceChangeListener {
 	private final ExtendedMarkersView view;
 	private final CachedMarkerBuilder builder;
 
-	private String[] listeningTypes;
+	private volatile Set<String> listeningTypes;
 	private boolean receiving;
 
 	// The time the build started. A -1 indicates no build in progress.
@@ -48,7 +52,7 @@ class MarkersChangeListener implements IResourceChangeListener {
 	MarkersChangeListener(ExtendedMarkersView view, CachedMarkerBuilder builder) {
 		this.view = view;
 		this.builder = builder;
-		listeningTypes = new String[0];
+		listeningTypes = Set.of();
 	}
 
 	/**
@@ -66,9 +70,7 @@ class MarkersChangeListener implements IResourceChangeListener {
 	 * Stop listening for changes.
 	 */
 	synchronized void stop() {
-		if (listeningTypes != null) {
-			listeningTypes = new String[0];
-		}
+		listeningTypes = Set.of();
 		ResourcesPlugin.getWorkspace().removeResourceChangeListener(this);
 	}
 
@@ -92,11 +94,9 @@ class MarkersChangeListener implements IResourceChangeListener {
 		try {
 			// register marker types being gathering
 			if (includeSubTypes) {
-				listeningTypes = MarkerResourceUtil.getAllSubTypesIds(typeIds);
-			} else {
-				// register marker types being gathering
-				listeningTypes = typeIds;
+				typeIds = MarkerResourceUtil.getAllSubTypesIds(typeIds);
 			}
+			listeningTypes = new HashSet<>(Arrays.asList(typeIds));
 		} catch (Exception e) {
 			MarkerSupportInternalUtilities.logViewError(e);
 		}
@@ -151,24 +151,12 @@ class MarkersChangeListener implements IResourceChangeListener {
 	 */
 	private boolean hasApplicableTypes(IResourceChangeEvent event) {
 		IMarkerDelta[] markerDeltas = event.findMarkerDeltas(null, true);
-		String[] types = listeningTypes;
-		if (types.length == 0) {
+		Set<String> types = listeningTypes;
+		if (types.isEmpty()) {
 			return false;
 		}
 		for (IMarkerDelta markerDelta : markerDeltas) {
-			if (isApplicableType(types, markerDelta.getType())) {
-				return true;
-			}
-		}
-		return false;
-	}
-
-	/**
-	 * Helper to {@link #hasApplicableTypes(IResourceChangeEvent)}
-	 */
-	private boolean isApplicableType(String[] types, String typeId) {
-		for (String type : types) {
-			if (type.equals(typeId)) {
+			if (types.contains(markerDelta.getType())) {
 				return true;
 			}
 		}

--- a/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/views/markers/internal/MarkerType.java
+++ b/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/views/markers/internal/MarkerType.java
@@ -15,7 +15,8 @@
 package org.eclipse.ui.views.markers.internal;
 
 import java.util.ArrayList;
-import java.util.List;
+import java.util.LinkedHashSet;
+import java.util.Set;
 
 /**
  * Represents a marker type.
@@ -82,35 +83,26 @@ public class MarkerType {
 	 * @return the direct subtypes of this type
 	 */
 	public MarkerType[] getSubtypes() {
-		MarkerType[] types = model.getTypes();
-		ArrayList<MarkerType> result = new ArrayList<>();
-		for (MarkerType type : types) {
-			for (String supertypeId : type.getSupertypeIds()) {
-				if (supertypeId.equals(id)) {
-					result.add(type);
-				}
-			}
-		}
-		return result.toArray(new MarkerType[result.size()]);
+		return model.getSubtypes(id).toArray(new MarkerType[0]);
 	}
 
 	/**
 	 * @return never null
 	 */
 	public MarkerType[] getAllSubTypes() {
-		List<MarkerType> subTypes = new ArrayList<>();
+		Set<MarkerType> subTypes = new LinkedHashSet<>();
+		// seed with this type so a supertype cycle cannot list it as its own subtype
+		subTypes.add(this);
 		addSubTypes(subTypes, this);
-		MarkerType[] subs = new MarkerType[subTypes.size()];
-		subTypes.toArray(subs);
-		return subs;
+		subTypes.remove(this);
+		return subTypes.toArray(new MarkerType[0]);
 	}
 
-	private void addSubTypes(List<MarkerType> list, MarkerType superType) {
-		for (MarkerType subType : superType.getSubtypes()) {
-			if (!list.contains(subType)) {
-				list.add(subType);
+	private void addSubTypes(Set<MarkerType> set, MarkerType superType) {
+		for (MarkerType subType : model.getSubtypes(superType.id)) {
+			if (set.add(subType)) {
+				addSubTypes(set, subType);
 			}
-			addSubTypes(list, subType);
 		}
 	}
 

--- a/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/views/markers/internal/MarkerTypesModel.java
+++ b/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/views/markers/internal/MarkerTypesModel.java
@@ -16,6 +16,8 @@ package org.eclipse.ui.views.markers.internal;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 import org.eclipse.core.resources.IMarker;
 import org.eclipse.core.resources.ResourcesPlugin;
@@ -48,11 +50,19 @@ public class MarkerTypesModel {
 	 */
 	private final HashMap<String, MarkerType> types;
 
+	// marker type id to its direct subtypes
+	private final Map<String, List<MarkerType>> subtypes = new HashMap<>();
+
 	/**
 	 * Creates a new marker types model.
 	 */
 	private MarkerTypesModel() {
 		types = readTypes();
+		for (MarkerType type : types.values()) {
+			for (String supertypeId : type.getSupertypeIds()) {
+				subtypes.computeIfAbsent(supertypeId, id -> new ArrayList<>()).add(type);
+			}
+		}
 	}
 
 	/**
@@ -70,6 +80,13 @@ public class MarkerTypesModel {
 		MarkerType[] result = new MarkerType[types.size()];
 		types.values().toArray(result);
 		return result;
+	}
+
+	/**
+	 * Returns the direct subtypes of the given type, never null.
+	 */
+	List<MarkerType> getSubtypes(String id) {
+		return subtypes.getOrDefault(id, List.of());
 	}
 
 	/**


### PR DESCRIPTION
Follow-up from profiling the Problems view rebuild in #4304. `MarkerType.getSubtypes` scanned every registered marker type on each call and `getAllSubTypes` recursed into types it had already collected, so the subtype closure cost grew with the number of paths through the type hierarchy; `MarkerTypesModel` now keeps a supertype-to-subtypes index and the closure visits each type once. `MarkersChangeListener` compared every marker delta against an array of listened type ids on the resource change thread; a `Set` turns that into one hash lookup per delta. The absolute saving per update is small (the closure is a few dozen types), the delta matching is the part that scales with the size of a build.