### PR TITLE
Recover from malformed CSS rules instead of dropping the sheet

### DIFF
--- a/bundles/org.eclipse.e4.ui.css.core/src/org/eclipse/e4/ui/css/core/impl/dom/CSSStyleSheetImpl.java
+++ b/bundles/org.eclipse.e4.ui.css.core/src/org/eclipse/e4/ui/css/core/impl/dom/CSSStyleSheetImpl.java
@@ -16,18 +16,35 @@ package org.eclipse.e4.ui.css.core.impl.dom;
 
 import java.util.List;
 
+import org.eclipse.e4.ui.css.core.impl.parser.CssParseException;
+
 /**
- * A parsed stylesheet: an ordered list of {@link CssRule}s.
+ * A parsed stylesheet: an ordered list of {@link CssRule}s, plus the rules and
+ * declarations the parser had to skip.
  */
 public final class CSSStyleSheetImpl {
 
 	private final List<CssRule> rules;
+	private final List<CssParseException> problems;
 
 	public CSSStyleSheetImpl(List<CssRule> rules) {
+		this(rules, List.of());
+	}
+
+	public CSSStyleSheetImpl(List<CssRule> rules, List<CssParseException> problems) {
 		this.rules = List.copyOf(rules);
+		this.problems = List.copyOf(problems);
 	}
 
 	public List<CssRule> getRules() {
 		return rules;
+	}
+
+	/**
+	 * The malformed rules and declarations skipped while parsing, in source
+	 * order. Empty for a sheet that parsed cleanly.
+	 */
+	public List<CssParseException> getProblems() {
+		return problems;
 	}
 }

--- a/bundles/org.eclipse.e4.ui.css.core/src/org/eclipse/e4/ui/css/core/impl/engine/CSSEngineImpl.java
+++ b/bundles/org.eclipse.e4.ui.css.core/src/org/eclipse/e4/ui/css/core/impl/engine/CSSEngineImpl.java
@@ -67,6 +67,7 @@ import org.eclipse.e4.ui.css.core.resources.ResourceRegistryKeyFactory;
 import org.eclipse.e4.ui.css.core.util.impl.resources.ResourcesLocatorManager;
 import org.eclipse.e4.ui.css.core.util.resources.IResourcesLocatorManager;
 import org.eclipse.e4.ui.css.core.utils.StringUtils;
+import org.eclipse.e4.ui.css.core.impl.parser.CssParseException;
 import org.eclipse.e4.ui.css.core.impl.parser.CssParser;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
@@ -164,9 +165,11 @@ public abstract class CSSEngineImpl implements CSSEngine {
 
 	private CSSStyleSheetImpl parseStyleSheet(String content, String uri) throws IOException {
 		CSSStyleSheetImpl styleSheet = CssParser.parseStyleSheet(content);
+		reportParseProblems(styleSheet);
 
 		List<CssRule> rules = styleSheet.getRules();
 		List<CssRule> masterList = new ArrayList<>();
+		List<CssParseException> problems = new ArrayList<>(styleSheet.getProblems());
 		int counter;
 		for (counter = 0; counter < rules.size(); counter++) {
 			if (!(rules.get(counter) instanceof CSSImportRuleImpl importRule)) {
@@ -202,6 +205,7 @@ public abstract class CSSEngineImpl implements CSSEngine {
 					parseImport--;
 				}
 				masterList.addAll(imported.getRules());
+				problems.addAll(imported.getProblems());
 			}
 		}
 
@@ -209,11 +213,18 @@ public abstract class CSSEngineImpl implements CSSEngine {
 		masterList.addAll(rules.subList(counter, rules.size()));
 
 		// final stylesheet
-		CSSStyleSheetImpl s = new CSSStyleSheetImpl(masterList);
+		CSSStyleSheetImpl s = new CSSStyleSheetImpl(masterList, problems);
 		if (parseImport == 0) {
 			addStyleSheet(s);
 		}
 		return s;
+	}
+
+	/** Report the rules and declarations the parser skipped, if any. */
+	private void reportParseProblems(CSSStyleSheetImpl styleSheet) {
+		for (CssParseException problem : styleSheet.getProblems()) {
+			handleExceptions(problem);
+		}
 	}
 
 	/** Register a parsed stylesheet with this engine's cascade. */

--- a/bundles/org.eclipse.e4.ui.css.core/src/org/eclipse/e4/ui/css/core/impl/parser/CssParser.java
+++ b/bundles/org.eclipse.e4.ui.css.core/src/org/eclipse/e4/ui/css/core/impl/parser/CssParser.java
@@ -67,6 +67,7 @@ public final class CssParser {
 
 	private final List<Token> tokens;
 	private int index;
+	private final List<CssParseException> problems = new ArrayList<>();
 
 	private CssParser(List<Token> tokens) {
 		this.tokens = tokens;
@@ -108,14 +109,42 @@ public final class CssParser {
 
 		skipWhitespace();
 		while (peek().kind != Kind.EOF) {
-			if (peek().kind == Kind.AT_KEYWORD) {
-				atRule(rules);
-			} else {
-				styleRule(rules);
+			try {
+				if (peek().kind == Kind.AT_KEYWORD) {
+					atRule(rules);
+				} else {
+					styleRule(rules);
+				}
+			} catch (CssParseException e) {
+				// CSS 2.1 section 4.2: a malformed rule is dropped and the rest
+				// of the sheet still applies.
+				problems.add(e);
+				skipMalformedRule();
 			}
 			skipWhitespace();
 		}
-		return new CSSStyleSheetImpl(rules);
+		return new CSSStyleSheetImpl(rules, problems);
+	}
+
+	/**
+	 * Consume through the end of the current rule so parsing can resume at the
+	 * next one. Never throws, and always advances unless the input is
+	 * exhausted, so the caller cannot loop.
+	 */
+	private void skipMalformedRule() {
+		int depth = 0;
+		while (peek().kind != Kind.EOF) {
+			Kind kind = advance().kind;
+			if (kind == Kind.LBRACE) {
+				depth++;
+			} else if (kind == Kind.RBRACE) {
+				if (--depth <= 0) {
+					return;
+				}
+			} else if (kind == Kind.SEMICOLON && depth == 0) {
+				return;
+			}
+		}
 	}
 
 	private void atRule(List<CssRule> rules) {
@@ -189,7 +218,37 @@ public final class CssParser {
 				advance(); // tolerate stray and leading semicolons
 				continue;
 			}
-			declaration(declaration);
+			try {
+				declaration(declaration);
+			} catch (CssParseException e) {
+				// A malformed declaration is dropped on its own; the rule keeps
+				// the declarations around it.
+				problems.add(e);
+				skipMalformedDeclaration();
+			}
+		}
+	}
+
+	/**
+	 * Consume through the end of the current declaration. Stops before the
+	 * brace closing the rule so the caller sees it and ends the block.
+	 */
+	private void skipMalformedDeclaration() {
+		int depth = 0;
+		while (true) {
+			Kind kind = peek().kind;
+			if (kind == Kind.EOF || (kind == Kind.RBRACE && depth == 0)) {
+				return;
+			}
+			if (kind == Kind.LBRACE) {
+				depth++;
+			} else if (kind == Kind.RBRACE) {
+				depth--;
+			}
+			advance();
+			if (kind == Kind.SEMICOLON && depth == 0) {
+				return;
+			}
 		}
 	}
 

--- a/tests/org.eclipse.e4.ui.tests.css.core/src/org/eclipse/e4/ui/tests/css/core/parser/StyleSheetStructureTest.java
+++ b/tests/org.eclipse.e4.ui.tests.css.core/src/org/eclipse/e4/ui/tests/css/core/parser/StyleSheetStructureTest.java
@@ -14,19 +14,14 @@
 package org.eclipse.e4.ui.tests.css.core.parser;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.io.StringReader;
-import java.util.ArrayList;
 import java.util.List;
 
-import org.eclipse.e4.ui.css.core.engine.CSSEngine;
-import org.eclipse.e4.ui.css.core.engine.CSSErrorHandler;
-import org.eclipse.e4.ui.css.swt.engine.CSSSWTEngineImpl;
 import org.eclipse.e4.ui.tests.css.core.util.ParserTestUtil;
-import org.eclipse.swt.widgets.Display;
 import org.junit.jupiter.api.Test;
 import org.eclipse.e4.ui.css.core.impl.dom.CSSImportRuleImpl;
 import org.eclipse.e4.ui.css.core.impl.dom.CSSStyleRuleImpl;
@@ -226,24 +221,62 @@ public class StyleSheetStructureTest {
 
 	@Test
 	void testInvalidInputErrorReported() throws Exception {
-		List<Exception> reported = new ArrayList<>();
-		CSSErrorHandler recorder = reported::add;
+		CSSStyleSheetImpl sheet = ParserTestUtil.parseCssWithoutImports("@@@ not valid css {");
 
-		CSSEngine engine = new CSSSWTEngineImpl(Display.getDefault());
-		engine.setErrorHandler(recorder);
+		// The contract is "garbage does not silently pass". The parser recovers
+		// rather than throwing, so the skipped input has to surface as a problem.
+		assertFalse(sheet.getProblems().isEmpty(), "expected a reported problem for invalid input");
+	}
 
-		boolean threw = false;
-		try {
-			engine.parseStyleSheet(new StringReader("@@@ not valid css {"));
-		} catch (Exception e) {
-			threw = true;
-		}
+	@Test
+	void testMalformedRuleDoesNotDropTheSheet() throws Exception {
+		CSSStyleSheetImpl sheet = ParserTestUtil
+				.parseCssWithoutImports("Button { color: red; } Label[] { color: blue; } Text { color: green; }");
 
-		// The contract is "garbage does not silently pass": either the parser
-		// throws, or the error handler is invoked. Both is also fine. A clean
-		// return with no error reported is the regression we want to catch.
-		assertTrue(threw || !reported.isEmpty(),
-				"expected the parser to throw or invoke the error handler for invalid input");
+		// The malformed rule is dropped whole; its neighbours survive.
+		assertEquals(2, sheet.getRules().size());
+		assertEquals(1, sheet.getProblems().size());
+		assertEquals("Button", ((CSSStyleRuleImpl) sheet.getRules().get(0)).getSelectorList().text());
+		assertEquals("Text", ((CSSStyleRuleImpl) sheet.getRules().get(1)).getSelectorList().text());
+	}
+
+	@Test
+	void testMalformedDeclarationDropsOnlyItself() throws Exception {
+		CSSStyleSheetImpl sheet = ParserTestUtil
+				.parseCssWithoutImports("Button { color: red; : bogus; background-color: blue; }");
+
+		CSSStyleDeclaration style = ((CSSStyleRuleImpl) sheet.getRules().get(0)).getStyle();
+		assertEquals("red", style.getPropertyCSSValue("color").getCssText());
+		assertEquals("blue", style.getPropertyCSSValue("background-color").getCssText());
+		assertEquals(1, sheet.getProblems().size());
+	}
+
+	@Test
+	void testInvalidSelectorInAGroupDropsTheWholeRule() throws Exception {
+		CSSStyleSheetImpl sheet = ParserTestUtil
+				.parseCssWithoutImports("Button, Label[ { color: red; } Text { color: green; }");
+
+		// A selector group is valid only as a whole, so the Button half goes
+		// with the malformed Label half.
+		assertEquals(1, sheet.getRules().size());
+		assertEquals("Text", ((CSSStyleRuleImpl) sheet.getRules().get(0)).getSelectorList().text());
+	}
+
+	@Test
+	void testUnknownAtRuleIsSkipped() throws Exception {
+		CSSStyleSheetImpl sheet = ParserTestUtil
+				.parseCssWithoutImports("@unknown wat; @weird { a: b; } Text { color: green; }");
+
+		assertEquals(1, sheet.getRules().size());
+		assertTrue(sheet.getProblems().isEmpty(), "an unknown at-rule is skipped, not reported as malformed");
+	}
+
+	@Test
+	void testUnterminatedRuleDoesNotHang() throws Exception {
+		CSSStyleSheetImpl sheet = ParserTestUtil.parseCssWithoutImports("Button { color: red; ");
+
+		// Unterminated input must terminate parsing, not loop.
+		assertEquals(1, sheet.getRules().size());
 	}
 
 	@Test


### PR DESCRIPTION
A single unsupported construct anywhere in a theme used to discard every rule in the file, because the parse exception propagated out of the style sheet loop. CSS 2.1 section 4.2 asks for the malformed rule to be skipped and parsing to continue, at both levels: a bad declaration is dropped on its own and its rule keeps the rest, while a bad selector drops the whole rule. The skipped input is collected on the style sheet and reported by the engine, so nothing fails silently.

The second commit fixes the tokenizer in the same area: a string now ends at an unescaped newline as the spec requires, instead of running to the next quote and swallowing every following rule as string content.

A theme therefore survives one construct the engine does not support, which is the practical win.

Verified with the org.eclipse.e4.ui.tests.css.core suite (137 tests) and org.eclipse.e4.ui.tests.css.swt (217 tests, 9 skipped) on Linux.