### PR TITLE
Support the :not() selector in the CSS engine

### DIFF
--- a/bundles/org.eclipse.e4.ui.css.core/src/org/eclipse/e4/ui/css/core/impl/engine/selector/RuleIndex.java
+++ b/bundles/org.eclipse.e4.ui.css.core/src/org/eclipse/e4/ui/css/core/impl/engine/selector/RuleIndex.java
@@ -100,6 +100,11 @@ public final class RuleIndex {
 			Selector right = rightmostKey(and.right());
 			return rank(left) >= rank(right) ? left : right;
 		}
+		if (selector instanceof Selectors.Not) {
+			// A negation says what the element is not, so it can never key a
+			// bucket: doing so would invert which elements are considered.
+			return null;
+		}
 		if (selector instanceof Selectors.IdSelector || selector instanceof Selectors.ClassSelector) {
 			return selector;
 		}

--- a/bundles/org.eclipse.e4.ui.css.core/src/org/eclipse/e4/ui/css/core/impl/engine/selector/SelectorMatcher.java
+++ b/bundles/org.eclipse.e4.ui.css.core/src/org/eclipse/e4/ui/css/core/impl/engine/selector/SelectorMatcher.java
@@ -24,6 +24,7 @@ import org.eclipse.e4.ui.css.core.impl.engine.selector.Selectors.ClassSelector;
 import org.eclipse.e4.ui.css.core.impl.engine.selector.Selectors.Descendant;
 import org.eclipse.e4.ui.css.core.impl.engine.selector.Selectors.ElementType;
 import org.eclipse.e4.ui.css.core.impl.engine.selector.Selectors.IdSelector;
+import org.eclipse.e4.ui.css.core.impl.engine.selector.Selectors.Not;
 import org.eclipse.e4.ui.css.core.impl.engine.selector.Selectors.PseudoClass;
 import org.eclipse.e4.ui.css.core.impl.engine.selector.Selectors.Selector;
 import org.eclipse.e4.ui.css.core.impl.engine.selector.Selectors.SelectorList;
@@ -95,6 +96,9 @@ public final class SelectorMatcher {
 		}
 		if (selector instanceof PseudoClass pc) {
 			return matchesPseudoClass(pc, element, pseudoElement);
+		}
+		if (selector instanceof Not not) {
+			return !matches(not.argument(), element, pseudoElement, hierarchy, hierarchyIndex);
 		}
 		if (selector instanceof And and) {
 			return matches(and.left(), element, pseudoElement, hierarchy, hierarchyIndex)

--- a/bundles/org.eclipse.e4.ui.css.core/src/org/eclipse/e4/ui/css/core/impl/engine/selector/Selectors.java
+++ b/bundles/org.eclipse.e4.ui.css.core/src/org/eclipse/e4/ui/css/core/impl/engine/selector/Selectors.java
@@ -41,7 +41,7 @@ public final class Selectors {
 	/** A parsed CSS selector. Sealed; pattern-match in the matcher. */
 	public sealed interface Selector
 			permits Universal, ElementType, ClassSelector, IdSelector, AttributeSelector,
-			AttributeIncludes, AttributeBeginHyphen, PseudoClass, And, Descendant, Child, Adjacent, SelectorList {
+			AttributeIncludes, AttributeBeginHyphen, PseudoClass, Not, And, Descendant, Child, Adjacent, SelectorList {
 
 		/** CSS specificity contribution of this selector. */
 		int specificity();
@@ -192,6 +192,29 @@ public final class Selectors {
 		@Override
 		public String text() {
 			return ":" + name; //$NON-NLS-1$
+		}
+
+		@Override
+		public String toString() {
+			return text();
+		}
+	}
+
+	/**
+	 * {@code :not(argument)} — matches when {@code argument} does not match
+	 * the element. The argument is a single simple selector; CSS3 forbids
+	 * combinators and nesting inside {@code :not()}.
+	 */
+	public record Not(Selector argument) implements Selector {
+		@Override
+		public int specificity() {
+			// CSS3: :not() itself contributes nothing, its argument counts.
+			return argument.specificity();
+		}
+
+		@Override
+		public String text() {
+			return ":not(" + argument.text() + ")"; //$NON-NLS-1$ //$NON-NLS-2$
 		}
 
 		@Override

--- a/bundles/org.eclipse.e4.ui.css.core/src/org/eclipse/e4/ui/css/core/impl/parser/CssParser.java
+++ b/bundles/org.eclipse.e4.ui.css.core/src/org/eclipse/e4/ui/css/core/impl/parser/CssParser.java
@@ -43,6 +43,7 @@ import org.eclipse.e4.ui.css.core.impl.engine.selector.Selectors.ClassSelector;
 import org.eclipse.e4.ui.css.core.impl.engine.selector.Selectors.Descendant;
 import org.eclipse.e4.ui.css.core.impl.engine.selector.Selectors.ElementType;
 import org.eclipse.e4.ui.css.core.impl.engine.selector.Selectors.IdSelector;
+import org.eclipse.e4.ui.css.core.impl.engine.selector.Selectors.Not;
 import org.eclipse.e4.ui.css.core.impl.engine.selector.Selectors.PseudoClass;
 import org.eclipse.e4.ui.css.core.impl.engine.selector.Selectors.Selector;
 import org.eclipse.e4.ui.css.core.impl.engine.selector.Selectors.Universal;
@@ -406,13 +407,20 @@ public final class CssParser {
 			case LBRACKET:
 				conditions.add(attribute());
 				break;
-			case COLON:
+			case COLON: {
 				advance();
-				if (peek().kind == Kind.COLON) {
+				boolean pseudoElement = peek().kind == Kind.COLON;
+				if (pseudoElement) {
 					advance(); // pseudo-element ::, modelled as a pseudo-class
 				}
-				conditions.add(new PseudoClass(expect(Kind.IDENT).text));
+				if (!pseudoElement && peek().kind == Kind.FUNCTION && peek().text.equalsIgnoreCase("not")) { //$NON-NLS-1$
+					advance(); // FUNCTION consumes the '('
+					conditions.add(new Not(notArgument()));
+				} else {
+					conditions.add(new PseudoClass(expect(Kind.IDENT).text));
+				}
 				break;
+			}
 			default:
 				reading = false;
 				break;
@@ -429,6 +437,33 @@ public final class CssParser {
 		// A universal element before conditions is dropped: '.foo' and '*[a]'
 		// carry no element-type contribution.
 		return element instanceof ElementType ? new And(element, conditionTree) : conditionTree;
+	}
+
+	/**
+	 * The argument of {@code :not()}: a single simple selector, per CSS3. A
+	 * pseudo-class argument is rejected because negating one would have to
+	 * invert the engine's static-pseudo-instance carve-out, which the cascade
+	 * relies on.
+	 */
+	private Selector notArgument() {
+		skipWhitespace();
+		Selector argument = switch (peek().kind) {
+		case STAR -> {
+			advance();
+			yield new Universal();
+		}
+		case IDENT -> new ElementType(advance().text);
+		case DOT -> {
+			advance();
+			yield new ClassSelector(expect(Kind.IDENT).text);
+		}
+		case HASH -> new IdSelector(advance().text);
+		case LBRACKET -> attribute();
+		default -> throw error("Expected a simple selector in :not(), found " + peek()); //$NON-NLS-1$
+		};
+		skipWhitespace();
+		expect(Kind.RPAREN);
+		return argument;
 	}
 
 	private Selector attribute() {

--- a/tests/org.eclipse.e4.ui.tests.css.core/src/org/eclipse/e4/ui/css/core/impl/engine/selector/SelectorMatcherTest.java
+++ b/tests/org.eclipse.e4.ui.tests.css.core/src/org/eclipse/e4/ui/css/core/impl/engine/selector/SelectorMatcherTest.java
@@ -30,6 +30,7 @@ import org.eclipse.e4.ui.css.core.impl.engine.selector.Selectors.ClassSelector;
 import org.eclipse.e4.ui.css.core.impl.engine.selector.Selectors.Descendant;
 import org.eclipse.e4.ui.css.core.impl.engine.selector.Selectors.ElementType;
 import org.eclipse.e4.ui.css.core.impl.engine.selector.Selectors.IdSelector;
+import org.eclipse.e4.ui.css.core.impl.engine.selector.Selectors.Not;
 import org.eclipse.e4.ui.css.core.impl.engine.selector.Selectors.PseudoClass;
 import org.eclipse.e4.ui.css.core.impl.engine.selector.Selectors.SelectorList;
 import org.eclipse.e4.ui.css.core.impl.engine.selector.Selectors.Universal;
@@ -59,6 +60,30 @@ class SelectorMatcherTest {
 			e.setId(id);
 		}
 		return e;
+	}
+
+	@Test
+	void notInvertsItsArgument() {
+		TestElement toolbar = element("Composite", "ToolbarComposite", null);
+		TestElement plain = element("Composite", "other", null);
+
+		assertFalse(SelectorMatcher.matches(new Not(new ClassSelector("ToolbarComposite")), toolbar, null));
+		assertTrue(SelectorMatcher.matches(new Not(new ClassSelector("ToolbarComposite")), plain, null));
+	}
+
+	@Test
+	void notComposesInsideACompound() {
+		Selectors.Selector selector = new And(new ElementType("Composite"),
+				new Not(new ClassSelector("ToolbarComposite")));
+
+		assertTrue(SelectorMatcher.matches(selector, element("Composite", "other", null), null));
+		assertFalse(SelectorMatcher.matches(selector, element("Composite", "ToolbarComposite", null), null));
+		assertFalse(SelectorMatcher.matches(selector, element("Button", "other", null), null));
+	}
+
+	@Test
+	void notOfUniversalNeverMatches() {
+		assertFalse(SelectorMatcher.matches(new Not(new Universal()), element("Button", null, null), null));
 	}
 
 	@Test

--- a/tests/org.eclipse.e4.ui.tests.css.core/src/org/eclipse/e4/ui/tests/css/core/RuleIndexTest.java
+++ b/tests/org.eclipse.e4.ui.tests.css.core/src/org/eclipse/e4/ui/tests/css/core/RuleIndexTest.java
@@ -55,6 +55,9 @@ public class RuleIndexTest {
 			Shell Composite Button.warning { p16: v; }
 			Composite > Button#go { p17: v; }
 			.other.warning { p18: v; }
+			Composite:not(.warning) { p19: v; }
+			:not(.warning) { p20: v; }
+			Button:not(#go) { p21: v; }
 			""";
 
 	private CSSEngine engine;
@@ -126,6 +129,16 @@ public class RuleIndexTest {
 		}
 		assertEquals(linearMatches, indexedMatches,
 				"index dropped matching alternatives for " + element.getLocalName());
+	}
+
+	@Test
+	void testNegationIsNeverABucketKey() {
+		// ':not(.warning)' must not land in the 'warning' class bucket: it
+		// applies to elements that do not carry the class at all.
+		TestElement plain = new TestElement("Canvas", engine);
+		boolean found = index.candidatesFor(plain).stream()
+				.anyMatch(candidate -> candidate.selector().text().equals(":not(.warning)"));
+		assertTrue(found, "a bare negation must be a candidate for every element");
 	}
 
 	@Test

--- a/tests/org.eclipse.e4.ui.tests.css.core/src/org/eclipse/e4/ui/tests/css/core/parser/SelectorTest.java
+++ b/tests/org.eclipse.e4.ui.tests.css.core/src/org/eclipse/e4/ui/tests/css/core/parser/SelectorTest.java
@@ -42,6 +42,43 @@ public class SelectorTest {
 	}
 
 	@Test
+	void testNotSelector() throws Exception {
+		Selectors.SelectorList list = engine.parseSelectors("Composite:not(.Toolbar)");
+		assertEquals(1, list.getLength());
+		assertEquals("Composite:not(.Toolbar)", list.item(0).text());
+	}
+
+	@Test
+	void testNotSelectorAcceptsEverySimpleSelector() throws Exception {
+		assertEquals("Button:not(*)", engine.parseSelectors("Button:not(*)").item(0).text());
+		assertEquals("Button:not(Label)", engine.parseSelectors("Button:not(Label)").item(0).text());
+		assertEquals("Button:not(.warning)", engine.parseSelectors("Button:not(.warning)").item(0).text());
+		assertEquals("Button:not(#go)", engine.parseSelectors("Button:not(#go)").item(0).text());
+		assertEquals("Button:not([role='editor'])", engine.parseSelectors("Button:not([role='editor'])").item(0).text());
+	}
+
+	@Test
+	void testNotSelectorSpecificity() throws Exception {
+		// CSS3: :not() adds nothing, its argument counts normally.
+		assertEquals(engine.parseSelectors("Button.warning").item(0).specificity(),
+				engine.parseSelectors("Button:not(.warning)").item(0).specificity());
+		assertEquals(engine.parseSelectors("Button").item(0).specificity(),
+				engine.parseSelectors("Button:not(*)").item(0).specificity());
+	}
+
+	@Test
+	void testNotSelectorRejectsUnsupportedArguments() {
+		// CSS3 allows a pseudo-class here; the engine does not, because
+		// negating one would invert the static-pseudo-instance carve-out.
+		assertThrows(CssParseException.class, () -> engine.parseSelectors("Button:not(:selected)"));
+		assertThrows(CssParseException.class, () -> engine.parseSelectors("Button:not()"));
+		assertThrows(CssParseException.class, () -> engine.parseSelectors("Button:not(.a"));
+		// No combinators and no nesting inside :not().
+		assertThrows(CssParseException.class, () -> engine.parseSelectors("Button:not(Composite Label)"));
+		assertThrows(CssParseException.class, () -> engine.parseSelectors("Button:not(:not(.a))"));
+	}
+
+	@Test
 	void testMultipleSelectors() throws Exception {
 		Selectors.SelectorList list = engine.parseSelectors("Type1, Type2");
 		assertNotNull(list);


### PR DESCRIPTION
CSS has no way to unset a declaration, so a broad rule cannot be made to stop applying to one subtree. :not() is the only construct that can carve that exception out, and themes need it wherever a widget has to keep the background SWT paints for its position rather than a declared one.

The argument is a single simple selector, as CSS3 requires, and a pseudo-class argument is rejected rather than supported: negating one would have to invert the static-pseudo-instance carve-out that pseudo-class matching relies on. Specificity follows CSS3, where :not() contributes nothing itself and its argument counts normally, and the rule index refuses to key a bucket on a negation, since a negation says what an element is not.

Verified with the org.eclipse.e4.ui.tests.css.core suite (139 tests) on Linux.