### PR TITLE
Broadcast the import delta when the creation operation ends

### DIFF
--- a/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/wizards/datatransfer/SmartImportJob.java
+++ b/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/wizards/datatransfer/SmartImportJob.java
@@ -194,6 +194,7 @@ public class SmartImportJob extends Job {
 				loopMonitor.worked(1);
 				// Create all projects in one workspace operation, so listeners see a single
 				// resource delta instead of one per project. No configurator runs here.
+				// AVOID_UPDATE would defer that delta to the workspace notification job.
 				workspace.run(creationMonitor -> {
 					for (final File directoryToImport : directories) {
 						final boolean alreadyAnEclipseProject = new File(directoryToImport,
@@ -214,7 +215,7 @@ public class SmartImportJob extends Job {
 							this.errors.put(path, ex);
 						}
 					}
-				}, this.workspaceRoot, IWorkspace.AVOID_UPDATE, null);
+				}, this.workspaceRoot, IResource.NONE, null);
 				if (configureProjects) {
 					JobGroup multiDirectoriesJobGroup = new JobGroup(
 							DataTransferMessages.SmartImportJob_configuringSelectedDirectories, 20, 1);


### PR DESCRIPTION
Smart import creates the selected projects in one workspace operation. That operation passed `IWorkspace.AVOID_UPDATE`, which suppresses the resource change notification at the end of the operation and leaves it to the workspace notification job, up to 1.5 seconds later. Listeners such as Project Explorer therefore learned about the imported projects late, and `SmartImportTests.testProjectsAreCreatedInASingleWorkspaceOperation` failed on the I20260831-2300 Linux build because it saw no event at all when it asserted right after the job returned.

Dropping the flag broadcasts the delta synchronously when the operation ends. It is still a single delta covering all projects, which is what batching the creation loop was introduced for, so listeners are notified once and immediately instead of once and late.

Verified with `SmartImportTests` (14 tests, no failures) run headless under Xvfb with `org.eclipse.ui.ide` in the reactor.