### PR TITLE
Support relative font sizes and px in the CSS engine

### DIFF
--- a/bundles/org.eclipse.e4.ui.css.core/src/org/eclipse/e4/ui/css/core/css2/CSS2FontHelper.java
+++ b/bundles/org.eclipse.e4.ui.css.core/src/org/eclipse/e4/ui/css/core/css2/CSS2FontHelper.java
@@ -85,7 +85,8 @@ public class CSS2FontHelper {
 			}
 		}
 		if (value instanceof CssNumeric numeric
-				&& (numeric.unit() == CssUnit.PT || numeric.unit() == CssUnit.NUMBER || numeric.unit() == CssUnit.PX)) {
+				&& (numeric.unit() == CssUnit.PT || numeric.unit() == CssUnit.NUMBER || numeric.unit() == CssUnit.PX
+						|| numeric.unit() == CssUnit.EM || numeric.unit() == CssUnit.PERCENT)) {
 			return "font-size";
 		}
 		return null;

--- a/bundles/org.eclipse.e4.ui.css.swt/src/org/eclipse/e4/ui/css/swt/helpers/CSSSWTFontHelper.java
+++ b/bundles/org.eclipse.e4.ui.css.swt/src/org/eclipse/e4/ui/css/swt/helpers/CSSSWTFontHelper.java
@@ -17,12 +17,16 @@ package org.eclipse.e4.ui.css.swt.helpers;
 
 import static org.eclipse.e4.ui.css.swt.helpers.ThemeElementDefinitionHelper.normalizeId;
 
+import java.util.OptionalInt;
+
 import org.eclipse.e4.ui.css.core.css2.CSS2FontHelper;
 import org.eclipse.e4.ui.css.core.css2.CSS2FontPropertiesHelpers;
+import org.eclipse.e4.ui.css.core.impl.dom.CssValues.CssDimension;
 import org.eclipse.e4.ui.css.core.impl.dom.CssValues.CssNumber;
 import org.eclipse.e4.ui.css.core.impl.dom.CssValues.CssNumeric;
 import org.eclipse.e4.ui.css.core.impl.dom.CssValues.CssPrimitive;
 import org.eclipse.e4.ui.css.core.impl.dom.CssValues.CssText;
+import org.eclipse.e4.ui.css.core.impl.dom.CssValues.CssUnit;
 import org.eclipse.e4.ui.css.core.dom.properties.css2.CSS2FontProperties;
 import org.eclipse.e4.ui.css.core.dom.properties.css2.CSS2FontPropertiesImpl;
 import org.eclipse.e4.ui.css.core.engine.CSSElementContext;
@@ -49,6 +53,15 @@ public class CSSSWTFontHelper {
 
 	private static final String DEFAULT_FONT = "defaultFont";
 
+	/** Lower bound so that a small factor cannot shrink a font away. */
+	private static final int MIN_FONT_HEIGHT = 1;
+
+	/** A CSS pixel is 1/96 inch, an SWT font height is 1/72 inch. */
+	private static final double PX_TO_PT = 72d / 96d;
+
+	/** Context key for the font an element had before it was ever styled. */
+	private static final String BASE_FONT_DATA = "org.eclipse.e4.ui.css.swt.baseFontData"; //$NON-NLS-1$
+
 	/**
 	 * Get CSS2FontProperties from Control stored into Data of Control. If
 	 * CSS2FontProperties doesn't exist, create it from Font of Control and
@@ -65,6 +78,7 @@ public class CSSSWTFontHelper {
 			// store into ClientProperty the CSS2FontProperties
 			CSS2FontPropertiesHelpers.setCSS2FontProperties(fontProperties,
 					context);
+			setBaseFontData(context, getFirstFontData(font));
 		}
 		return fontProperties;
 	}
@@ -95,6 +109,7 @@ public class CSSSWTFontHelper {
 			// store into ClientProperty the CSS2FontProperties
 			CSS2FontPropertiesHelpers.setCSS2FontProperties(fontProperties,
 					context);
+			setBaseFontData(context, getFirstFontData(font));
 		}
 		return fontProperties;
 	}
@@ -178,16 +193,16 @@ public class CSSSWTFontHelper {
 		newFontData.setStyle(style);
 
 		// Height
-		CssPrimitive cssFontSize = fontProperties.getSize();
+		OptionalInt cssFontHeight = fontProperties.isSizeFromCSS()
+				? getFontHeight(fontProperties.getSize(), oldFontData)
+				: OptionalInt.empty();
 		boolean fontHeightSet = false;
 
-		if (!(cssFontSize instanceof CssNumeric) || !fontProperties.isSizeFromCSS()) {
-			if (fontDefinitionAsFamily && fontDataByDefinition.length > 0) {
-				newFontData.setHeight(fontDataByDefinition[0].getHeight());
-				fontHeightSet = true;
-			}
-		} else {
-			newFontData.setHeight((int) ((CssNumeric) cssFontSize).value());
+		if (cssFontHeight.isPresent()) {
+			newFontData.setHeight(cssFontHeight.getAsInt());
+			fontHeightSet = true;
+		} else if (fontDefinitionAsFamily && fontDataByDefinition.length > 0) {
+			newFontData.setHeight(fontDataByDefinition[0].getHeight());
 			fontHeightSet = true;
 		}
 		if (!fontHeightSet && oldFontData != null) {
@@ -195,6 +210,85 @@ public class CSSSWTFontHelper {
 		}
 
 		return newFontData;
+	}
+
+	/**
+	 * Resolves a CSS font-size to an SWT font height in points, empty if the value
+	 * cannot be resolved. Relative sizes (em, %) scale the font the widget had
+	 * before styling.
+	 */
+	private static OptionalInt getFontHeight(CssPrimitive cssFontSize, FontData oldFontData) {
+		if (cssFontSize instanceof CssNumeric numeric) {
+			return switch (numeric.unit()) {
+			case EM -> scaleFontHeight(numeric.value(), oldFontData);
+			case PERCENT -> scaleFontHeight(numeric.value() / 100, oldFontData);
+			case PX -> OptionalInt.of(toFontHeight(numeric.value() * PX_TO_PT));
+			// SWT font heights are points, so any other unit is taken as-is
+			default -> OptionalInt.of(toFontHeight(numeric.value()));
+			};
+		}
+		return OptionalInt.empty();
+	}
+
+	private static OptionalInt scaleFontHeight(double factor, FontData oldFontData) {
+		if (oldFontData == null) {
+			return OptionalInt.empty();
+		}
+		return OptionalInt.of(toFontHeight(oldFontData.getHeight() * factor));
+	}
+
+	private static int toFontHeight(double size) {
+		return Math.max(MIN_FONT_HEIGHT, (int) Math.round(size));
+	}
+
+	/**
+	 * Remembers the font an element had before any style was applied to it, the
+	 * base that relative font sizes are resolved against.
+	 */
+	public static void setBaseFontData(CSSElementContext context, FontData fontData) {
+		if (context != null && fontData != null) {
+			context.setData(BASE_FONT_DATA, fontData);
+		}
+	}
+
+	/**
+	 * The font an element had before any style was applied to it, or
+	 * <code>null</code> if it was never recorded.
+	 */
+	public static FontData getBaseFontData(CSSElementContext context) {
+		return context != null && context.getData(BASE_FONT_DATA) instanceof FontData fontData ? fontData : null;
+	}
+
+	/**
+	 * Returns font properties whose size is an absolute point size, resolving a
+	 * relative size against <code>baseFontData</code>. Relative sizes have to be
+	 * resolved before the font is converted, because the converted fonts are
+	 * cached by their CSS values alone and '200%' means a different font for
+	 * every element it is applied to.
+	 */
+	public static CSS2FontProperties resolveRelativeSize(CSS2FontProperties fontProperties, FontData baseFontData) {
+		if (!fontProperties.isSizeFromCSS() || !isRelativeSize(fontProperties.getSize())) {
+			return fontProperties;
+		}
+		OptionalInt height = getFontHeight(fontProperties.getSize(), baseFontData);
+		if (height.isEmpty()) {
+			return fontProperties;
+		}
+		CSS2FontProperties resolved = new CSS2FontPropertiesImpl();
+		resolved.setFamily(fontProperties.getFamily());
+		resolved.setSize(new CssDimension(height.getAsInt(), CssUnit.PT));
+		resolved.setSizeFromCSS(true);
+		resolved.setSizeAdjust(fontProperties.getSizeAdjust());
+		resolved.setWeight(fontProperties.getWeight());
+		resolved.setStyle(fontProperties.getStyle());
+		resolved.setVariant(fontProperties.getVariant());
+		resolved.setStretch(fontProperties.getStretch());
+		return resolved;
+	}
+
+	private static boolean isRelativeSize(CssPrimitive size) {
+		return size instanceof CssNumeric numeric
+				&& (numeric.unit() == CssUnit.EM || numeric.unit() == CssUnit.PERCENT);
 	}
 
 	public static boolean hasFontDefinitionAsFamily(CSSValue value) {

--- a/bundles/org.eclipse.e4.ui.css.swt/src/org/eclipse/e4/ui/css/swt/properties/css2/CSSPropertyFontSWTHandler.java
+++ b/bundles/org.eclipse.e4.ui.css.swt/src/org/eclipse/e4/ui/css/swt/properties/css2/CSSPropertyFontSWTHandler.java
@@ -20,6 +20,7 @@ import org.eclipse.core.runtime.ILog;
 import org.eclipse.e4.ui.css.core.dom.properties.css2.AbstractCSSPropertyFontHandler;
 import org.eclipse.e4.ui.css.core.dom.properties.css2.CSS2FontProperties;
 import org.eclipse.e4.ui.css.core.dom.properties.css2.ICSSPropertyFontHandler;
+import org.eclipse.e4.ui.css.core.engine.CSSElementContext;
 import org.eclipse.e4.ui.css.core.engine.CSSEngine;
 import org.eclipse.e4.ui.css.core.exceptions.UnsupportedPropertyException;
 import org.eclipse.e4.ui.css.swt.dom.ItemElement;
@@ -69,6 +70,15 @@ public class CSSPropertyFontSWTHandler extends AbstractCSSPropertyFontHandler {
 				}
 			}
 		}
+	}
+
+	/**
+	 * Resolves a relative font size against the font the element had before it was
+	 * styled, so that reapplying a style does not scale an already scaled font.
+	 */
+	private static CSS2FontProperties resolveRelativeSize(CSS2FontProperties fontProperties,
+			CSSElementContext context) {
+		return CSSSWTFontHelper.resolveRelativeSize(fontProperties, CSSSWTFontHelper.getBaseFontData(context));
 	}
 
 	private static void updateChildrenFonts(CTabFolder folder, Font font) {
@@ -237,13 +247,12 @@ public class CSSPropertyFontSWTHandler extends AbstractCSSPropertyFontHandler {
 		if (widget == null || widget instanceof CTabItem) {
 			return;
 		}
-		CSS2FontProperties fontProperties = CSSSWTFontHelper
-				.getCSS2FontProperties(widget, engine
-						.getCSSElementContext(widget));
+		CSSElementContext context = engine.getCSSElementContext(widget);
+		CSS2FontProperties fontProperties = CSSSWTFontHelper.getCSS2FontProperties(widget, context);
 		if (fontProperties == null) {
 			return;
 		}
-		Font font = (Font) engine.convert(fontProperties, Font.class, widget);
+		Font font = (Font) engine.convert(resolveRelativeSize(fontProperties, context), Font.class, widget);
 		setFont(widget, font);
 	}
 
@@ -332,7 +341,8 @@ public class CSSPropertyFontSWTHandler extends AbstractCSSPropertyFontHandler {
 
 				try {
 					// set the font
-					Font font = (Font) engine.convert(fontProperties,
+					Font font = (Font) engine.convert(
+							resolveRelativeSize(fontProperties, engine.getCSSElementContext(item)),
 							Font.class, item);
 					setFont(item, font);
 				} catch (Exception e) {

--- a/bundles/org.eclipse.e4.ui.css.swt/src/org/eclipse/e4/ui/css/swt/properties/definition/CSSPropertyFontDefinitionHandler.java
+++ b/bundles/org.eclipse.e4.ui.css.swt/src/org/eclipse/e4/ui/css/swt/properties/definition/CSSPropertyFontDefinitionHandler.java
@@ -16,6 +16,7 @@ package org.eclipse.e4.ui.css.swt.properties.definition;
 import org.eclipse.e4.ui.css.core.dom.properties.css2.AbstractCSSPropertyFontHandler;
 import org.eclipse.e4.ui.css.core.dom.properties.css2.CSS2FontProperties;
 import org.eclipse.e4.ui.css.core.dom.properties.css2.CSS2FontPropertiesImpl;
+import org.eclipse.e4.ui.css.core.engine.CSSElementContext;
 import org.eclipse.e4.ui.css.core.engine.CSSEngine;
 import org.eclipse.e4.ui.css.swt.dom.definition.FontDefinitionElement;
 import org.eclipse.e4.ui.css.swt.helpers.CSSSWTFontHelper;
@@ -30,9 +31,10 @@ public class CSSPropertyFontDefinitionHandler extends AbstractCSSPropertyFontHan
 		if (element instanceof FontDefinitionElement) {
 			CSS2FontProperties properties = new CSS2FontPropertiesImpl();
 			IFontDefinitionOverridable definition = (IFontDefinitionOverridable) ((FontDefinitionElement) element).getNativeWidget();
+			FontData baseFontData = getBaseFontData(definition, engine.getCSSElementContext(element));
 
 			super.applyCSSProperty(properties, property, value, pseudo, engine);
-			setFontProperties(definition, properties);
+			setFontProperties(definition, CSSSWTFontHelper.resolveRelativeSize(properties, baseFontData));
 			return true;
 		}
 		return false;
@@ -45,8 +47,27 @@ public class CSSPropertyFontDefinitionHandler extends AbstractCSSPropertyFontHan
 	}
 
 	private void setFontProperties(IFontDefinitionOverridable definition, CSS2FontProperties properties) {
-		FontData fontData = definition.getValue() != null? definition.getValue()[0]: null;
-		definition.setValue(new FontData[]{CSSSWTFontHelper.getFontData(properties, fontData)});
+		definition.setValue(new FontData[] { CSSSWTFontHelper.getFontData(properties, getFontData(definition)) });
+	}
+
+	/**
+	 * The font the definition was registered with, so that a relative size scales
+	 * the registered font instead of the override applied by an earlier style.
+	 */
+	private static FontData getBaseFontData(IFontDefinitionOverridable definition, CSSElementContext context) {
+		FontData baseFontData = CSSSWTFontHelper.getBaseFontData(context);
+		// an overridden definition still carries the override of an earlier pass,
+		// unless it was reset to its registered value in between
+		if (baseFontData == null || !definition.isOverridden()) {
+			baseFontData = getFontData(definition);
+			CSSSWTFontHelper.setBaseFontData(context, baseFontData);
+		}
+		return baseFontData;
+	}
+
+	private static FontData getFontData(IFontDefinitionOverridable definition) {
+		FontData[] value = definition.getValue();
+		return value != null && value.length > 0 ? value[0] : null;
 	}
 
 	@Override

--- a/examples/org.eclipse.e4.demo.cssbridge/css/common.css
+++ b/examples/org.eclipse.e4.demo.cssbridge/css/common.css
@@ -19,28 +19,28 @@ ThemesExtension {
 /* for IDs see the class: org.eclipse.e4.demo.cssbridge.ui.views.Theme.FoldersView */
 FontDefinition#org-eclipse-e4-demo-cssbridge-ui-views-theme-foldersview-mailbox-name-font {
 	font-family: Times;
-	font-size: 10px;
+	font-size: 10pt;
 }
 
 FontDefinition#org-eclipse-e4-demo-cssbridge-ui-views-theme-foldersview-folder-type-font {
 	font-family: Tahoma;
-	font-size:8px;
+	font-size:8pt;
 }
 
 /* for IDs see the class: org.eclipse.e4.demo.cssbridge.ui.views.Theme.FolderPreviewView */
 FontDefinition#org-eclipse-e4-demo-cssbridge-ui-views-theme-folderpreviewview-low-imp-mail-font {
 	font-family: Terminal;
-	font-size: 8px;
+	font-size: 8pt;
 }
 
 FontDefinition#org-eclipse-e4-demo-cssbridge-ui-views-theme-folderpreviewview-normal-imp-mail-font {
 	font-family: Tahoma;
-	font-size: 8px;
+	font-size: 8pt;
 }
 
 FontDefinition#org-eclipse-e4-demo-cssbridge-ui-views-theme-folderpreviewview-high-imp-mail-font {
 	font-family: Times;
-	font-size: 11px;
+	font-size: 11pt;
 	font-style: italic;
 }
 

--- a/tests/org.eclipse.e4.ui.tests.css.swt/src/org/eclipse/e4/ui/css/swt/helpers/CSSSWTFontHelperTest.java
+++ b/tests/org.eclipse.e4.ui.tests.css.swt/src/org/eclipse/e4/ui/css/swt/helpers/CSSSWTFontHelperTest.java
@@ -17,6 +17,12 @@ package org.eclipse.e4.ui.css.swt.helpers;
 import static org.eclipse.e4.ui.css.swt.helpers.CSSSWTFontHelper.getFontData;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import org.eclipse.e4.ui.css.core.dom.properties.css2.CSS2FontProperties;
+import org.eclipse.e4.ui.css.core.dom.properties.css2.CSS2FontPropertiesImpl;
+import org.eclipse.e4.ui.css.core.impl.dom.CssValues.CssDimension;
+import org.eclipse.e4.ui.css.core.impl.dom.CssValues.CssPrimitive;
+import org.eclipse.e4.ui.css.core.impl.dom.CssValues.CssText;
+import org.eclipse.e4.ui.css.core.impl.dom.CssValues.CssUnit;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.graphics.FontData;
 import org.junit.jupiter.api.Test;
@@ -143,6 +149,106 @@ public class CSSSWTFontHelperTest extends CSSSWTHelperTestCase {
 	}
 
 	@Test
+	void testGetFontDataWithSizeInEm() {
+		FontData result = getFontData(fontPropertiesWithSize(new CssDimension(1.5, CssUnit.EM)),
+				new FontData("Courier", 10, SWT.NORMAL));
+
+		assertEquals(15, result.getHeight());
+	}
+
+	@Test
+	void testGetFontDataWithSizeInEmIsRounded() {
+		FontData result = getFontData(fontPropertiesWithSize(new CssDimension(1.2, CssUnit.EM)),
+				new FontData("Courier", 9, SWT.NORMAL));
+
+		assertEquals(11, result.getHeight());
+	}
+
+	@Test
+	void testGetFontDataWithSizeInPercent() {
+		FontData result = getFontData(fontPropertiesWithSize(new CssDimension(120, CssUnit.PERCENT)),
+				new FontData("Courier", 10, SWT.NORMAL));
+
+		assertEquals(12, result.getHeight());
+	}
+
+	@Test
+	void testGetFontDataWithSizeInPercentBelowHundred() {
+		FontData result = getFontData(fontPropertiesWithSize(new CssDimension(50, CssUnit.PERCENT)),
+				new FontData("Courier", 11, SWT.NORMAL));
+
+		assertEquals(6, result.getHeight());
+	}
+
+	@Test
+	void testGetFontDataWithRelativeSizeNeverReachesZero() {
+		FontData result = getFontData(fontPropertiesWithSize(new CssDimension(1, CssUnit.PERCENT)),
+				new FontData("Courier", 10, SWT.NORMAL));
+
+		assertEquals(1, result.getHeight());
+	}
+
+	@Test
+	void testGetFontDataWithRelativeSizeAndWithoutOldFont() {
+		FontData result = getFontData(fontPropertiesWithSize(new CssDimension(1.5, CssUnit.EM)), null);
+
+		assertEquals(new FontData().getHeight(), result.getHeight());
+	}
+
+	@Test
+	void testGetFontDataWithSizeKeywordKeepsTheOldSize() {
+		FontData result = getFontData(fontPropertiesWithSize(keyword("larger")),
+				new FontData("Courier", 10, SWT.NORMAL));
+
+		assertEquals(10, result.getHeight());
+	}
+
+	@Test
+	void testGetFontDataWithSizeInPixels() {
+		FontData result = getFontData(fontPropertiesWithSize(new CssDimension(16, CssUnit.PX)),
+				new FontData("Courier", 10, SWT.NORMAL));
+
+		assertEquals(12, result.getHeight());
+	}
+
+	@Test
+	void testGetFontDataWithSizeInPixelsIsRounded() {
+		FontData result = getFontData(fontPropertiesWithSize(new CssDimension(11, CssUnit.PX)),
+				new FontData("Courier", 10, SWT.NORMAL));
+
+		assertEquals(8, result.getHeight());
+	}
+
+	@Test
+	void testGetFontDataWithSizeInPoints() {
+		FontData result = getFontData(fontPropertiesWithSize(new CssDimension(16, CssUnit.PT)),
+				new FontData("Courier", 10, SWT.NORMAL));
+
+		assertEquals(16, result.getHeight());
+	}
+
+	@Test
+	void testGetFontDataWithSizeWithoutUnitIsTakenAsPoints() {
+		FontData result = getFontData(fontPropertiesWithSize(new CssDimension(16, CssUnit.NUMBER)),
+				new FontData("Courier", 10, SWT.NORMAL));
+
+		assertEquals(16, result.getHeight());
+	}
+
+	@Test
+	void testGetFontDataWhenFontFamilyFromDefinitionAndRelativeSize() {
+		registerFontProviderWith("org.eclipse.jface.bannerfont", "Arial", 15, SWT.NORMAL);
+
+		FontData result = getFontData(
+				fontPropertiesWithSize(addFontDefinitionMarker("org-eclipse-jface-bannerfont"),
+						new CssDimension(200, CssUnit.PERCENT)),
+				new FontData("Courier", 10, SWT.NORMAL));
+
+		assertEquals("Arial", result.getName());
+		assertEquals(20, result.getHeight());
+	}
+
+	@Test
 	void testGetFontDataFromFontDefinition() {
 		registerFontProviderWith("org.eclipse.jface.bannerfont", "Arial", 15, SWT.ITALIC | SWT.BOLD);
 
@@ -153,5 +259,23 @@ public class CSSSWTFontHelperTest extends CSSSWTHelperTestCase {
 		assertEquals("Arial", result.getName());
 		assertEquals(15, result.getHeight());
 		assertEquals(SWT.ITALIC | SWT.BOLD, result.getStyle());
+	}
+
+	private static CssPrimitive keyword(String value) {
+		return new CssText(CssText.Kind.IDENT, value);
+	}
+
+	private static CSS2FontProperties fontPropertiesWithSize(CssPrimitive size) {
+		return fontPropertiesWithSize(null, size);
+	}
+
+	private static CSS2FontProperties fontPropertiesWithSize(String family, CssPrimitive size) {
+		CSS2FontProperties result = new CSS2FontPropertiesImpl();
+		if (family != null) {
+			result.setFamily(new CssText(CssText.Kind.IDENT, family));
+		}
+		result.setSize(size);
+		result.setSizeFromCSS(true);
+		return result;
 	}
 }

--- a/tests/org.eclipse.e4.ui.tests.css.swt/src/org/eclipse/e4/ui/tests/css/swt/ButtonTest.java
+++ b/tests/org.eclipse.e4.ui.tests.css.swt/src/org/eclipse/e4/ui/tests/css/swt/ButtonTest.java
@@ -78,7 +78,7 @@ public class ButtonTest {
 
 	@Test
 	void testFontRegular() {
-		Button buttonToTest = createTestButton("Button { font: Verdana 16px }", SWT.CHECK);
+		Button buttonToTest = createTestButton("Button { font: Verdana 16pt }", SWT.CHECK);
 		assertEquals(1, buttonToTest.getFont().getFontData().length);
 		FontData fontData = buttonToTest.getFont().getFontData()[0];
 		assertEquals("Verdana", fontData.getName());
@@ -88,7 +88,7 @@ public class ButtonTest {
 
 	@Test
 	void testFontBold() {
-		Button buttonToTest = createTestButton("Button { font: Arial 12px; font-weight: bold }", SWT.CHECK);
+		Button buttonToTest = createTestButton("Button { font: Arial 12pt; font-weight: bold }", SWT.CHECK);
 		assertEquals(1, buttonToTest.getFont().getFontData().length);
 		FontData fontData = buttonToTest.getFont().getFontData()[0];
 		assertEquals("Arial", fontData.getName());

--- a/tests/org.eclipse.e4.ui.tests.css.swt/src/org/eclipse/e4/ui/tests/css/swt/CTabFolderTest.java
+++ b/tests/org.eclipse.e4.ui.tests.css.swt/src/org/eclipse/e4/ui/tests/css/swt/CTabFolderTest.java
@@ -152,7 +152,7 @@ public class CTabFolderTest {
 
 	@Test
 	void testFontRegular() {
-		CTabFolder folderToTest = createTestCTabFolder("CTabFolder { font: Verdana 16px }");
+		CTabFolder folderToTest = createTestCTabFolder("CTabFolder { font: Verdana 16pt }");
 		assertEquals(1, folderToTest.getFont().getFontData().length);
 		FontData fontData = folderToTest.getFont().getFontData()[0];
 		assertEquals("Verdana", fontData.getName());
@@ -162,7 +162,7 @@ public class CTabFolderTest {
 
 	@Test
 	void testFontBold() {
-		CTabFolder folderToTest = createTestCTabFolder("CTabFolder { font: Arial 12px; font-weight: bold }");
+		CTabFolder folderToTest = createTestCTabFolder("CTabFolder { font: Arial 12pt; font-weight: bold }");
 		assertEquals(1, folderToTest.getFont().getFontData().length);
 		FontData fontData = folderToTest.getFont().getFontData()[0];
 		assertEquals("Arial", fontData.getName());
@@ -172,7 +172,7 @@ public class CTabFolderTest {
 
 	@Test
 	void testFontItalic() {
-		CTabFolder folderToTest = createTestCTabFolder("CTabFolder { font: Arial 12px; font-style: italic }");
+		CTabFolder folderToTest = createTestCTabFolder("CTabFolder { font: Arial 12pt; font-style: italic }");
 		assertEquals(1, folderToTest.getFont().getFontData().length);
 		FontData fontData = folderToTest.getFont().getFontData()[0];
 		assertEquals("Arial", fontData.getName());

--- a/tests/org.eclipse.e4.ui.tests.css.swt/src/org/eclipse/e4/ui/tests/css/swt/FontDefinitionTest.java
+++ b/tests/org.eclipse.e4.ui.tests.css.swt/src/org/eclipse/e4/ui/tests/css/swt/FontDefinitionTest.java
@@ -93,6 +93,22 @@ public class FontDefinitionTest {
 	}
 
 	@Test
+	void testFontDefinitionWithRelativeSizeScalesTheRegisteredFont() {
+		// given
+		CSSEngine engine = css.createEngine("FontDefinition#org-eclipse-jface-bannerfont {font-size: 200%;}");
+		FontDefinition definition = fontDefinition("org.eclipse.jface.bannerfont", "name", "categoryId",
+				"description");
+		definition.setValue(new FontData[] { new FontData("Arial", 10, SWT.NORMAL) });
+
+		// when
+		engine.applyStyles(definition, true);
+		engine.applyStyles(definition, true);
+
+		// then the registered font is scaled once, not once per styling pass
+		assertEquals(20, definition.getValue()[0].getHeight());
+	}
+
+	@Test
 	void testFontDefinitionWhenDefinitionStylesheetNotFound() {
 		//given
 		CSSEngine engine = css.createEngine(

--- a/tests/org.eclipse.e4.ui.tests.css.swt/src/org/eclipse/e4/ui/tests/css/swt/LabelTest.java
+++ b/tests/org.eclipse.e4.ui.tests.css.swt/src/org/eclipse/e4/ui/tests/css/swt/LabelTest.java
@@ -19,9 +19,12 @@ import static org.eclipse.e4.ui.tests.css.swt.CssSwtEngine.BLUE;
 import static org.eclipse.e4.ui.tests.css.swt.CssSwtEngine.RED;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import org.eclipse.e4.ui.css.core.engine.CSSEngine;
 import org.eclipse.swt.SWT;
+import org.eclipse.swt.graphics.Font;
 import org.eclipse.swt.graphics.FontData;
 import org.eclipse.swt.widgets.Label;
+import org.eclipse.swt.widgets.Shell;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
@@ -39,7 +42,7 @@ public class LabelTest {
 
 	@Test
 	void testFontRegular() {
-		Label labelToTest = css.createTestLabel("Label { font: Verdana 16px }");
+		Label labelToTest = css.createTestLabel("Label { font: Verdana 16pt }");
 		assertEquals(1, labelToTest.getFont().getFontData().length);
 		FontData fontData = labelToTest.getFont().getFontData()[0];
 		assertEquals("Verdana", fontData.getName());
@@ -49,7 +52,7 @@ public class LabelTest {
 
 	@Test
 	void testFontBold() {
-		Label labelToTest = css.createTestLabel("Label { font: Arial 12px; font-weight: bold }");
+		Label labelToTest = css.createTestLabel("Label { font: Arial 12pt; font-weight: bold }");
 		assertEquals(1, labelToTest.getFont().getFontData().length);
 		FontData fontData = labelToTest.getFont().getFontData()[0];
 		assertEquals("Arial", fontData.getName());
@@ -63,6 +66,77 @@ public class LabelTest {
 		assertEquals(1, labelToTest.getFont().getFontData().length);
 		FontData fontData = labelToTest.getFont().getFontData()[0];
 		assertEquals(SWT.ITALIC, fontData.getStyle());
+	}
+
+	@Test
+	void testFontSizeInPercent() {
+		int inheritedHeight = css.getDisplay().getSystemFont().getFontData()[0].getHeight();
+
+		Label labelToTest = css.createTestLabel("Label { font-size: 200% }");
+
+		assertEquals(inheritedHeight * 2, labelToTest.getFont().getFontData()[0].getHeight());
+	}
+
+	@Test
+	void testFontSizeInEm() {
+		int inheritedHeight = css.getDisplay().getSystemFont().getFontData()[0].getHeight();
+
+		Label labelToTest = css.createTestLabel("Label { font-size: 2em }");
+
+		assertEquals(inheritedHeight * 2, labelToTest.getFont().getFontData()[0].getHeight());
+	}
+
+	@Test
+	void testFontSizeInPixels() {
+		Label labelToTest = css.createTestLabel("Label { font-size: 16px }");
+
+		assertEquals(12, labelToTest.getFont().getFontData()[0].getHeight());
+	}
+
+	@Test
+	void testFontSizeInPoints() {
+		Label labelToTest = css.createTestLabel("Label { font-size: 16pt }");
+
+		assertEquals(16, labelToTest.getFont().getFontData()[0].getHeight());
+	}
+
+	@Test
+	void testFontSizeInPercentIsNotCompoundedWhenStylesAreReapplied() {
+		int inheritedHeight = css.getDisplay().getSystemFont().getFontData()[0].getHeight();
+		Label labelToTest = css.createTestLabel("Label { font-size: 200% }");
+		FontData styledFontData = labelToTest.getFont().getFontData()[0];
+
+		// styling the label again with a cold font cache must scale the font the
+		// label started with, not the one the first pass gave it
+		css.getEngine().getResourcesRegistry().dispose();
+		Font styledFont = new Font(css.getDisplay(), styledFontData);
+		labelToTest.setFont(styledFont);
+		css.getEngine().applyStyles(labelToTest, true);
+
+		assertEquals(inheritedHeight * 2, labelToTest.getFont().getFontData()[0].getHeight());
+		styledFont.dispose();
+	}
+
+	@Test
+	void testFontSizeInPercentIsResolvedPerWidget() {
+		CSSEngine engine = css.createEngine("Label { font-size: 200% }");
+		Shell shell = new Shell(css.getDisplay());
+		Label smallLabel = new Label(shell, SWT.NONE);
+		Label largeLabel = new Label(shell, SWT.NONE);
+		// same family and style, so the two only differ in the size they scale from
+		Font smallFont = new Font(css.getDisplay(), "Arial", 10, SWT.NORMAL);
+		Font largeFont = new Font(css.getDisplay(), "Arial", 20, SWT.NORMAL);
+		smallLabel.setFont(smallFont);
+		largeLabel.setFont(largeFont);
+
+		engine.applyStyles(smallLabel, true);
+		engine.applyStyles(largeLabel, true);
+
+		assertEquals(20, smallLabel.getFont().getFontData()[0].getHeight());
+		assertEquals(40, largeLabel.getFont().getFontData()[0].getHeight());
+		shell.dispose();
+		smallFont.dispose();
+		largeFont.dispose();
 	}
 
 	@Test

--- a/tests/org.eclipse.e4.ui.tests.css.swt/src/org/eclipse/e4/ui/tests/css/swt/ShellTest.java
+++ b/tests/org.eclipse.e4.ui.tests.css.swt/src/org/eclipse/e4/ui/tests/css/swt/ShellTest.java
@@ -69,7 +69,7 @@ public class ShellTest {
 
 	@Test
 	void testFontRegular() {
-		Shell shellToTest = createTestShell("Shell { font: Verdana 16px }");
+		Shell shellToTest = createTestShell("Shell { font: Verdana 16pt }");
 		assertEquals(1, shellToTest.getFont().getFontData().length);
 		FontData fontData = shellToTest.getFont().getFontData()[0];
 		assertEquals("Verdana", fontData.getName());
@@ -79,7 +79,7 @@ public class ShellTest {
 
 	@Test
 	void testFontBold() {
-		Shell shellToTest = createTestShell("Shell { font: Arial 12px; font-weight: bold }");
+		Shell shellToTest = createTestShell("Shell { font: Arial 12pt; font-weight: bold }");
 		assertEquals(1, shellToTest.getFont().getFontData().length);
 		FontData fontData = shellToTest.getFont().getFontData()[0];
 		assertEquals("Arial", fontData.getName());


### PR DESCRIPTION
The CSS engine now understands `em` and `%` for `font-size`, resolved against the font the widget inherited. A theme can therefore ask for a slightly larger font without overriding the size the user configured, which was not expressible before.

`px` was accepted already but silently read as a point size. It is now converted with 1px = 0.75pt, matching the CSS definition of a pixel as 1/96 inch against SWT's 1/72 inch font height. Style sheets that relied on the old reading render smaller and have to state `pt`, as the cssbridge example now does. Unitless values and any other unit keep being read as points.

The `font` shorthand accepts the new forms too, and a relative size on a `FontDefinition` scales the registered font instead of replacing it. 