### PR TITLE
Relax LargeFileTest marker timing factor #2622

### DIFF
--- a/tests/org.eclipse.ui.editors.tests/src/org/eclipse/ui/editors/tests/LargeFileTest.java
+++ b/tests/org.eclipse.ui.editors.tests/src/org/eclipse/ui/editors/tests/LargeFileTest.java
@@ -130,9 +130,9 @@ public class LargeFileTest {
 		page.closeEditor(part, false);
 		TestUtil.runEventLoop();
 		// Be generous here; all this timing is approximate. Fail if the attempt
-		// with the marker takes more than twice as long. If the OverviewRuler
+		// with the marker takes more than five times as long. If the OverviewRuler
 		// is badly implemented, opening with the marker will take much longer.
-		assertTrue(withMarker[0] / 2 <= baseline[0], "Opening large file took too long: " + (withMarker[0] / 1000000.0f) + "ms with marker vs. "
+		assertTrue(withMarker[0] / 5 <= baseline[0], "Opening large file took too long: " + (withMarker[0] / 1000000.0f) + "ms with marker vs. "
 				+ (baseline[0] / 1000000.0f) + "ms without");
 	}
 }


### PR DESCRIPTION
LargeFileTest.openLargeFileWithAnnotation fails on macOS CI when opening with a marker takes a little over 2x the baseline (about 0.6-1.0s vs 0.3-0.5s). That is machine jitter, not a 15s OverviewRuler freeze.

I widened the relative limit from 2x to 5x so the test still flags a real freeze without flaking.

Fixes #2622
