### PR TITLE
Fix two latent defects in Quick Access

### DIFF
--- a/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/quickaccess/PreviousPicksProvider.java
+++ b/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/quickaccess/PreviousPicksProvider.java
@@ -90,6 +90,8 @@ class PreviousPicksProvider extends QuickAccessProvider {
 	}
 
 	public void addPreviousPick(QuickAccessElement element, Consumer<QuickAccessElement> onRemoveElement) {
+		// Force the restore, in case a pick is made before any query populated the list
+		getElements();
 		elements.remove(element);
 		if (elements.size() == maxNumberOfElements) {
 			QuickAccessElement removedElement = elements.removeLast();

--- a/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/quickaccess/QuickAccessHandler.java
+++ b/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/quickaccess/QuickAccessHandler.java
@@ -16,6 +16,7 @@ package org.eclipse.ui.internal.quickaccess;
 
 import java.util.Arrays;
 import java.util.Optional;
+import java.util.stream.Stream;
 import org.eclipse.core.commands.AbstractHandler;
 import org.eclipse.core.commands.Command;
 import org.eclipse.core.commands.ExecutionEvent;
@@ -37,13 +38,18 @@ public class QuickAccessHandler extends AbstractHandler {
 			return null;
 		}
 
-		Optional<QuickAccessContents> existingContents = Arrays.stream(window.getShell().getDisplay().getShells()) //
+		// Prefer the active shell, so another open dialog cannot claim the toggle
+		Shell activeShell = window.getShell().getDisplay().getActiveShell();
+		Optional<QuickAccessContents> existingContents = Stream
+				.concat(Stream.ofNullable(activeShell),
+						Arrays.stream(window.getShell().getDisplay().getShells())
+								.filter(shell -> shell != activeShell))
 				.filter(Shell::isVisible) //
 				.map(Shell::getData) //
 				.filter(QuickAccessDialog.class::isInstance) //
 				.map(QuickAccessDialog.class::cast) //
 				.map(QuickAccessDialog::getQuickAccessContents) //
-				.findAny();
+				.findFirst();
 		if (existingContents.isPresent()) {
 			QuickAccessContents contents = existingContents.get();
 			contents.setShowAllMatches(!contents.getShowAllMatches());


### PR DESCRIPTION
Two small defects found while investigating the Quick Access test flakiness, unrelated to each other and to that work.

`PreviousPicksProvider.addPreviousPick` dereferenced the previous picks list before anything had populated it, so choosing an entry before a query had run threw an NPE. The show-all toggle picked an arbitrary visible Quick Access dialog via `findAny()`; it now prefers the active shell, so a dialog left open elsewhere cannot claim the toggle.

Verified by compiling `org.eclipse.ui.workbench` and running the `org.eclipse.ui.tests.quickaccess` suite (44 tests, all green).