### PR TITLE
Style the progress bar in the dark theme

### DIFF
--- a/bundles/org.eclipse.ui.themes/css/dark/e4-dark_globalstyle.css
+++ b/bundles/org.eclipse.ui.themes/css/dark/e4-dark_globalstyle.css
@@ -142,9 +142,14 @@ CompareViewerPane > * {
     color: '#org-eclipse-ui-workbench-DARK_FOREGROUND'; 
 }
 
-ProgressIndicator {
-    background-color: #777;
-    color: '#org-eclipse-ui-workbench-DARK_FOREGROUND'; 
+/* Element selectors match the exact widget class name, so the bars inside a
+ * ProgressIndicator need the child selector. Inside a part the bar is styled by
+ * the '.MPart' copies in e4-dark_partstyle.css. */
+ProgressIndicator,
+ProgressIndicator > *,
+ProgressBar {
+    background-color: #5A5F62;
+    color: '#org-eclipse-ui-workbench-LINK_COLOR';
 }
 
 DiscoveryItem,

--- a/bundles/org.eclipse.ui.themes/css/dark/e4-dark_partstyle.css
+++ b/bundles/org.eclipse.ui.themes/css/dark/e4-dark_partstyle.css
@@ -60,6 +60,15 @@
 }
 
 
+/* Ties '.MPart Composite > * > *' above on specificity, so it has to sit after
+ * it. Keep in step with the ProgressBar rule in e4-dark_globalstyle.css. */
+.MPart ProgressIndicator,
+.MPart ProgressIndicator > *,
+.MPart ProgressBar {
+    background-color: #5A5F62;
+    color: '#org-eclipse-ui-workbench-LINK_COLOR';
+}
+
 .MPart Section > Label {
     background-color: #2F2F2F;
     color: #ABCEDA;


### PR DESCRIPTION
The progress bar had no rule of its own in the dark theme: only the `ProgressIndicator` around it was coloured, so the bar fell to the `Composite > *` catch-all on `DARK_BACKGROUND` and did not separate from the chrome.

Gives it `#5A5F62` as the trough and `LINK_COLOR` as the fill. The `.MPart` copies live in `e4-dark_partstyle.css` because they only tie `.MPart Composite > * > *` on specificity and need to be imported after it.

Verified on Windows in the Progress view, the status line and the p2 install wizard: fill and trough resolve to the two colours at every fill level.

🤖 Generated with [Claude Code](https://claude.com/claude-code)