### PR TITLE
Do not scan dot folders during smart import detection

### DIFF
--- a/bundles/org.eclipse.ui.ide/.settings/.api_filters
+++ b/bundles/org.eclipse.ui.ide/.settings/.api_filters
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<component id="org.eclipse.ui.ide" version="2">
+    <resource path="META-INF/MANIFEST.MF">
+        <filter id="926941240">
+            <message_arguments>
+                <message_argument value="3.24.0"/>
+                <message_argument value="3.23.200"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="src/org/eclipse/ui/wizards/datatransfer/ProjectConfigurator.java" type="org.eclipse.ui.wizards.datatransfer.ProjectConfigurator">
+        <filter id="404000815">
+            <message_arguments>
+                <message_argument value="org.eclipse.ui.wizards.datatransfer.ProjectConfigurator"/>
+                <message_argument value="findConfigurableLocations(File, boolean, IProgressMonitor)"/>
+            </message_arguments>
+        </filter>
+    </resource>
+</component>

--- a/bundles/org.eclipse.ui.ide/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.ui.ide/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Plugin.name
 Bundle-SymbolicName: org.eclipse.ui.ide; singleton:=true
-Bundle-Version: 3.23.300.qualifier
+Bundle-Version: 3.24.0.qualifier
 Bundle-Activator: org.eclipse.ui.internal.ide.IDEWorkbenchPlugin
 Bundle-ActivationPolicy: lazy
 Bundle-Vendor: %Plugin.providerName

--- a/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/wizards/datatransfer/EclipseProjectConfigurator.java
+++ b/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/wizards/datatransfer/EclipseProjectConfigurator.java
@@ -41,10 +41,15 @@ public class EclipseProjectConfigurator implements ProjectConfigurator {
 
 	@Override
 	public Set<File> findConfigurableLocations(File root, IProgressMonitor monitor) {
+		return findConfigurableLocations(root, false, monitor);
+	}
+
+	@Override
+	public Set<File> findConfigurableLocations(File root, boolean skipDotFolders, IProgressMonitor monitor) {
 		Set<File> projectFiles = new LinkedHashSet<>();
 		Set<String> visitedDirectories = new HashSet<>();
 		WizardProjectsImportPage.collectProjectFilesFromDirectory(projectFiles, root, visitedDirectories, true,
-				false, monitor);
+				skipDotFolders, monitor);
 		Set<File> res = new LinkedHashSet<>();
 		for (File projectFile : projectFiles) {
 			res.add(projectFile.getParentFile());

--- a/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/wizards/datatransfer/SmartImportJob.java
+++ b/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/wizards/datatransfer/SmartImportJob.java
@@ -696,7 +696,7 @@ public class SmartImportJob extends Job {
 			SubMonitor loopMonitor = SubMonitor.convert(monitor, activeConfigurators.size());
 			for (ProjectConfigurator configurator : activeConfigurators) {
 				Set<File> supportedDirectories = configurator.findConfigurableLocations(
-						SmartImportJob.this.rootDirectory,
+						SmartImportJob.this.rootDirectory, this.skipDotFolders,
 						loopMonitor.split(1));
 				if (supportedDirectories != null) {
 					for (File supportedDirectory : supportedDirectories) {

--- a/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/wizards/datatransfer/ProjectConfigurator.java
+++ b/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/wizards/datatransfer/ProjectConfigurator.java
@@ -73,6 +73,29 @@ public interface ProjectConfigurator {
 	public Set<File> findConfigurableLocations(File root, IProgressMonitor monitor);
 
 	/**
+	 * Same as {@link #findConfigurableLocations(File, IProgressMonitor)}, but
+	 * allows the import to request that folders starting with a dot (such as
+	 * {@code .git}) are not visited at all. Implementations that walk the file
+	 * system should override this method, so that skipped locations are not
+	 * searched in the first place.
+	 *
+	 * <p>
+	 * This method must be stateless.
+	 * </p>
+	 *
+	 * @param root           the root directory on which to start the discovery
+	 * @param skipDotFolders whether folders starting with a dot must not be
+	 *                       visited
+	 * @param monitor        the progress monitor
+	 * @return the children (at any depth) that this configurator suggests to
+	 *         import as project
+	 * @since 3.24
+	 */
+	default Set<File> findConfigurableLocations(File root, boolean skipDotFolders, IProgressMonitor monitor) {
+		return findConfigurableLocations(root, monitor);
+	}
+
+	/**
 	 * Removes from the set of directories those that should not be proposed to
 	 * the user for import. Those are typically dirty volatile directories such
 	 * as build output directories.

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/datatransfer/SmartImportTests.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/datatransfer/SmartImportTests.java
@@ -35,8 +35,10 @@ import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
 
@@ -583,6 +585,16 @@ public class SmartImportTests {
 		}
 	}
 
+	/** Records the directories the proposal scan reports as sub tasks. */
+	private static final class DirectoryRecordingMonitor extends NullProgressMonitor {
+		final List<String> scanned = new CopyOnWriteArrayList<>();
+
+		@Override
+		public void subTask(String name) {
+			scanned.add(name);
+		}
+	}
+
 	@Test
 	public void testSmartImportJobSkipsDotFoldersInProposals() throws Exception {
 		java.nio.file.Path tempDir = Files.createTempDirectory("smartImportProposalTest");
@@ -602,11 +614,16 @@ public class SmartImportTests {
 
 			// Default skipDotFolders=true: .git projects should be filtered out
 			SmartImportJob jobSkip = new SmartImportJob(tempDir.toFile(), Collections.emptySet(), true, true);
-			Map<File, ?> proposalsSkip = jobSkip.getImportProposals(new NullProgressMonitor());
+			DirectoryRecordingMonitor monitor = new DirectoryRecordingMonitor();
+			Map<File, ?> proposalsSkip = jobSkip.getImportProposals(monitor);
 			for (File proposed : proposalsSkip.keySet()) {
 				assertFalse("Proposal inside .git folder should be filtered out by default",
 						proposed.getAbsolutePath().contains(".git"));
 			}
+			assertTrue("Normal project should have been scanned",
+					monitor.scanned.stream().anyMatch(task -> task.contains("normalProject")));
+			assertFalse("Dot folder should not be scanned at all",
+					monitor.scanned.stream().anyMatch(task -> task.contains(".git")));
 		} finally {
 			org.eclipse.core.tests.harness.FileSystemHelper.clear(tempDir.toFile());
 		}


### PR DESCRIPTION
The "skip folders starting with '.'" option only removed dot folders from the
proposals, after `EclipseProjectConfigurator` had already walked them. On trees
with large git object stores that walk dominates the detection time and can
produce nothing usable.

Add a `ProjectConfigurator.findConfigurableLocations` overload carrying the flag,
default-delegating to the existing method, so `SmartImportJob` can pass the
option through and dot folders are never entered. Bundle version bumped for the
added API.

Assisted-by: multiple AI agents and layers of automated tooling 🤖