### PR TITLE
Log instead of fail when a project cannot be opened

### DIFF
--- a/bundles/org.eclipse.ui.ide/extensions/org/eclipse/ui/actions/OpenResourceAction.java
+++ b/bundles/org.eclipse.ui.ide/extensions/org/eclipse/ui/actions/OpenResourceAction.java
@@ -26,6 +26,7 @@ import org.eclipse.core.resources.IResourceDelta;
 import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.resources.WorkspaceJob;
 import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.ILog;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.OperationCanceledException;
@@ -216,6 +217,14 @@ public class OpenResourceAction extends WorkspaceAction implements IResourceChan
 	}
 
 	/**
+	 * Logs a project that could not be opened, e.g. because its .project file is
+	 * missing, so that the remaining projects can still be opened.
+	 */
+	private static void logOpenFailure(IProject project, CoreException e) {
+		ILog.of(OpenResourceAction.class).warn("Failed to open project " + project.getName(), e); //$NON-NLS-1$
+	}
+
+	/**
 	 * Opens the selected projects, and all related projects, in the background.
 	 */
 	private void runOpenWithReferences() {
@@ -232,7 +241,12 @@ public class OpenResourceAction extends WorkspaceAction implements IResourceChan
 					return;
 				}
 				SubMonitor subMonitor = SubMonitor.convert(mon, openProjectReferences ? 2 : 1);
-				project.open(IResource.BACKGROUND_REFRESH, subMonitor.split(1));
+				try {
+					project.open(IResource.BACKGROUND_REFRESH, subMonitor.split(1));
+				} catch (CoreException e) {
+					logOpenFailure(project, e);
+					return;
+				}
 				final IProject[] references = project.getReferencedProjects();
 				if (!hasPrompted) {
 					openProjectReferences = false;
@@ -266,7 +280,7 @@ public class OpenResourceAction extends WorkspaceAction implements IResourceChan
 			}
 
 			@Override
-			public IStatus runInWorkspace(IProgressMonitor monitor) throws CoreException {
+			public IStatus runInWorkspace(IProgressMonitor monitor) {
 				SubMonitor subMonitor = SubMonitor.convert(monitor, countClosedProjects());
 				// at most we can only open all projects currently closed
 				subMonitor.setTaskName(getOperationMessage());
@@ -278,7 +292,11 @@ public class OpenResourceAction extends WorkspaceAction implements IResourceChan
 					if (!project.exists() || project.isOpen()) {
 						continue;
 					}
-					doOpenWithReferences(project, subMonitor.split(1));
+					try {
+						doOpenWithReferences(project, subMonitor.split(1));
+					} catch (CoreException e) {
+						logOpenFailure(project, e);
+					}
 				}
 				return Status.OK_STATUS;
 			}

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/ApiTestSuite.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/ApiTestSuite.java
@@ -22,6 +22,7 @@ import org.eclipse.ui.tests.api.workbenchpart.OverriddenTitleTest;
 import org.eclipse.ui.tests.api.workbenchpart.RawIViewPartTest;
 import org.eclipse.ui.tests.api.workbenchpart.ViewPartTitleTest;
 import org.eclipse.ui.tests.e4.CloseAllHandlerTest;
+import org.eclipse.ui.tests.ide.OpenResourceActionTest;
 import org.eclipse.ui.tests.ide.api.FileEditorInputTest;
 import org.eclipse.ui.tests.ide.api.IDETest;
 import org.eclipse.ui.tests.ide.api.IDETest2;
@@ -73,6 +74,7 @@ import org.junit.platform.suite.api.Suite;
 	 FileEditorInputTest.class,
 	 IDETest.class,
 	 IDETest2.class,
+	 OpenResourceActionTest.class,
 	 IEditorMatchingStrategyTest.class,
 	 XMLMementoTest.class,
 	 IWorkbenchPartTestableTests.class,

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/ide/OpenResourceActionTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/ide/OpenResourceActionTest.java
@@ -1,0 +1,78 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Vogella GmbH and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Lars Vogel <Lars.Vogel@vogella.com> - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.ui.tests.ide;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IProjectDescription;
+import org.eclipse.core.resources.IResource;
+import org.eclipse.core.resources.ResourcesPlugin;
+import org.eclipse.jface.viewers.StructuredSelection;
+import org.eclipse.swt.widgets.Shell;
+import org.eclipse.ui.PlatformUI;
+import org.eclipse.ui.actions.OpenResourceAction;
+import org.eclipse.ui.tests.harness.util.UITestUtil;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for {@link OpenResourceAction}.
+ */
+public class OpenResourceActionTest {
+
+	private final List<IProject> projects = new ArrayList<>();
+
+	@AfterEach
+	public void deleteProjects() throws Exception {
+		for (IProject project : projects) {
+			project.delete(IResource.ALWAYS_DELETE_PROJECT_CONTENT, null);
+		}
+		projects.clear();
+	}
+
+	/**
+	 * A project whose .project file is gone must not prevent the other selected
+	 * projects from being opened.
+	 */
+	@Test
+	public void testOpenSkipsProjectWithMissingDescription() throws Exception {
+		IProject broken = createClosedProject("openResourceActionTest_broken");
+		IProject healthy = createClosedProject("openResourceActionTest_healthy");
+		Files.delete(broken.getLocation().append(IProjectDescription.DESCRIPTION_FILE_NAME).toFile().toPath());
+
+		Shell shell = PlatformUI.getWorkbench().getActiveWorkbenchWindow().getShell();
+		OpenResourceAction action = new OpenResourceAction(() -> shell);
+		action.selectionChanged(new StructuredSelection(new Object[] { broken, healthy }));
+		action.run();
+		UITestUtil.processEventsUntil(healthy::isOpen, 30000);
+
+		assertFalse(broken.isOpen(), "Project with missing .project file should stay closed");
+		assertTrue(healthy.isOpen(), "Remaining project should have been opened");
+	}
+
+	private IProject createClosedProject(String name) throws Exception {
+		IProject project = ResourcesPlugin.getWorkspace().getRoot().getProject(name);
+		project.create(null);
+		project.open(null);
+		project.close(null);
+		projects.add(project);
+		return project;
+	}
+}


### PR DESCRIPTION
Opening several projects aborted as soon as one of them failed, e.g. because its `.project` file was missing:

> The project description file (.project) for '...' is missing.

The `CoreException` propagated out of the job, an error dialog was shown and the remaining selected projects stayed closed.

Now the failure is caught per project, logged as a warning, and the other projects are still opened. Adds `OpenResourceActionTest` covering the case.