### PR TITLE
Remove the heap status border

### DIFF
--- a/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/HeapStatus.java
+++ b/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/HeapStatus.java
@@ -331,10 +331,19 @@ public class HeapStatus extends Composite {
 		}
 	}
 
-	private static Color blend(Color c1, Color c2) {
-		return new Color(Math.round((c1.getRed() + c2.getRed()) / 2f),
-				Math.round((c1.getGreen() + c2.getGreen()) / 2f),
-				Math.round((c1.getBlue() + c2.getBlue()) / 2f));
+	/** 40% foreground keeps the used-memory bar a light gray on light themes. */
+	private static Color blend(Color fg, Color bg) {
+		return new Color(mix(fg.getRed(), bg.getRed()), mix(fg.getGreen(), bg.getGreen()),
+				mix(fg.getBlue(), bg.getBlue()));
+	}
+
+	private static int mix(int fg, int bg) {
+		return Math.round(bg + (fg - bg) * 0.4f);
+	}
+
+	/** A one pixel separator; drawLine would leave half-covered end pixels. */
+	private static void fillColumn(GC gc, int x, int y, int h) {
+		gc.fillRectangle(x, y + 1, 1, h - 2);
 	}
 
 	private void paintComposite(GC gc) {
@@ -361,10 +370,9 @@ public class HeapStatus extends Composite {
 		Color midCol = blend(fg, bg);
 		gc.setBackground(bg);
 		gc.fillRectangle(rect);
-		gc.setForeground(midCol);
-		gc.drawLine(dx, y, dx, y + h);
-		gc.drawLine(ux, y, ux, y + h);
-		gc.drawRectangle(x, y, w - 1, h - 1);
+		gc.setBackground(midCol);
+		fillColumn(gc, dx, y, h);
+		fillColumn(gc, ux, y, h);
 
 		gc.setBackground(midCol);
 		gc.fillRectangle(x + 1, y + 1, uw, h - 2);
@@ -403,11 +411,10 @@ public class HeapStatus extends Composite {
 		Color midCol = blend(fg, bg);
 		gc.setBackground(bg);
 		gc.fillRectangle(rect);
-		gc.setForeground(midCol);
-		gc.drawLine(dx, y, dx, y + h);
-		gc.drawLine(ux, y, ux, y + h);
-		gc.drawLine(tx, y, tx, y + h);
-		gc.drawRectangle(x, y, w - 1, h - 1);
+		gc.setBackground(midCol);
+		fillColumn(gc, dx, y, h);
+		fillColumn(gc, ux, y, h);
+		fillColumn(gc, tx, y, h);
 
 		if (lowMemThreshold != 0 && ((double) (maxMem - usedMem) / (double) maxMem < lowMemThreshold)) {
 			gc.setBackground(lowMemCol);


### PR DESCRIPTION
Since #4280 the heap status border and used-memory bar are a 50/50 blend of foreground and background, which on the light GTK theme draws a prominent mid-gray frame around the control. Following the discussion in #4306 the border is removed entirely, and the bar and its separators mix 40% foreground into the background, close to the old hardcoded gray. The separators are painted with fillRectangle instead of drawLine, because cairo leaves the end pixels of a 1px line half covered, which showed as lighter corners once the border no longer hid them.

Fixes https://github.com/eclipse-platform/eclipse.platform.ui/issues/4306