### PR TITLE
Mark when Quick Access results are final instead of guessing

### DIFF
--- a/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/quickaccess/QuickAccessContents.java
+++ b/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/quickaccess/QuickAccessContents.java
@@ -30,8 +30,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
-import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -109,6 +110,12 @@ public abstract class QuickAccessContents {
 	private static final int FILTER_DEBOUNCE_MS = 100;
 
 	/**
+	 * Row-count difference a resize must exceed before it recomputes. A scroll bar
+	 * appearing and disappearing changes the count by one in each direction.
+	 */
+	private static final int ROW_COUNT_TOLERANCE = 1;
+
+	/**
 	 * Family of the background job that computes the matching entries. Lets tests
 	 * join on the streaming compute deterministically instead of polling the table.
 	 */
@@ -118,7 +125,7 @@ public abstract class QuickAccessContents {
 
 	private final QuickAccessProvider[] providers;
 	private Map<String, QuickAccessProvider> providerMap = new HashMap<>();
-	private final Map<QuickAccessElement, QuickAccessProvider> elementsToProviders = new HashMap<>();
+	private final Map<QuickAccessElement, QuickAccessProvider> elementsToProviders = new ConcurrentHashMap<>();
 
 	private Composite tableComposite;
 	protected Table table;
@@ -138,6 +145,15 @@ public abstract class QuickAccessContents {
 	private int lastComputedItemCount = -1;
 	private TriggerSequence keySequence;
 	private Job computeProposalsJob;
+
+	/** Id of the most recent proposal request. UI thread only. */
+	private int currentRequest;
+
+	/** Id of the request whose final results are in the table. UI thread only. */
+	private int lastRenderedRequest;
+
+	/** Whether a debounced resize recompute is still armed. UI thread only. */
+	private boolean resizeUpdatePending;
 
 	/**
 	 * Orders entries by descending relevance score, then match quality. Applied
@@ -194,6 +210,7 @@ public abstract class QuickAccessContents {
 			return;
 		}
 		final Display display = table.getDisplay();
+		final int request = ++currentRequest;
 
 		// perfect match, to be selected in the table if not null
 		QuickAccessElement perfectMatch = getPerfectMatch(filter);
@@ -207,17 +224,31 @@ public abstract class QuickAccessContents {
 		// flashes over content that has already streamed in.
 		boolean[] rendered = { false };
 		AtomicReference<UIJob> feedbackJobRef = new AtomicReference<>();
+		// Newest snapshot waiting to be drawn, plus whether a draw is already queued
+		// for it: together they conflate a burst of per-provider results into one rebuild.
+		AtomicReference<List<QuickAccessEntry>[]> pendingSnapshot = new AtomicReference<>();
+		AtomicBoolean renderQueued = new AtomicBoolean();
+		Object[] appliedSnapshot = new Object[1];
 		final Job currentComputeEntriesJob = new Job(computingMessage) {
 			@Override
 			protected IStatus run(IProgressMonitor theMonitor) {
-				// Query providers one at a time and re-render as each returns, so a slow
-				// provider neither holds the UI thread for the whole batch nor delays the
+				// Re-render as results arrive, so a slow provider does not delay the
 				// results that are already available.
-				computeMatchingEntries(filter, perfectMatch, maxNumberOfItemsInTable, theMonitor, entries -> {
+				computeMatchingEntries(filter, perfectMatch, maxNumberOfItemsInTable, theMonitor,
+						(entries, last) -> {
 					if (table.isDisposed()) {
 						return;
 					}
+					pendingSnapshot.set(entries);
+					// A queued draw picks up the newest snapshot by the time it runs, so
+					// only the final draw has to be queued unconditionally.
+					if (!last && !renderQueued.compareAndSet(false, true)) {
+						return;
+					}
 					display.asyncExec(() -> {
+						if (!last) {
+							renderQueued.set(false);
+						}
 						if (table.isDisposed() || filterText == null || filterText.isDisposed()) {
 							return;
 						}
@@ -227,15 +258,29 @@ public abstract class QuickAccessContents {
 								|| requestShowAllMatches != showAllMatches) {
 							return;
 						}
-						if (Policy.DEBUG_QUICK_ACCESS) {
-							trace("Setting quick access contents: " + toIds(entries)); //$NON-NLS-1$
+						List<QuickAccessEntry>[] snapshot = pendingSnapshot.get();
+						if (snapshot != appliedSnapshot[0]) {
+							appliedSnapshot[0] = snapshot;
+							if (Policy.DEBUG_QUICK_ACCESS) {
+								trace("Setting quick access contents: " + toIds(snapshot)); //$NON-NLS-1$
+							}
+							rendered[0] = true;
+							UIJob feedbackJob = feedbackJobRef.get();
+							if (feedbackJob != null) {
+								feedbackJob.cancel();
+							}
+							refreshTable(perfectMatch, snapshot, filter);
 						}
-						rendered[0] = true;
-						UIJob feedbackJob = feedbackJobRef.get();
-						if (feedbackJob != null) {
-							feedbackJob.cancel();
+						if (last) {
+							// Nothing else marks this edge: the job ends as soon as this
+							// draw is queued, not once it has run.
+							lastRenderedRequest = request;
+							// Resizes were ignored while this compute ran, and it was sized
+							// for the layout at request time.
+							if (needsResizeUpdate()) {
+								updateProposals(filter);
+							}
 						}
-						refreshTable(perfectMatch, entries, filter);
 					});
 				});
 				return theMonitor.isCanceled() ? Status.CANCEL_STATUS : Status.OK_STATUS;
@@ -273,6 +318,13 @@ public abstract class QuickAccessContents {
 							", last proposals Job: " + computeProposalsJob); //$NON-NLS-1$
 				}
 				computingFeedbackJob.cancel();
+				// A compute that died before its final render would otherwise leave
+				// the dialog permanently unsettled.
+				display.asyncExec(() -> {
+					if (request == currentRequest) {
+						lastRenderedRequest = request;
+					}
+				});
 			}
 		});
 		this.computeProposalsJob = currentComputeEntriesJob;
@@ -283,6 +335,26 @@ public abstract class QuickAccessContents {
 		// Keep the feedback delay relative to when the compute actually starts, so the
 		// debounce window never flashes the "computing" hint.
 		computingFeedbackJob.schedule(scheduleDelay + 200);
+	}
+
+	/**
+	 * Returns whether the table holds the final results of the most recent request
+	 * and no further recompute is armed. Must be called on the UI thread.
+	 */
+	public boolean isSettled() {
+		if (table == null || table.isDisposed()) {
+			return true;
+		}
+		return lastRenderedRequest == currentRequest && !resizeUpdatePending;
+	}
+
+	/**
+	 * Receives one table snapshot. {@code last} marks the snapshot that completes
+	 * the request, so the renderer can conflate the ones before it.
+	 */
+	@FunctionalInterface
+	private interface ResultRenderer {
+		void render(List<QuickAccessEntry>[] entries, boolean last);
 	}
 
 	/**
@@ -469,9 +541,10 @@ public abstract class QuickAccessContents {
 	/**
 	 * Queries each provider in turn and streams the matching entries to {@code render}
 	 * after every provider that contributes, so results appear as they are computed
-	 * rather than only once the slowest provider has finished. The number of entries
-	 * is affected by {@link #getShowAllMatches()} and the size of the table's
-	 * composite.
+	 * rather than only once the slowest provider has finished. The last snapshot is
+	 * always rendered with {@code last} set, even when nothing matched, so the table
+	 * reflects the final result rather than stale content. The number of entries is
+	 * affected by {@link #getShowAllMatches()} and the size of the table's composite.
 	 *
 	 * @param filter       the string text filter to apply, possibly empty
 	 * @param perfectMatch a quick access element that should be given priority or
@@ -479,7 +552,7 @@ public abstract class QuickAccessContents {
 	 * @param render       receives one snapshot (a list per provider) per re-render
 	 */
 	private void computeMatchingEntries(String filter, QuickAccessElement perfectMatch, int maxNumberOfItemsInTable,
-			IProgressMonitor aMonitor, Consumer<List<QuickAccessEntry>[]> render) {
+			IProgressMonitor aMonitor, ResultRenderer render) {
 		if (aMonitor == null) {
 			aMonitor = new NullProgressMonitor();
 		}
@@ -496,7 +569,6 @@ public abstract class QuickAccessContents {
 		// stream into the table.
 		LinkedHashMap<QuickAccessProvider, List<QuickAccessElement>> elementsForProviders = new LinkedHashMap<>(
 				providers.length);
-		boolean anyRendered = false;
 		for (QuickAccessProvider provider : providers) {
 			if (aMonitor.isCanceled()) {
 				return;
@@ -522,16 +594,17 @@ public abstract class QuickAccessContents {
 			if (sortedElements.isEmpty()) {
 				continue;
 			}
-			render.accept(assembleEntries(elementsForProviders, finalFilter, perfectMatch, maxNumberOfItemsInTable,
-					aMonitor));
-			anyRendered = true;
+			render.render(assembleEntries(elementsForProviders, finalFilter, perfectMatch, maxNumberOfItemsInTable,
+					aMonitor), false);
 		}
-		// Nothing matched (or only a perfect match exists): render once so the table
-		// reflects the final result rather than stale content.
-		if (!anyRendered && !aMonitor.isCanceled()) {
-			render.accept(assembleEntries(elementsForProviders, finalFilter, perfectMatch, maxNumberOfItemsInTable,
-					aMonitor));
+		if (aMonitor.isCanceled()) {
+			return;
 		}
+		// Always close with a full render: it is what marks the request settled, and
+		// it also covers the case where nothing matched at all.
+		render.render(
+				assembleEntries(elementsForProviders, finalFilter, perfectMatch, maxNumberOfItemsInTable, aMonitor),
+				true);
 	}
 
 	/**
@@ -660,7 +733,19 @@ public abstract class QuickAccessContents {
 		return categoryPattern;
 	}
 
+	/**
+	 * Whether the layout now fits enough more or fewer rows than the table was last
+	 * computed for to be worth recomputing.
+	 */
+	private boolean needsResizeUpdate() {
+		if (showAllMatches || table == null || table.isDisposed() || filterText == null || filterText.isDisposed()) {
+			return false;
+		}
+		return Math.abs(computeNumberOfItems() - lastComputedItemCount) > ROW_COUNT_TOLERANCE;
+	}
+
 	private void doDispose() {
+		resizeUpdatePending = false;
 		// Stop any in-flight compute so a closed dialog neither keeps querying providers
 		// nor leaves a job lingering in COMPUTE_JOB_FAMILY.
 		if (computeProposalsJob != null) {
@@ -821,13 +906,8 @@ public abstract class QuickAccessContents {
 		GridDataFactory.fillDefaults().grab(true, true).applyTo(tableComposite);
 		table = new Table(tableComposite, SWT.SINGLE | SWT.FULL_SELECTION);
 		final Runnable resizeUpdate = () -> {
-			if (showAllMatches || table == null || table.isDisposed() || filterText == null
-					|| filterText.isDisposed()) {
-				return;
-			}
-			// Skip when the layout settled back to the row count we already computed for,
-			// so an oscillating burst does not cancel the in-flight compute job.
-			if (computeNumberOfItems() == lastComputedItemCount) {
+			resizeUpdatePending = false;
+			if (!needsResizeUpdate()) {
 				return;
 			}
 			if (Policy.DEBUG_QUICK_ACCESS) {
@@ -838,16 +918,12 @@ public abstract class QuickAccessContents {
 		table.getShell().addControlListener(new ControlAdapter() {
 			@Override
 			public void controlResized(ControlEvent e) {
-				if (showAllMatches || table == null || table.isDisposed() || filterText == null
-						|| filterText.isDisposed()) {
+				// The final render of a compute in flight catches up with the layout.
+				if (!isSettled() || !needsResizeUpdate()) {
 					return;
 				}
-				// A resize only matters when the number of visible rows changes. Coalesce a
-				// burst of resizes (e.g. scrollbar oscillation during initial layout) into a
-				// single trailing update, and skip it when the row count is unchanged.
-				if (computeNumberOfItems() == lastComputedItemCount) {
-					return;
-				}
+				// Coalesce a burst of resizes into a single trailing update.
+				resizeUpdatePending = true;
 				e.display.timerExec(-1, resizeUpdate);
 				e.display.timerExec(RESIZE_DEBOUNCE_MS, resizeUpdate);
 			}

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/quickaccess/QuickAccessDialogTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/quickaccess/QuickAccessDialogTest.java
@@ -32,15 +32,16 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Predicate;
 
 import org.eclipse.core.commands.Command;
-import org.eclipse.core.runtime.jobs.Job;
 import org.eclipse.jface.dialogs.DialogSettings;
 import org.eclipse.jface.dialogs.IDialogSettings;
 import org.eclipse.swt.SWT;
+import org.eclipse.swt.graphics.Point;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Event;
 import org.eclipse.swt.widgets.Shell;
 import org.eclipse.swt.widgets.Table;
 import org.eclipse.swt.widgets.Text;
+import org.eclipse.ui.IWorkbenchPage;
 import org.eclipse.ui.IWorkbenchWindow;
 import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.commands.ICommandService;
@@ -68,8 +69,6 @@ public class QuickAccessDialogTest {
 
 	private class TestQuickAccessDialog extends QuickAccessDialog {
 
-		private volatile String infoText;
-
 		public TestQuickAccessDialog(IWorkbenchWindow activeWorkbenchWindow, Command command) {
 			super(activeWorkbenchWindow, command);
 		}
@@ -78,22 +77,13 @@ public class QuickAccessDialogTest {
 		protected IDialogSettings getDialogSettings() {
 			return dialogSettings;
 		}
-
-		@Override
-		protected void setInfoText(String text) {
-			super.setInfoText(text);
-			infoText = text;
-		}
 	}
 
 	private static final int TIMEOUT = 5000;
-	// Generous safety bound for joining the streaming compute job; only consumed if
-	// that job genuinely hangs, never on a healthy run.
+	// Safety bound only; consumed if the compute genuinely hangs, never on a healthy run.
 	private static final int COMPUTE_TIMEOUT = 30000;
 	// Generous bound for the one-time cold initialization of the lazy providers.
 	private static final int WARMUP_TIMEOUT = 60000;
-	// The lazy providers initialize once per JVM, so warm them only once.
-	private static boolean providersWarmedUp;
 	// As defined in QuickAccessDialog and in SearchField
 	private static final int MAXIMUM_NUMBER_OF_ELEMENTS = 60;
 	private static final Predicate<Shell> isQuickAccessShell = shell -> shell.getText()
@@ -102,8 +92,18 @@ public class QuickAccessDialogTest {
 	private IWorkbenchWindow activeWorkbenchWindow;
 
 	@BeforeAll
-	public static void enableDebugOutputs() {
+	public static void warmUpProviders() {
 		Policy.DEBUG_QUICK_ACCESS = true;
+		// The lazy providers do their expensive first query once per JVM. Pay it here
+		// with a real filter, an empty one skips them, so it never lands in a timed wait.
+		QuickAccessDialog warmupDialog = new QuickAccessDialog(PlatformUI.getWorkbench().getActiveWorkbenchWindow(),
+				null);
+		warmupDialog.open();
+		QuickAccessContents contents = warmupDialog.getQuickAccessContents();
+		contents.getFilterText().setText("t");
+		DisplayHelper.waitForCondition(contents.getTable().getDisplay(), WARMUP_TIMEOUT,
+				() -> contents.isSettled() && contents.getTable().getItemCount() > 0);
+		warmupDialog.close();
 	}
 
 	@AfterAll
@@ -116,22 +116,6 @@ public class QuickAccessDialogTest {
 		Arrays.stream(Display.getDefault().getShells()).filter(isQuickAccessShell).forEach(Shell::close);
 		dialogSettings = new DialogSettings("QuickAccessDialogTest" + System.currentTimeMillis());
 		activeWorkbenchWindow = openTestWindow();
-		QuickAccessDialog warmupDialog = new QuickAccessDialog(activeWorkbenchWindow, null);
-		warmupDialog.open();
-		if (!providersWarmedUp) {
-			// Warm the lazy providers once with a real filter so their slow first query
-			// runs here, not inside a test's timed wait. An empty filter skips them.
-			Text warmupText = warmupDialog.getQuickAccessContents().getFilterText();
-			Table warmupTable = warmupDialog.getQuickAccessContents().getTable();
-			warmupText.setText("t");
-			// Wait for results AND for the compute job to drain, so the lazy providers'
-			// slow first query completes here rather than leaking into a test's timed wait.
-			DisplayHelper.waitForCondition(warmupText.getDisplay(), WARMUP_TIMEOUT,
-					() -> warmupTable.getItemCount() > 0
-							&& Job.getJobManager().find(QuickAccessContents.COMPUTE_JOB_FAMILY).length == 0);
-			providersWarmedUp = true;
-		}
-		warmupDialog.close();
 	}
 
 	static Optional<QuickAccessDialog> findQuickAccessDialog() {
@@ -174,14 +158,14 @@ public class QuickAccessDialogTest {
 		assertEquals(0, table.getItemCount(), "Quick access table should be empty");
 
 		text.setText("T");
-		waitForQuickAccessResults(table.getDisplay());
+		waitForQuickAccessResults(dialog);
 		int oldCount = table.getItemCount();
 		assertTrue(oldCount > 3, "Not enough quick access items for simple filter");
 		assertTrue(oldCount < MAXIMUM_NUMBER_OF_ELEMENTS, "Too many quick access items for size of table");
 		final String oldFirstItemText = table.getItem(0).getText(1);
 
 		text.setText("B"); // The letter mustn't be part of the previous 1st proposal
-		waitForQuickAccessResults(table.getDisplay());
+		waitForQuickAccessResults(dialog);
 		assertTrue(table.getItemCount() > 1 && !table.getItem(0).getText(1).equals(oldFirstItemText),
 				"The quick access items should have changed");
 		int newCount = table.getItemCount();
@@ -199,7 +183,7 @@ public class QuickAccessDialogTest {
 		assertEquals(0, table.getItemCount(), "Quick access table should be empty");
 
 		text.setText(TestQuickAccessComputer.TEST_QUICK_ACCESS_PROPOSAL_LABEL);
-		waitForQuickAccessResults(dialog.getShell().getDisplay());
+		waitForQuickAccessResults(dialog);
 		assertTrue(dialogContains(dialog, TestQuickAccessComputer.TEST_QUICK_ACCESS_PROPOSAL_LABEL),
 				"Missing contributed element");
 	}
@@ -267,7 +251,7 @@ public class QuickAccessDialogTest {
 
 		// Set a filter to get some items
 		text.setText("T");
-		waitForQuickAccessResults(table.getDisplay());
+		waitForQuickAccessResults(dialog);
 		final int defaultCount = table.getItemCount();
 		assertTrue(defaultCount > 3, "Not enough quick access items for simple filter");
 		assertTrue(defaultCount < MAXIMUM_NUMBER_OF_ELEMENTS, "Too many quick access items for size of table");
@@ -277,32 +261,33 @@ public class QuickAccessDialogTest {
 				.getService(IHandlerService.class);
 		// Run the handler to turn on show all
 		handlerService.executeCommand("org.eclipse.ui.window.quickAccess", null); //$NON-NLS-1$
-		waitForQuickAccessResults(table.getDisplay());
+		waitForQuickAccessResults(dialog);
 		final int allCount = table.getItemCount();
 		assertTrue(allCount > defaultCount, "Turning on show all should display more items");
 		assertEquals(oldFirstItemText, table.getItem(0).getText(1), "Turning on show all should not change the top item");
 
 		// Run the handler to turn off show all
 		handlerService.executeCommand("org.eclipse.ui.window.quickAccess", null); //$NON-NLS-1$
-		waitForQuickAccessResults(table.getDisplay());
+		waitForQuickAccessResults(dialog);
 		// Note: The table count may one off from the old count because of shell resizing (scroll bars being added then removed)
 		assertTrue(table.getItemCount() < allCount, "Turning off show all should limit items shown");
 		assertEquals(oldFirstItemText, table.getItem(0).getText(1), "Turning off show all should not change the top item");
 
 		// Run the handler to turn on show all
 		handlerService.executeCommand("org.eclipse.ui.window.quickAccess", null); //$NON-NLS-1$
-		waitForQuickAccessResults(table.getDisplay());
+		waitForQuickAccessResults(dialog);
 		assertEquals(allCount, table.getItemCount(), "Turning on show all twice shouldn't change the items");
 		assertEquals(oldFirstItemText, table.getItem(0).getText(1), "Turning on show all twice shouldn't change the top item");
 
-		// Close and reopen the shell
+		// Reopening through the handler would yield a dialog on the shared workbench
+		// settings, whose previous picks accumulate across tests.
 		dialog.close();
-		handlerService.executeCommand("org.eclipse.ui.window.quickAccess", null); //$NON-NLS-1$
-		dialog = findQuickAccessDialog().get();
+		dialog = new TestQuickAccessDialog(activeWorkbenchWindow, null);
+		dialog.open();
 		text = dialog.getQuickAccessContents().getFilterText();
 		Table newTable = dialog.getQuickAccessContents().getTable();
 		text.setText("T");
-		waitForQuickAccessResults(newTable.getDisplay());
+		waitForQuickAccessResults(dialog);
 		// Note: The table count may one off from the old count because of shell resizing (scroll bars being added then removed)
 		assertTrue(newTable.getItemCount() < allCount,
 				"Show all should be turned off when the shell is closed and reopened");
@@ -317,7 +302,7 @@ public class QuickAccessDialogTest {
 		Table firstTable = dialog.getQuickAccessContents().getTable();
 		String quickAccessElementText = "Project Explorer";
 		text.setText(quickAccessElementText);
-		waitForQuickAccessResults(firstTable.getDisplay());
+		waitForQuickAccessResults(dialog);
 		assertTrue(dialogContains(dialog, quickAccessElementText), "Missing entry");
 		firstTable.select(0);
 		activateCurrentElement(dialog);
@@ -331,7 +316,7 @@ public class QuickAccessDialogTest {
 		// then try in a new SearchField
 		QuickAccessDialog secondDialog = new TestQuickAccessDialog(activeWorkbenchWindow, null);
 		secondDialog.open();
-		waitForQuickAccessResults(secondDialog.getShell().getDisplay());
+		waitForQuickAccessResults(secondDialog);
 		assertTrue(dialogContains(secondDialog, quickAccessElementText), "Missing entry in previous pick");
 	}
 
@@ -340,7 +325,10 @@ public class QuickAccessDialogTest {
 		enterPressed.widget = dialog.getQuickAccessContents().getFilterText();
 		enterPressed.keyCode = SWT.CR;
 		enterPressed.widget.notifyListeners(SWT.KeyDown, enterPressed);
-		processEventsUntil(() -> enterPressed.widget.isDisposed(), 500);
+		processEventsUntil(() -> enterPressed.widget.isDisposed(), TIMEOUT);
+		// Otherwise the pick was never recorded and a later assertion fails for an
+		// unrelated reason.
+		assertTrue(enterPressed.widget.isDisposed(), "Quick access dialog did not close on Enter");
 	}
 
 	@Test
@@ -349,16 +337,9 @@ public class QuickAccessDialogTest {
 		TestQuickAccessDialog dialog = new TestQuickAccessDialog(activeWorkbenchWindow, null);
 		Text text = dialog.getQuickAccessContents().getFilterText();
 		dialog.open();
-		/*
-		 * wait for the dialog initialization, to avoid race conditions later on in the test, see:
-		 * https://github.com/eclipse-platform/eclipse.platform.ui/issues/4009
-		 */
-		assertTrue(DisplayHelper.waitForCondition(text.getDisplay(), TIMEOUT,
-				() -> dialog.infoText != null),
-				"Unexpected dialog info: " + dialog.infoText);
 		text.setText(TestQuickAccessComputer.TEST_QUICK_ACCESS_PROPOSAL_LABEL);
 		final Table firstTable = dialog.getQuickAccessContents().getTable();
-		waitForQuickAccessResults(text.getDisplay());
+		waitForQuickAccessResults(dialog);
 		assertTrue(dialogContains(dialog, TestQuickAccessComputer.TEST_QUICK_ACCESS_PROPOSAL_LABEL),
 				"Unexpected dialog contents: " + getAllEntries(firstTable));
 		firstTable.select(0);
@@ -366,7 +347,7 @@ public class QuickAccessDialogTest {
 		// then try in a new SearchField
 		QuickAccessDialog secondDialog = new TestQuickAccessDialog(activeWorkbenchWindow, null);
 		secondDialog.open();
-		waitForQuickAccessResults(secondDialog.getShell().getDisplay());
+		waitForQuickAccessResults(secondDialog);
 		assertTrue(getAllEntries(secondDialog.getQuickAccessContents().getTable()).stream()
 						.anyMatch(TestQuickAccessComputer::isContributedItem),
 				"Contributed item not found in previous choices");
@@ -379,7 +360,7 @@ public class QuickAccessDialogTest {
 		Text text = dialog.getQuickAccessContents().getFilterText();
 		text.setText(TestIncrementalQuickAccessComputer.ENABLEMENT_QUERY);
 		final Table firstTable = dialog.getQuickAccessContents().getTable();
-		waitForQuickAccessResults(text.getDisplay());
+		waitForQuickAccessResults(dialog);
 		assertTrue(firstTable.getItemCount() > 0
 				&& TestIncrementalQuickAccessComputer.isContributedItem(getAllEntries(firstTable).get(0)),
 				"Contributed item not first in results");
@@ -389,10 +370,31 @@ public class QuickAccessDialogTest {
 		dialog = new TestQuickAccessDialog(activeWorkbenchWindow, null);
 		dialog.open();
 		final Table secondTable = dialog.getQuickAccessContents().getTable();
-		waitForQuickAccessResults(secondTable.getDisplay());
+		waitForQuickAccessResults(dialog);
 		assertTrue(getAllEntries(secondTable).stream()
 						.anyMatch(TestIncrementalQuickAccessComputer::isContributedItem),
 				"Contributed item not found in previous choices");
+	}
+
+	@Test
+	public void testResizeDuringComputeIsApplied() {
+		QuickAccessDialog dialog = new TestQuickAccessDialog(activeWorkbenchWindow, null);
+		dialog.open();
+		QuickAccessContents contents = dialog.getQuickAccessContents();
+		Table table = contents.getTable();
+		contents.getFilterText().setText("e");
+		waitForQuickAccessResults(dialog);
+		int fullCount = table.getItemCount();
+		assertTrue(fullCount > 10, "Not enough quick access items to fill the table");
+
+		// Shrink the shell while the recompute is still in flight
+		contents.updateProposals("e");
+		Shell shell = dialog.getShell();
+		Point size = shell.getSize();
+		shell.setSize(size.x, size.y - 5 * table.getItemHeight());
+		waitForQuickAccessResults(dialog);
+		assertTrue(table.getItemCount() < fullCount - 1,
+				"Results were not recomputed for the shrunken table: " + table.getItemCount() + " of " + fullCount);
 	}
 
 	@Test
@@ -402,7 +404,7 @@ public class QuickAccessDialogTest {
 		Text text = dialog.getQuickAccessContents().getFilterText();
 		Table table = dialog.getQuickAccessContents().getTable();
 		text.setText("P");
-		waitForQuickAccessResults(table.getDisplay());
+		waitForQuickAccessResults(dialog);
 		assertTrue(table.getItemCount() > 3, "Not enough quick access items for simple filter");
 		assertTrue(table.getItem(0).getText(1).toLowerCase().startsWith("p"), "Non-prefix match first");
 	}
@@ -415,17 +417,21 @@ public class QuickAccessDialogTest {
 
 		File tmpFile = File.createTempFile("blah", ".txt");
 		tmpFile.deleteOnExit();
-		IDE.openEditor(PlatformUI.getWorkbench().getActiveWorkbenchWindow().getActivePage(), tmpFile.toURI(),
-				"org.eclipse.ui.DefaultTextEditor", true);
-
-		QuickAccessDialog dialog = new TestQuickAccessDialog(activeWorkbenchWindow, null);
-		dialog.open();
-		Text text = dialog.getQuickAccessContents().getFilterText();
-		Table table = dialog.getQuickAccessContents().getTable();
-		text.setText("Toggle Split");
-		waitForQuickAccessResults(table.getDisplay());
-		assertTrue(table.getItemCount() > 1, "Not enough quick access items for simple filter");
-		assertTrue(table.getItem(0).getText(1).toLowerCase().startsWith("toggle split"), "Non-prefix match first");
+		IWorkbenchPage page = PlatformUI.getWorkbench().getActiveWorkbenchWindow().getActivePage();
+		IDE.openEditor(page, tmpFile.toURI(), "org.eclipse.ui.DefaultTextEditor", true);
+		try {
+			QuickAccessDialog dialog = new TestQuickAccessDialog(activeWorkbenchWindow, null);
+			dialog.open();
+			Text text = dialog.getQuickAccessContents().getFilterText();
+			Table table = dialog.getQuickAccessContents().getTable();
+			text.setText("Toggle Split");
+			waitForQuickAccessResults(dialog);
+			assertTrue(table.getItemCount() > 1, "Not enough quick access items for simple filter");
+			assertTrue(table.getItem(0).getText(1).toLowerCase().startsWith("toggle split"), "Non-prefix match first");
+		} finally {
+			// Left open, this editor shows up as an extra proposal in every later test
+			page.closeAllEditors(false);
+		}
 	}
 
 	private List<String> getAllEntries(Table table) {
@@ -444,18 +450,13 @@ public class QuickAccessDialogTest {
 	}
 
 	/**
-	 * Waits for the streaming Quick Access computation to finish and renders its
-	 * results, so assertions run against settled contents instead of racing a fixed
-	 * timeout. The compute job applies its results through {@code asyncExec}, so once
-	 * the job family is idle the pending render is drained before returning.
+	 * Waits until the table holds the final results of the most recent request, so no
+	 * assertion races a queued render or a recompute a resize is about to start.
 	 */
-	private static void waitForQuickAccessResults(Display display) {
-		boolean computed = DisplayHelper.waitForCondition(display, COMPUTE_TIMEOUT,
-				() -> Job.getJobManager().find(QuickAccessContents.COMPUTE_JOB_FAMILY).length == 0);
-		assertTrue(computed, "Quick Access computation did not finish");
-		while (display.readAndDispatch()) {
-			// drain the asyncExec that renders the streamed results
-		}
+	private static void waitForQuickAccessResults(QuickAccessDialog dialog) {
+		QuickAccessContents contents = dialog.getQuickAccessContents();
+		assertTrue(DisplayHelper.waitForCondition(contents.getTable().getDisplay(), COMPUTE_TIMEOUT,
+				contents::isSettled), "Quick Access computation did not settle");
 	}
 
 	private boolean dialogContains(QuickAccessDialog dialog, String substring) {

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/quickaccess/TestLongRunningQuickAccessComputer.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/quickaccess/TestLongRunningQuickAccessComputer.java
@@ -7,7 +7,7 @@ import org.eclipse.ui.quickaccess.QuickAccessElement;
 
 public class TestLongRunningQuickAccessComputer implements IQuickAccessComputerExtension {
 
-	public static final int DELAY = 3000;
+	public static final int DELAY = 1500;
 	public static final QuickAccessElement THE_ELEMENT = new QuickAccessElement() {
 		@Override
 		public String getLabel() {


### PR DESCRIPTION
The Quick Access compute job posted one `asyncExec` table redraw per contributing provider, around eleven per keystroke, and returned as soon as the last one was queued. Nothing in the implementation marked the point at which the table actually held a request's final results, so `QuickAccessDialogTest` waited on the job family and raced redraws that were still pending, and a shell resize could kick off a further compute after everything looked settled. That is the mechanism behind the sporadic empty-table and item-count failures in #4009 and #80.

Each request now carries an id that is stamped from the redraw completing it, exposed as `isSettled()`. The intermediate redraws are conflated into a single outstanding draw that picks up the newest snapshot, which cuts redraws per keystroke to four or five and removes most of the layout churn that was feeding the resize listener. Resizes are ignored while a compute is in flight, and its final render catches up with the layout instead. A resize also needs more than a one-row difference, so a scroll bar appearing and disappearing can no longer recompute in a loop.

The test now waits on `isSettled()`, warms the lazy providers once for the class rather than once per test, asserts that the dialog really closed on Enter, and stops leaking an editor and shared dialog settings into later tests.

Verified on Linux under Xvfb: the `org.eclipse.ui.tests.quickaccess` suite is green (44 tests). Interleaved with master over three rounds, `QuickAccessDialogTest` drops from a median of 13.2s to 9.8s. The CI failures this targets have only ever reproduced on the build machines, so the fix cannot be proven locally.
