### PR TITLE
Support @media rules with platform features in the CSS engine

### DIFF
--- a/bundles/org.eclipse.e4.ui.css.core/src/org/eclipse/e4/ui/css/core/impl/dom/CSSMediaRuleImpl.java
+++ b/bundles/org.eclipse.e4.ui.css.core/src/org/eclipse/e4/ui/css/core/impl/dom/CSSMediaRuleImpl.java
@@ -1,0 +1,53 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Lars Vogel and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Lars Vogel <Lars.Vogel@vogella.com> - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.e4.ui.css.core.impl.dom;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * An {@code @media} rule: a query list plus the style rules it guards. The
+ * rules join the cascade at this rule's position while the query matches.
+ */
+public final class CSSMediaRuleImpl implements CssRule {
+
+	private final List<Media.Query> queries;
+	private final List<CSSStyleRuleImpl> rules;
+
+	public CSSMediaRuleImpl(List<Media.Query> queries, List<CSSStyleRuleImpl> rules) {
+		this.queries = List.copyOf(queries);
+		this.rules = List.copyOf(rules);
+	}
+
+	public List<Media.Query> getQueries() {
+		return queries;
+	}
+
+	public List<CSSStyleRuleImpl> getRules() {
+		return rules;
+	}
+
+	public boolean matches(Media.Context context) {
+		return Media.matches(queries, context);
+	}
+
+	public String getMediaText() {
+		return queries.stream().map(Media.Query::text).collect(Collectors.joining(", ")); //$NON-NLS-1$
+	}
+
+	@Override
+	public String toString() {
+		return "@media " + getMediaText(); //$NON-NLS-1$
+	}
+}

--- a/bundles/org.eclipse.e4.ui.css.core/src/org/eclipse/e4/ui/css/core/impl/dom/CssRule.java
+++ b/bundles/org.eclipse.e4.ui.css.core/src/org/eclipse/e4/ui/css/core/impl/dom/CssRule.java
@@ -14,7 +14,8 @@
 package org.eclipse.e4.ui.css.core.impl.dom;
 
 /**
- * A rule in a parsed stylesheet: either a style rule or an {@code @import}.
+ * A rule in a parsed stylesheet: a style rule, an {@code @import} or an
+ * {@code @media} block.
  */
-public sealed interface CssRule permits CSSStyleRuleImpl, CSSImportRuleImpl {
+public sealed interface CssRule permits CSSStyleRuleImpl, CSSImportRuleImpl, CSSMediaRuleImpl {
 }

--- a/bundles/org.eclipse.e4.ui.css.core/src/org/eclipse/e4/ui/css/core/impl/dom/Media.java
+++ b/bundles/org.eclipse.e4.ui.css.core/src/org/eclipse/e4/ui/css/core/impl/dom/Media.java
@@ -18,15 +18,16 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import org.eclipse.core.runtime.Platform;
+import org.osgi.framework.Bundle;
 
 /**
  * Media query model for {@code @media} rules.
  *
  * <p>
  * The media types {@code all} and {@code screen} match, plus vendor features
- * for the operating system, the windowing system and the operating system
- * version. Unknown types, features and values evaluate to false, as Media
- * Queries requires.
+ * for the operating system, the windowing system, the operating system version
+ * and the installed bundles. Unknown types, features and values evaluate to
+ * false, as Media Queries requires.
  * </p>
  */
 public final class Media {
@@ -46,7 +47,24 @@ public final class Media {
 	/** Upper bound on the operating system version, inclusive. */
 	public static final String FEATURE_MAX_OS_VERSION = "-eclipse-max-os-version"; //$NON-NLS-1$
 
+	/** Feature naming a bundle that has to be installed. */
+	public static final String FEATURE_BUNDLE = "-eclipse-bundle"; //$NON-NLS-1$
+
+	/** Feature naming a bundle and its version, e.g. {@code "org.eclipse.ui 3.2"}. */
+	public static final String FEATURE_BUNDLE_VERSION = "-eclipse-bundle-version"; //$NON-NLS-1$
+
+	/** Lower bound on a bundle's version, inclusive. */
+	public static final String FEATURE_MIN_BUNDLE_VERSION = "-eclipse-min-bundle-version"; //$NON-NLS-1$
+
+	/** Upper bound on a bundle's version, inclusive. */
+	public static final String FEATURE_MAX_BUNDLE_VERSION = "-eclipse-max-bundle-version"; //$NON-NLS-1$
+
+	private static final List<String> BUNDLE_FEATURES = List.of(FEATURE_BUNDLE, FEATURE_BUNDLE_VERSION,
+			FEATURE_MIN_BUNDLE_VERSION, FEATURE_MAX_BUNDLE_VERSION);
+
 	private static final Pattern NON_DIGITS = Pattern.compile("[^0-9]+"); //$NON-NLS-1$
+
+	private static final Pattern WHITESPACE = Pattern.compile("\\s+"); //$NON-NLS-1$
 
 	private static final List<String> SUPPORTED_TYPES = List.of("all", "screen"); //$NON-NLS-1$ //$NON-NLS-2$
 
@@ -54,16 +72,40 @@ public final class Media {
 		// constants and nested types only
 	}
 
-	/** The environment a query is evaluated against. */
-	public record Context(String os, String ws, String osVersion) {
+	/** Looks a bundle's version up by symbolic name. */
+	@FunctionalInterface
+	public interface BundleVersions {
+
+		/** The version of that bundle, or {@code null} when it is not installed. */
+		String versionOf(String symbolicName);
+	}
+
+	/**
+	 * The environment a query is evaluated against. The installed bundles can
+	 * change while the workbench runs, so a bundle query answers for the moment
+	 * the rules were indexed.
+	 */
+	public record Context(String os, String ws, String osVersion, BundleVersions bundles) {
+
+		private static final BundleVersions NONE_INSTALLED = symbolicName -> null;
 
 		public Context(String os, String ws) {
-			this(os, ws, null);
+			this(os, ws, null, NONE_INSTALLED);
+		}
+
+		public Context(String os, String ws, String osVersion) {
+			this(os, ws, osVersion, NONE_INSTALLED);
 		}
 
 		/** The platform this workbench runs on. */
 		public static Context current() {
-			return new Context(Platform.getOS(), Platform.getWS(), System.getProperty("os.version")); //$NON-NLS-1$
+			return new Context(Platform.getOS(), Platform.getWS(), System.getProperty("os.version"), //$NON-NLS-1$
+					Context::installedVersion);
+		}
+
+		private static String installedVersion(String symbolicName) {
+			Bundle bundle = Platform.getBundle(symbolicName);
+			return bundle == null ? null : bundle.getVersion().toString();
 		}
 	}
 
@@ -75,6 +117,9 @@ public final class Media {
 
 		boolean matches(Context context) {
 			String feature = name.toLowerCase();
+			if (BUNDLE_FEATURES.contains(feature)) {
+				return matchesBundle(feature, context);
+			}
 			String actual = switch (feature) {
 			case FEATURE_OS -> context.os();
 			case FEATURE_WS -> context.ws();
@@ -92,6 +137,33 @@ public final class Media {
 			case FEATURE_MIN_OS_VERSION -> compareVersions(actual, value) >= 0;
 			case FEATURE_MAX_OS_VERSION -> compareVersions(actual, value) <= 0;
 			default -> actual.equalsIgnoreCase(value);
+			};
+		}
+
+		/**
+		 * A bundle feature names its subject in its value, as
+		 * {@code "<symbolic name> <version>"}: features are evaluated one by one
+		 * and cannot refer to each other.
+		 */
+		private boolean matchesBundle(String feature, Context context) {
+			if (value == null) {
+				return false; // the boolean form names no bundle
+			}
+			String[] parts = WHITESPACE.split(value.trim(), 2);
+			String installed = context.bundles().versionOf(parts[0]);
+			if (installed == null) {
+				return false;
+			}
+			if (feature.equals(FEATURE_BUNDLE)) {
+				return true;
+			}
+			if (parts.length < 2) {
+				return false; // a bound needs a version to compare against
+			}
+			return switch (feature) {
+			case FEATURE_BUNDLE_VERSION -> compareVersions(installed, parts[1]) == 0;
+			case FEATURE_MIN_BUNDLE_VERSION -> compareVersions(installed, parts[1]) >= 0;
+			default -> compareVersions(installed, parts[1]) <= 0;
 			};
 		}
 

--- a/bundles/org.eclipse.e4.ui.css.core/src/org/eclipse/e4/ui/css/core/impl/dom/Media.java
+++ b/bundles/org.eclipse.e4.ui.css.core/src/org/eclipse/e4/ui/css/core/impl/dom/Media.java
@@ -1,0 +1,163 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Lars Vogel and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Lars Vogel <Lars.Vogel@vogella.com> - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.e4.ui.css.core.impl.dom;
+
+import java.util.List;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+import org.eclipse.core.runtime.Platform;
+
+/**
+ * Media query model for {@code @media} rules.
+ *
+ * <p>
+ * The media types {@code all} and {@code screen} match, plus vendor features
+ * for the operating system, the windowing system and the operating system
+ * version. Unknown types, features and values evaluate to false, as Media
+ * Queries requires.
+ * </p>
+ */
+public final class Media {
+
+	/** Feature naming the operating system, e.g. {@code linux}. */
+	public static final String FEATURE_OS = "-eclipse-os"; //$NON-NLS-1$
+
+	/** Feature naming the windowing system, e.g. {@code gtk}. */
+	public static final String FEATURE_WS = "-eclipse-ws"; //$NON-NLS-1$
+
+	/** Feature naming the operating system version, e.g. {@code "10.15"}. */
+	public static final String FEATURE_OS_VERSION = "-eclipse-os-version"; //$NON-NLS-1$
+
+	/** Lower bound on the operating system version, inclusive. */
+	public static final String FEATURE_MIN_OS_VERSION = "-eclipse-min-os-version"; //$NON-NLS-1$
+
+	/** Upper bound on the operating system version, inclusive. */
+	public static final String FEATURE_MAX_OS_VERSION = "-eclipse-max-os-version"; //$NON-NLS-1$
+
+	private static final Pattern NON_DIGITS = Pattern.compile("[^0-9]+"); //$NON-NLS-1$
+
+	private static final List<String> SUPPORTED_TYPES = List.of("all", "screen"); //$NON-NLS-1$ //$NON-NLS-2$
+
+	private Media() {
+		// constants and nested types only
+	}
+
+	/** The environment a query is evaluated against. */
+	public record Context(String os, String ws, String osVersion) {
+
+		public Context(String os, String ws) {
+			this(os, ws, null);
+		}
+
+		/** The platform this workbench runs on. */
+		public static Context current() {
+			return new Context(Platform.getOS(), Platform.getWS(), System.getProperty("os.version")); //$NON-NLS-1$
+		}
+	}
+
+	/**
+	 * One {@code (name: value)} expression. A {@code null} value is the boolean
+	 * form {@code (name)}, true whenever the feature has a value at all.
+	 */
+	public record Feature(String name, String value) {
+
+		boolean matches(Context context) {
+			String feature = name.toLowerCase();
+			String actual = switch (feature) {
+			case FEATURE_OS -> context.os();
+			case FEATURE_WS -> context.ws();
+			case FEATURE_OS_VERSION, FEATURE_MIN_OS_VERSION, FEATURE_MAX_OS_VERSION -> context.osVersion();
+			default -> null;
+			};
+			if (actual == null || actual.isEmpty()) {
+				return false;
+			}
+			if (value == null) {
+				return true;
+			}
+			return switch (feature) {
+			case FEATURE_OS_VERSION -> compareVersions(actual, value) == 0;
+			case FEATURE_MIN_OS_VERSION -> compareVersions(actual, value) >= 0;
+			case FEATURE_MAX_OS_VERSION -> compareVersions(actual, value) <= 0;
+			default -> actual.equalsIgnoreCase(value);
+			};
+		}
+
+		String text() {
+			return value == null ? "(" + name + ")" : "(" + name + ": " + value + ")"; //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
+		}
+	}
+
+	/**
+	 * A single media query: an optional {@code not}, a media type and the
+	 * features joined to it with {@code and}.
+	 */
+	public record Query(boolean negated, String type, List<Feature> features) {
+
+		/** {@code not all}, what a malformed query evaluates to. */
+		public static final Query NEVER = new Query(true, "all", List.of()); //$NON-NLS-1$
+
+		public Query {
+			features = List.copyOf(features);
+		}
+
+		public boolean matches(Context context) {
+			boolean matched = SUPPORTED_TYPES.contains(type.toLowerCase())
+					&& features.stream().allMatch(feature -> feature.matches(context));
+			return negated != matched;
+		}
+
+		public String text() {
+			String expressions = features.stream().map(Feature::text).collect(Collectors.joining(" and ")); //$NON-NLS-1$
+			String prefix = negated ? "not " + type : type; //$NON-NLS-1$
+			return expressions.isEmpty() ? prefix : prefix + " and " + expressions; //$NON-NLS-1$
+		}
+
+		@Override
+		public String toString() {
+			return text();
+		}
+	}
+
+	/**
+	 * Compares versions over the segments the value gives, so its precision is
+	 * the granularity: {@code "10.15"} covers all of 10.15.x. Anything that is
+	 * not a digit separates segments, dropping a {@code -33-generic} tail.
+	 */
+	private static int compareVersions(String actual, String required) {
+		long[] left = segments(actual);
+		long[] right = segments(required);
+		for (int i = 0; i < right.length; i++) {
+			int difference = Long.compare(i < left.length ? left[i] : 0, right[i]);
+			if (difference != 0) {
+				return difference;
+			}
+		}
+		return 0;
+	}
+
+	private static long[] segments(String version) {
+		return NON_DIGITS.splitAsStream(version).filter(part -> !part.isEmpty())
+				.mapToLong(part -> part.length() > 18 ? Long.MAX_VALUE : Long.parseLong(part)).toArray();
+	}
+
+	/**
+	 * Whether a comma separated query list applies. Any query matching is
+	 * enough, and an empty list matches everything.
+	 */
+	public static boolean matches(List<Query> queries, Context context) {
+		return queries.isEmpty() || queries.stream().anyMatch(query -> query.matches(context));
+	}
+}

--- a/bundles/org.eclipse.e4.ui.css.core/src/org/eclipse/e4/ui/css/core/impl/engine/selector/RuleIndex.java
+++ b/bundles/org.eclipse.e4.ui.css.core/src/org/eclipse/e4/ui/css/core/impl/engine/selector/RuleIndex.java
@@ -21,9 +21,11 @@ import java.util.List;
 import java.util.Map;
 
 import org.eclipse.e4.ui.css.core.dom.CSSStylableElement;
+import org.eclipse.e4.ui.css.core.impl.dom.CSSMediaRuleImpl;
 import org.eclipse.e4.ui.css.core.impl.dom.CSSStyleRuleImpl;
 import org.eclipse.e4.ui.css.core.impl.dom.CSSStyleSheetImpl;
 import org.eclipse.e4.ui.css.core.impl.dom.CssRule;
+import org.eclipse.e4.ui.css.core.impl.dom.Media;
 import org.eclipse.e4.ui.css.core.impl.engine.selector.Selectors.Selector;
 import org.w3c.dom.Element;
 
@@ -49,19 +51,34 @@ public final class RuleIndex {
 	private RuleIndex() {
 	}
 
-	/** Indexes every style rule of the given stylesheets in cascade order. */
+	/** Indexes every style rule in cascade order, for the running platform. */
 	public static RuleIndex of(List<CSSStyleSheetImpl> styleSheets) {
+		return of(styleSheets, Media.Context.current());
+	}
+
+	/**
+	 * Indexes every style rule in cascade order. A rule guarded by an
+	 * {@code @media} query is indexed at its block's position, and only when
+	 * the query matches.
+	 */
+	public static RuleIndex of(List<CSSStyleSheetImpl> styleSheets, Media.Context media) {
 		RuleIndex index = new RuleIndex();
 		for (CSSStyleSheetImpl styleSheet : styleSheets) {
 			for (CssRule rule : styleSheet.getRules()) {
 				if (rule instanceof CSSStyleRuleImpl styleRule) {
-					for (Selector alternative : styleRule.getSelectorList().alternatives()) {
-						index.add(new Candidate(alternative, styleRule, index.all.size()));
-					}
+					index.addRule(styleRule);
+				} else if (rule instanceof CSSMediaRuleImpl mediaRule && mediaRule.matches(media)) {
+					mediaRule.getRules().forEach(index::addRule);
 				}
 			}
 		}
 		return index;
+	}
+
+	private void addRule(CSSStyleRuleImpl styleRule) {
+		for (Selector alternative : styleRule.getSelectorList().alternatives()) {
+			add(new Candidate(alternative, styleRule, all.size()));
+		}
 	}
 
 	private void add(Candidate candidate) {

--- a/bundles/org.eclipse.e4.ui.css.core/src/org/eclipse/e4/ui/css/core/impl/parser/CssParser.java
+++ b/bundles/org.eclipse.e4.ui.css.core/src/org/eclipse/e4/ui/css/core/impl/parser/CssParser.java
@@ -17,6 +17,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.eclipse.e4.ui.css.core.impl.dom.CSSImportRuleImpl;
+import org.eclipse.e4.ui.css.core.impl.dom.CSSMediaRuleImpl;
 import org.eclipse.e4.ui.css.core.impl.dom.CSSPropertyImpl;
 import org.eclipse.e4.ui.css.core.impl.dom.CSSStyleDeclarationImpl;
 import org.eclipse.e4.ui.css.core.impl.dom.CSSStyleRuleImpl;
@@ -32,6 +33,7 @@ import org.eclipse.e4.ui.css.core.impl.dom.CssValues.CssPrimitive;
 import org.eclipse.e4.ui.css.core.impl.dom.CssValues.CssText;
 import org.eclipse.e4.ui.css.core.impl.dom.CssValues.CssUnit;
 import org.eclipse.e4.ui.css.core.impl.dom.CssValues.CssValue;
+import org.eclipse.e4.ui.css.core.impl.dom.Media;
 import org.eclipse.e4.ui.css.core.impl.engine.selector.Selectors;
 import org.eclipse.e4.ui.css.core.impl.engine.selector.Selectors.Adjacent;
 import org.eclipse.e4.ui.css.core.impl.engine.selector.Selectors.And;
@@ -59,7 +61,8 @@ import org.w3c.dom.css.CSSValue;
  * {@link org.eclipse.e4.ui.css.core.impl.dom.CssValues} value records.
  *
  * <p>
- * {@code @media}, {@code @font-face} and {@code @page} are parsed and discarded;
+ * {@code @media} is kept as a media rule holding the style rules it guards;
+ * {@code @font-face} and {@code @page} are parsed and discarded;
  * {@code !important} is recorded on the declaration; {@code @import} is kept as
  * an import rule.
  * </p>
@@ -114,7 +117,7 @@ public final class CssParser {
 				if (peek().kind == Kind.AT_KEYWORD) {
 					atRule(rules);
 				} else {
-					styleRule(rules);
+					rules.add(styleRule());
 				}
 			} catch (CssParseException e) {
 				// CSS 2.1 section 4.2: a malformed rule is dropped and the rest
@@ -163,8 +166,10 @@ public final class CssParser {
 			if (href != null) {
 				rules.add(new CSSImportRuleImpl(href));
 			}
+		} else if (name.equals("media")) { //$NON-NLS-1$
+			rules.add(mediaRule());
 		} else {
-			// @media / @font-face / @page / unknown: parse and discard.
+			// @font-face / @page / unknown: parse and discard.
 			discardUntilStatementEnd();
 		}
 	}
@@ -194,7 +199,7 @@ public final class CssParser {
 		}
 	}
 
-	private void styleRule(List<CssRule> rules) {
+	private CSSStyleRuleImpl styleRule() {
 		Selectors.SelectorList selectors = selectorList();
 		expect(Kind.LBRACE);
 		CSSStyleRuleImpl rule = new CSSStyleRuleImpl(selectors);
@@ -204,7 +209,188 @@ public final class CssParser {
 		if (peek().kind == Kind.RBRACE) {
 			advance();
 		}
-		rules.add(rule);
+		return rule;
+	}
+
+	// ---------- media rules ----------
+
+	/**
+	 * Parse an {@code @media} block. The query list is kept unevaluated, so the
+	 * rule index decides which blocks contribute.
+	 */
+	private CssRule mediaRule() {
+		List<Media.Query> queries = mediaQueryList();
+		expect(Kind.LBRACE);
+		List<CSSStyleRuleImpl> nested = new ArrayList<>();
+		while (true) {
+			skipWhitespace();
+			Kind kind = peek().kind;
+			if (kind == Kind.EOF) {
+				break;
+			}
+			if (kind == Kind.RBRACE) {
+				advance();
+				break;
+			}
+			try {
+				if (kind == Kind.AT_KEYWORD) {
+					// No at-rule nests inside @media in this subset.
+					advance();
+					discardUntilStatementEnd();
+				} else {
+					nested.add(styleRule());
+				}
+			} catch (CssParseException e) {
+				problems.add(e);
+				skipMalformedNestedRule();
+			}
+		}
+		return new CSSMediaRuleImpl(queries, nested);
+	}
+
+	/**
+	 * Consume through the end of a rule nested in a block, stopping before the
+	 * brace that closes the block so the caller still sees it.
+	 */
+	private void skipMalformedNestedRule() {
+		int depth = 0;
+		while (true) {
+			Kind kind = peek().kind;
+			if (kind == Kind.EOF || (kind == Kind.RBRACE && depth == 0)) {
+				return;
+			}
+			advance();
+			if (kind == Kind.LBRACE) {
+				depth++;
+			} else if (kind == Kind.RBRACE && --depth <= 0) {
+				return;
+			} else if (kind == Kind.SEMICOLON && depth == 0) {
+				return;
+			}
+		}
+	}
+
+	private List<Media.Query> mediaQueryList() {
+		List<Media.Query> queries = new ArrayList<>();
+		skipWhitespace();
+		if (peek().kind == Kind.LBRACE) {
+			return queries; // '@media { ... }': an empty list matches everything
+		}
+		while (true) {
+			queries.add(mediaQuery());
+			skipWhitespace();
+			if (peek().kind != Kind.COMMA) {
+				return queries;
+			}
+			advance();
+		}
+	}
+
+	private Media.Query mediaQuery() {
+		int start = index;
+		try {
+			return mediaQueryBody();
+		} catch (CssParseException e) {
+			// Media Queries section 2.1: a malformed query becomes 'not all',
+			// which never matches, and the queries beside it still count.
+			problems.add(e);
+			index = start;
+			skipMediaQuery();
+			return Media.Query.NEVER;
+		}
+	}
+
+	private Media.Query mediaQueryBody() {
+		skipWhitespace();
+		boolean negated = false;
+		if (peekIdent("not")) { //$NON-NLS-1$
+			advance();
+			negated = true;
+			skipWhitespace();
+		} else if (peekIdent("only")) { //$NON-NLS-1$
+			advance(); // legacy hiding keyword, no effect on matching
+			skipWhitespace();
+		}
+
+		String type = "all"; //$NON-NLS-1$
+		if (peek().kind == Kind.IDENT) {
+			type = advance().text;
+			skipWhitespace();
+			if (peek().kind == Kind.LPAREN) {
+				throw error("Expected 'and' between media type and expression"); //$NON-NLS-1$
+			}
+		} else if (peek().kind != Kind.LPAREN) {
+			throw error("Expected a media type or expression, found " + peek()); //$NON-NLS-1$
+		}
+
+		List<Media.Feature> features = new ArrayList<>();
+		if (peek().kind == Kind.LPAREN) {
+			features.add(mediaFeature());
+			skipWhitespace();
+		}
+		while (peekIdent("and")) { //$NON-NLS-1$
+			advance();
+			skipWhitespace();
+			features.add(mediaFeature());
+			skipWhitespace();
+		}
+		return new Media.Query(negated, type, features);
+	}
+
+	private Media.Feature mediaFeature() {
+		expect(Kind.LPAREN);
+		skipWhitespace();
+		String name = expect(Kind.IDENT).text;
+		skipWhitespace();
+		String value = null;
+		if (peek().kind == Kind.COLON) {
+			advance();
+			skipWhitespace();
+			value = mediaFeatureValue();
+			skipWhitespace();
+		}
+		expect(Kind.RPAREN);
+		return new Media.Feature(name, value);
+	}
+
+	/**
+	 * The value of a media feature. A dimension is taken as written: an
+	 * expression this engine does not know is a false query, not a parse error.
+	 */
+	private String mediaFeatureValue() {
+		Token token = peek();
+		switch (token.kind) {
+		case IDENT, STRING:
+			advance();
+			return token.text;
+		case NUMBER, DIMENSION, PERCENTAGE:
+			advance();
+			return token.unit == null ? token.text : token.text + token.unit;
+		default:
+			throw error("Expected a media feature value, found " + token); //$NON-NLS-1$
+		}
+	}
+
+	/** Skip to the end of a malformed query, leaving the ',' or '{' in place. */
+	private void skipMediaQuery() {
+		int depth = 0;
+		while (true) {
+			Kind kind = peek().kind;
+			if (kind == Kind.EOF || kind == Kind.LBRACE || (kind == Kind.COMMA && depth == 0)) {
+				return;
+			}
+			if (kind == Kind.LPAREN) {
+				depth++;
+			} else if (kind == Kind.RPAREN) {
+				depth--;
+			}
+			advance();
+		}
+	}
+
+	private boolean peekIdent(String keyword) {
+		Token token = peek();
+		return token.kind == Kind.IDENT && token.text.equalsIgnoreCase(keyword);
 	}
 
 	/** Parse declarations up to a closing brace or end of input; the brace is left in place. */

--- a/bundles/org.eclipse.e4.ui.css.core/src/org/eclipse/e4/ui/css/core/impl/parser/CssTokenizer.java
+++ b/bundles/org.eclipse.e4.ui.css.core/src/org/eclipse/e4/ui/css/core/impl/parser/CssTokenizer.java
@@ -28,7 +28,7 @@ final class CssTokenizer {
 
 	enum Kind {
 		IDENT, FUNCTION, AT_KEYWORD, HASH, STRING, BAD_STRING, NUMBER, PERCENTAGE, DIMENSION, URI,
-		COLON, SEMICOLON, COMMA, LBRACE, RBRACE, LBRACKET, RBRACKET, RPAREN,
+		COLON, SEMICOLON, COMMA, LBRACE, RBRACE, LBRACKET, RBRACKET, LPAREN, RPAREN,
 		DOT, STAR, GT, PLUS, TILDE, BAR, EQUALS, INCLUDE_MATCH, DASH_MATCH, BANG,
 		WS, EOF
 	}
@@ -102,6 +102,7 @@ final class CssTokenizer {
 		case '}': advance(); return new Token(Kind.RBRACE, "}", 0, false, null, startLine, startColumn); //$NON-NLS-1$
 		case '[': advance(); return new Token(Kind.LBRACKET, "[", 0, false, null, startLine, startColumn); //$NON-NLS-1$
 		case ']': advance(); return new Token(Kind.RBRACKET, "]", 0, false, null, startLine, startColumn); //$NON-NLS-1$
+		case '(': advance(); return new Token(Kind.LPAREN, "(", 0, false, null, startLine, startColumn); //$NON-NLS-1$
 		case ')': advance(); return new Token(Kind.RPAREN, ")", 0, false, null, startLine, startColumn); //$NON-NLS-1$
 		case ':': advance(); return new Token(Kind.COLON, ":", 0, false, null, startLine, startColumn); //$NON-NLS-1$
 		case ';': advance(); return new Token(Kind.SEMICOLON, ";", 0, false, null, startLine, startColumn); //$NON-NLS-1$

--- a/docs/CSS.md
+++ b/docs/CSS.md
@@ -42,6 +42,17 @@ Quote a version with more than one dot, since `10.15.7` is not a single CSS numb
 Comparison happens over the segments the value gives, so its own precision decides the granularity: `"10.15"` covers all of 10.15.x, and both bounds include the line they name.
 Anything that is not a digit separates segments, which drops a Linux `-33-generic` tail.
 
+A rule can also depend on an installed bundle, which is useful when an optional contribution has to be styled only where it exists.
+The bundle is named in the value, since media features are evaluated one by one and cannot refer to each other, and `-eclipse-bundle-version`, `-eclipse-min-bundle-version` and `-eclipse-max-bundle-version` take a symbolic name followed by a version.
+
+```css
+@media (-eclipse-bundle: "org.eclipse.ui") { ... }
+@media (-eclipse-min-bundle-version: "org.eclipse.ui 3.2") { ... }
+```
+
+Unlike the operating system, the installed bundles can change while the workbench runs.
+A bundle query answers for the moment the rules were indexed, which is when a theme is applied, so a bundle installed afterwards is picked up at the next theme switch.
+
 The usual media query syntax applies: `and` requires every expression, a comma separated list matches when any query does, `not` inverts one query, and the media types `all` and `screen` match while `print` and the rest do not.
 A guarded rule takes part in the cascade at the position of its `@media` block.
 An unknown feature, value or media type simply does not match, so a query written for a browser contributes no rules instead of breaking the sheet.

--- a/docs/CSS.md
+++ b/docs/CSS.md
@@ -16,6 +16,38 @@ The new **CSS** declarative styling support provides developers with the flexibi
 
 Note that while the support for SWT widgets is the primary focus of the current developers that are working on the CSS code, the core engine is **headless** and can be used to "style" other things such as for applying arbitrary properties to a model.
 
+Platform-specific rules
+-----------------------
+
+An `@media` rule restricts the rules it contains to one platform, so a theme can carve out an exception without shipping a second style sheet.
+Two vendor features name the platform, `-eclipse-os` and `-eclipse-ws`, whose values are the ones `Platform.getOS()` and `Platform.getWS()` report (`linux`, `win32`, `macosx` and `gtk`, `win32`, `cocoa`).
+
+```css
+CTabFolder { background-color: #fafafa; }
+
+@media (-eclipse-os: linux) {
+  CTabFolder { background-color: #2f2f2f; }
+}
+```
+
+Three more features cover the operating system version: `-eclipse-os-version`, `-eclipse-min-os-version` and `-eclipse-max-os-version`.
+Quote a version with more than one dot, since `10.15.7` is not a single CSS number.
+
+```css
+@media (-eclipse-os: macosx) and (-eclipse-min-os-version: "10.15") {
+  CTabFolder { background-color: #2f2f2f; }
+}
+```
+
+Comparison happens over the segments the value gives, so its own precision decides the granularity: `"10.15"` covers all of 10.15.x, and both bounds include the line they name.
+Anything that is not a digit separates segments, which drops a Linux `-33-generic` tail.
+
+The usual media query syntax applies: `and` requires every expression, a comma separated list matches when any query does, `not` inverts one query, and the media types `all` and `screen` match while `print` and the rest do not.
+A guarded rule takes part in the cascade at the position of its `@media` block.
+An unknown feature, value or media type simply does not match, so a query written for a browser contributes no rules instead of breaking the sheet.
+
+Rules can also be restricted per platform from the outside, with the `os` and `ws` attributes of the `org.eclipse.e4.ui.css.swt.theme` extension point, which pick a whole style sheet rather than single rules.
+
 Sample
 ------
 

--- a/tests/org.eclipse.e4.ui.tests.css.core/src/org/eclipse/e4/ui/tests/css/core/RuleIndexTest.java
+++ b/tests/org.eclipse.e4.ui.tests.css.core/src/org/eclipse/e4/ui/tests/css/core/RuleIndexTest.java
@@ -22,6 +22,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.eclipse.e4.ui.css.core.engine.CSSEngine;
+import org.eclipse.e4.ui.css.core.impl.dom.Media;
 import org.eclipse.e4.ui.css.core.impl.engine.selector.RuleIndex;
 import org.eclipse.e4.ui.css.core.impl.engine.selector.SelectorMatcher;
 import org.eclipse.e4.ui.tests.css.core.util.ParserTestUtil;
@@ -139,6 +140,24 @@ public class RuleIndexTest {
 		boolean found = index.candidatesFor(plain).stream()
 				.anyMatch(candidate -> candidate.selector().text().equals(":not(.warning)"));
 		assertTrue(found, "a bare negation must be a candidate for every element");
+	}
+
+	@Test
+	void testMediaRulesAreIndexedOnlyWhenTheQueryMatches() throws Exception {
+		String sheet = """
+				Label { color: red; }
+				@media (-eclipse-os: linux) { Label { color: blue; } }
+				""";
+		TestElement label = new TestElement("Label", engine);
+
+		RuleIndex onLinux = RuleIndex.of(List.of(ParserTestUtil.parseCss(sheet)), new Media.Context("linux", "gtk"));
+		assertEquals(2, onLinux.candidatesFor(label).size());
+		// The guarded rule keeps the position of its block, so it still wins.
+		assertEquals(1, onLinux.candidatesFor(label).get(1).order());
+
+		RuleIndex onWindows = RuleIndex.of(List.of(ParserTestUtil.parseCss(sheet)),
+				new Media.Context("win32", "win32"));
+		assertEquals(1, onWindows.candidatesFor(label).size());
 	}
 
 	@Test

--- a/tests/org.eclipse.e4.ui.tests.css.core/src/org/eclipse/e4/ui/tests/css/core/parser/CssParserTest.java
+++ b/tests/org.eclipse.e4.ui.tests.css.core/src/org/eclipse/e4/ui/tests/css/core/parser/CssParserTest.java
@@ -26,6 +26,7 @@ import org.junit.jupiter.api.Test;
 import java.util.List;
 
 import org.eclipse.e4.ui.css.core.impl.dom.CSSImportRuleImpl;
+import org.eclipse.e4.ui.css.core.impl.dom.CSSMediaRuleImpl;
 import org.eclipse.e4.ui.css.core.impl.dom.CSSStyleRuleImpl;
 import org.eclipse.e4.ui.css.core.impl.dom.CSSStyleSheetImpl;
 import org.eclipse.e4.ui.css.core.impl.dom.CssRule;
@@ -194,16 +195,18 @@ public class CssParserTest {
 	}
 
 	@Test
-	void testMediaAndFontFaceDiscardedFollowingRuleKept() {
+	void testFontFaceDiscardedMediaKeptFollowingRuleKept() {
 		CSSStyleSheetImpl sheet = CssParser.parseStyleSheet("""
 				@font-face { font-family: x; }
-				@media screen { Hidden { color: red; } }
+				@media screen { Guarded { color: red; } }
 				Label { color: blue; }
 				""");
-		// Both at-rules are discarded entirely; only the top-level Label remains.
+		// @font-face is discarded, @media keeps the rules it guards.
 		List<CssRule> rules = sheet.getRules();
-		assertEquals(1, rules.size());
-		CSSStyleRuleImpl label = (CSSStyleRuleImpl) rules.get(0);
+		assertEquals(2, rules.size());
+		CSSMediaRuleImpl media = (CSSMediaRuleImpl) rules.get(0);
+		assertEquals("Guarded", media.getRules().get(0).getSelectorText());
+		CSSStyleRuleImpl label = (CSSStyleRuleImpl) rules.get(1);
 		assertEquals("Label", label.getSelectorText());
 		assertEquals("blue", label.getStyle().getPropertyCSSValue("color").getCssText());
 	}

--- a/tests/org.eclipse.e4.ui.tests.css.core/src/org/eclipse/e4/ui/tests/css/core/parser/MediaRulesTest.java
+++ b/tests/org.eclipse.e4.ui.tests.css.core/src/org/eclipse/e4/ui/tests/css/core/parser/MediaRulesTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2009, 2014 EclipseSource and others.
+ * Copyright (c) 2009, 2026 EclipseSource and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -16,32 +16,218 @@ package org.eclipse.e4.ui.tests.css.core.parser;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.List;
+
+import org.eclipse.e4.ui.css.core.impl.dom.CSSMediaRuleImpl;
 import org.eclipse.e4.ui.css.core.impl.dom.CSSStyleRuleImpl;
 import org.eclipse.e4.ui.css.core.impl.dom.CSSStyleSheetImpl;
+import org.eclipse.e4.ui.css.core.impl.dom.CssRule;
+import org.eclipse.e4.ui.css.core.impl.dom.Media;
 import org.eclipse.e4.ui.tests.css.core.util.ParserTestUtil;
 import org.junit.jupiter.api.Test;
 
 /**
- * Assert that <code>@media</code> rules are ignored.
+ * Verifies {@code @media} parsing and the platform features the engine
+ * evaluates its queries against.
  */
 public class MediaRulesTest {
 
+	private static final Media.Context LINUX = new Media.Context("linux", "gtk", "6.14.0-33-generic");
+	private static final Media.Context WINDOWS = new Media.Context("win32", "win32", "10.0");
+	private static final Media.Context MACOS = new Media.Context("macosx", "cocoa", "10.15.7");
+
+	private static CSSMediaRuleImpl parseMediaRule(String css) {
+		CSSStyleSheetImpl styleSheet = ParserTestUtil.parseCssWithoutImports(css);
+		assertTrue(styleSheet.getProblems().isEmpty(), "unexpected parse problems: " + styleSheet.getProblems());
+		CssRule rule = styleSheet.getRules().get(0);
+		assertTrue(rule instanceof CSSMediaRuleImpl, "expected a media rule, got " + rule);
+		return (CSSMediaRuleImpl) rule;
+	}
+
 	@Test
-	void testMediaRule() throws Exception {
+	void testMediaBlockKeepsItsRules() {
 		String css = """
 				@media screen, print {
 				BODY { line-height: 1.2 }
+				Label { color: #FF0000 }
 				}
 				Label { background-color: #FF0000 }""";
-		CSSStyleSheetImpl styleSheet = ParserTestUtil.parseCss(css);
-		assertNotNull(styleSheet);
-		// The @media block is discarded entirely; only the following top-level
-		// rule remains, with its declaration intact.
-		assertEquals(1, styleSheet.getRules().size());
-		assertFalse(((CSSStyleRuleImpl) styleSheet.getRules().get(0)).getCssText().contains("line-height"));
-		assertTrue(((CSSStyleRuleImpl) styleSheet.getRules().get(0)).getCssText().contains("background-color"));
+		CSSStyleSheetImpl styleSheet = ParserTestUtil.parseCssWithoutImports(css);
+
+		assertEquals(2, styleSheet.getRules().size());
+		CSSMediaRuleImpl media = (CSSMediaRuleImpl) styleSheet.getRules().get(0);
+		assertEquals(2, media.getRules().size());
+		assertTrue(media.getRules().get(0).getCssText().contains("line-height"));
+		assertTrue(((CSSStyleRuleImpl) styleSheet.getRules().get(1)).getCssText().contains("background-color"));
+	}
+
+	@Test
+	void testScreenAndAllMatchOtherMediaTypesDoNot() {
+		assertTrue(parseMediaRule("@media screen { Label { color: red } }").matches(LINUX));
+		assertTrue(parseMediaRule("@media all { Label { color: red } }").matches(LINUX));
+		assertFalse(parseMediaRule("@media print { Label { color: red } }").matches(LINUX));
+		assertFalse(parseMediaRule("@media speech { Label { color: red } }").matches(LINUX));
+	}
+
+	@Test
+	void testOperatingSystemFeature() {
+		CSSMediaRuleImpl rule = parseMediaRule("@media (-eclipse-os: linux) { Label { color: red } }");
+		assertTrue(rule.matches(LINUX));
+		assertFalse(rule.matches(WINDOWS));
+	}
+
+	@Test
+	void testWindowingSystemFeature() {
+		CSSMediaRuleImpl rule = parseMediaRule("@media (-eclipse-ws: gtk) { Label { color: red } }");
+		assertTrue(rule.matches(LINUX));
+		assertFalse(rule.matches(WINDOWS));
+	}
+
+	@Test
+	void testFeatureValueIsCaseInsensitive() {
+		assertTrue(parseMediaRule("@media (-ECLIPSE-OS: LINUX) { Label { color: red } }").matches(LINUX));
+	}
+
+	@Test
+	void testBooleanFormIsTrueWheneverTheFeatureHasAValue() {
+		CSSMediaRuleImpl rule = parseMediaRule("@media (-eclipse-os) { Label { color: red } }");
+		assertTrue(rule.matches(LINUX));
+		assertFalse(rule.matches(new Media.Context(null, "gtk")));
+	}
+
+	@Test
+	void testAndRequiresEveryFeature() {
+		CSSMediaRuleImpl rule = parseMediaRule(
+				"@media screen and (-eclipse-os: linux) and (-eclipse-ws: gtk) { Label { color: red } }");
+		assertTrue(rule.matches(LINUX));
+		assertFalse(rule.matches(new Media.Context("linux", "cocoa")));
+	}
+
+	@Test
+	void testCommaIsOr() {
+		CSSMediaRuleImpl rule = parseMediaRule(
+				"@media (-eclipse-os: linux), (-eclipse-os: win32) { Label { color: red } }");
+		assertTrue(rule.matches(LINUX));
+		assertTrue(rule.matches(WINDOWS));
+		assertFalse(rule.matches(new Media.Context("macosx", "cocoa")));
+	}
+
+	@Test
+	void testNotInverts() {
+		assertFalse(parseMediaRule("@media not (-eclipse-os: linux) { Label { color: red } }").matches(LINUX));
+		assertTrue(parseMediaRule("@media not (-eclipse-os: linux) { Label { color: red } }").matches(WINDOWS));
+		assertFalse(parseMediaRule("@media not screen { Label { color: red } }").matches(LINUX));
+	}
+
+	@Test
+	void testOnlyIsIgnored() {
+		assertTrue(parseMediaRule("@media only screen { Label { color: red } }").matches(LINUX));
+	}
+
+	@Test
+	void testOsVersionMatchesAtThePrecisionOfTheValue() {
+		CSSMediaRuleImpl rule = parseMediaRule("@media (-eclipse-os-version: \"10.15\") { Label { color: red } }");
+		assertTrue(rule.matches(MACOS));
+		assertFalse(rule.matches(new Media.Context("macosx", "cocoa", "10.14.6")));
+		assertFalse(rule.matches(new Media.Context("macosx", "cocoa", "11.0")));
+	}
+
+	@Test
+	void testMinOsVersionIsInclusive() {
+		CSSMediaRuleImpl rule = parseMediaRule("@media (-eclipse-min-os-version: \"10.15\") { Label { color: red } }");
+		assertTrue(rule.matches(MACOS));
+		assertTrue(rule.matches(new Media.Context("macosx", "cocoa", "11.0")));
+		assertFalse(rule.matches(new Media.Context("macosx", "cocoa", "10.14.6")));
+	}
+
+	@Test
+	void testMaxOsVersionCoversTheWholeLineItNames() {
+		CSSMediaRuleImpl rule = parseMediaRule("@media (-eclipse-max-os-version: \"10.15\") { Label { color: red } }");
+		assertTrue(rule.matches(MACOS));
+		assertTrue(rule.matches(new Media.Context("macosx", "cocoa", "10.14.6")));
+		assertFalse(rule.matches(new Media.Context("macosx", "cocoa", "11.0")));
+	}
+
+	@Test
+	void testOsVersionIgnoresANonNumericTail() {
+		assertTrue(parseMediaRule("@media (-eclipse-min-os-version: \"6.14\") { Label { color: red } }")
+				.matches(LINUX));
+	}
+
+	@Test
+	void testOsVersionCombinesWithTheOperatingSystem() {
+		CSSMediaRuleImpl rule = parseMediaRule(
+				"@media (-eclipse-os: macosx) and (-eclipse-min-os-version: \"10.15\") { Label { color: red } }");
+		assertTrue(rule.matches(MACOS));
+		assertFalse(rule.matches(LINUX));
+	}
+
+	@Test
+	void testOsVersionNeverMatchesWhenTheVersionIsUnknown() {
+		assertFalse(parseMediaRule("@media (-eclipse-min-os-version: \"10.15\") { Label { color: red } }")
+				.matches(new Media.Context("macosx", "cocoa")));
+	}
+
+	@Test
+	void testUnquotedTwoSegmentVersionIsAccepted() {
+		assertTrue(parseMediaRule("@media (-eclipse-min-os-version: 10.15) { Label { color: red } }").matches(MACOS));
+	}
+
+	@Test
+	void testUnknownFeatureNeverMatches() {
+		assertFalse(parseMediaRule("@media (-eclipse-unknown: linux) { Label { color: red } }").matches(LINUX));
+	}
+
+	@Test
+	void testEmptyQueryListMatches() {
+		assertTrue(parseMediaRule("@media { Label { color: red } }").matches(LINUX));
+	}
+
+	@Test
+	void testUnsupportedButWellFormedQueryIsNotAParseError() {
+		CSSStyleSheetImpl styleSheet = ParserTestUtil
+				.parseCssWithoutImports("@media (min-width: 100px) { Label { color: red } }");
+
+		assertTrue(styleSheet.getProblems().isEmpty(), "unexpected parse problems: " + styleSheet.getProblems());
+		assertFalse(((CSSMediaRuleImpl) styleSheet.getRules().get(0)).matches(LINUX));
+	}
+
+	@Test
+	void testMalformedQueryBecomesNotAllAndSparesItsNeighbours() {
+		CSSStyleSheetImpl styleSheet = ParserTestUtil
+				.parseCssWithoutImports("@media 42, (-eclipse-os: linux) { Label { color: red } }");
+		CSSMediaRuleImpl rule = (CSSMediaRuleImpl) styleSheet.getRules().get(0);
+
+		assertFalse(styleSheet.getProblems().isEmpty(), "the malformed query should be reported");
+		assertEquals(List.of(Media.Query.NEVER,
+				new Media.Query(false, "all", List.of(new Media.Feature(Media.FEATURE_OS, "linux")))),
+				rule.getQueries());
+		assertTrue(rule.matches(LINUX));
+		assertFalse(rule.matches(WINDOWS));
+	}
+
+	@Test
+	void testMalformedRuleInsideBlockDoesNotSwallowTheBlock() {
+		CSSStyleSheetImpl styleSheet = ParserTestUtil.parseCssWithoutImports("""
+				@media screen {
+				[ { color: red }
+				Label { color: blue }
+				}
+				Button { color: green }""");
+
+		assertEquals(2, styleSheet.getRules().size());
+		CSSMediaRuleImpl media = (CSSMediaRuleImpl) styleSheet.getRules().get(0);
+		assertEquals(1, media.getRules().size());
+		assertEquals("Label", media.getRules().get(0).getSelectorText());
+		assertEquals("Button", ((CSSStyleRuleImpl) styleSheet.getRules().get(1)).getSelectorText());
+	}
+
+	@Test
+	void testMediaTextRoundTrip() {
+		CSSMediaRuleImpl rule = parseMediaRule(
+				"@media not screen and (-eclipse-os: linux), (-eclipse-ws) { Label { color: red } }");
+		assertEquals("not screen and (-eclipse-os: linux), all and (-eclipse-ws)", rule.getMediaText());
 	}
 }

--- a/tests/org.eclipse.e4.ui.tests.css.core/src/org/eclipse/e4/ui/tests/css/core/parser/MediaRulesTest.java
+++ b/tests/org.eclipse.e4.ui.tests.css.core/src/org/eclipse/e4/ui/tests/css/core/parser/MediaRulesTest.java
@@ -38,6 +38,10 @@ public class MediaRulesTest {
 	private static final Media.Context WINDOWS = new Media.Context("win32", "win32", "10.0");
 	private static final Media.Context MACOS = new Media.Context("macosx", "cocoa", "10.15.7");
 
+	/** A workbench with one optional bundle installed. */
+	private static final Media.Context WITH_UI = new Media.Context("linux", "gtk", "6.14.0",
+			name -> "org.eclipse.ui".equals(name) ? "3.2.0.v20260101" : null);
+
 	private static CSSMediaRuleImpl parseMediaRule(String css) {
 		CSSStyleSheetImpl styleSheet = ParserTestUtil.parseCssWithoutImports(css);
 		assertTrue(styleSheet.getProblems().isEmpty(), "unexpected parse problems: " + styleSheet.getProblems());
@@ -173,6 +177,42 @@ public class MediaRulesTest {
 	@Test
 	void testUnquotedTwoSegmentVersionIsAccepted() {
 		assertTrue(parseMediaRule("@media (-eclipse-min-os-version: 10.15) { Label { color: red } }").matches(MACOS));
+	}
+
+	@Test
+	void testBundleFeatureTestsForInstallation() {
+		CSSMediaRuleImpl rule = parseMediaRule("@media (-eclipse-bundle: \"org.eclipse.ui\") { Label { color: red } }");
+		assertTrue(rule.matches(WITH_UI));
+		assertFalse(rule.matches(LINUX));
+		assertFalse(parseMediaRule("@media (-eclipse-bundle: \"org.eclipse.absent\") { Label { color: red } }")
+				.matches(WITH_UI));
+	}
+
+	@Test
+	void testBundleVersionBounds() {
+		assertTrue(parseMediaRule("@media (-eclipse-min-bundle-version: \"org.eclipse.ui 3.2\") { Label { color: red } }")
+				.matches(WITH_UI));
+		assertFalse(parseMediaRule("@media (-eclipse-min-bundle-version: \"org.eclipse.ui 4.0\") { Label { color: red } }")
+				.matches(WITH_UI));
+		assertTrue(parseMediaRule("@media (-eclipse-max-bundle-version: \"org.eclipse.ui 3.2\") { Label { color: red } }")
+				.matches(WITH_UI));
+		assertTrue(parseMediaRule("@media (-eclipse-bundle-version: \"org.eclipse.ui 3.2\") { Label { color: red } }")
+				.matches(WITH_UI));
+		assertFalse(parseMediaRule("@media (-eclipse-bundle-version: \"org.eclipse.ui 3.3\") { Label { color: red } }")
+				.matches(WITH_UI));
+	}
+
+	@Test
+	void testBundleVersionOfAnAbsentBundleNeverMatches() {
+		assertFalse(parseMediaRule("@media (-eclipse-max-bundle-version: \"org.eclipse.absent 9.9\") { Label { color: red } }")
+				.matches(WITH_UI));
+	}
+
+	@Test
+	void testBundleFeatureNeedsASubject() {
+		assertFalse(parseMediaRule("@media (-eclipse-bundle) { Label { color: red } }").matches(WITH_UI));
+		assertFalse(parseMediaRule("@media (-eclipse-min-bundle-version: \"org.eclipse.ui\") { Label { color: red } }")
+				.matches(WITH_UI));
 	}
 
 	@Test


### PR DESCRIPTION
A theme that needs one platform to differ has to ship a whole second stylesheet today, picked by the os and ws attributes of the theme extension point. @media is what CSS has for conditioning on the environment rather than on the element, so the engine now keeps the blocks it used to discard and evaluates their queries. Five vendor features answer for the platform, -eclipse-os and -eclipse-ws plus -eclipse-os-version with min and max bounds, and four more for the installed bundles, so an optional contribution can be styled only where it exists.

Queries stay unevaluated on the parsed rule and the rule index decides which blocks contribute, at the position of their block, so the cascade is unchanged. Unknown media types, features and values evaluate to false and a malformed query becomes "not all", as Media Queries requires, so a sheet written for a browser contributes no rules instead of failing to parse. docs/CSS.md gains a section on both.

Verified with the org.eclipse.e4.ui.tests.css.core suite (163 tests) on Linux after the rebase onto the merged #4321.