### PR TITLE
Remove resource filters injected by the Java Language Server

### DIFF
--- a/bundles/org.eclipse.core.commands/.project
+++ b/bundles/org.eclipse.core.commands/.project
@@ -37,15 +37,4 @@
 		<nature>org.eclipse.jdt.core.javanature</nature>
 		<nature>org.eclipse.pde.api.tools.apiAnalysisNature</nature>
 	</natures>
-	<filteredResources>
-		<filter>
-			<id>1676382308243</id>
-			<name></name>
-			<type>30</type>
-			<matcher>
-				<id>org.eclipse.core.resources.regexFilterMatcher</id>
-				<arguments>node_modules|\.git|__CREATED_BY_JAVA_LANGUAGE_SERVER__</arguments>
-			</matcher>
-		</filter>
-	</filteredResources>
 </projectDescription>

--- a/bundles/org.eclipse.core.databinding.beans/.project
+++ b/bundles/org.eclipse.core.databinding.beans/.project
@@ -37,15 +37,4 @@
 		<nature>org.eclipse.jdt.core.javanature</nature>
 		<nature>org.eclipse.pde.api.tools.apiAnalysisNature</nature>
 	</natures>
-	<filteredResources>
-		<filter>
-			<id>1676382308267</id>
-			<name></name>
-			<type>30</type>
-			<matcher>
-				<id>org.eclipse.core.resources.regexFilterMatcher</id>
-				<arguments>node_modules|\.git|__CREATED_BY_JAVA_LANGUAGE_SERVER__</arguments>
-			</matcher>
-		</filter>
-	</filteredResources>
 </projectDescription>

--- a/bundles/org.eclipse.core.databinding.beans/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.core.databinding.beans/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.core.databinding.beans
-Bundle-Version: 1.10.500.qualifier
+Bundle-Version: 1.10.600.qualifier
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Export-Package: org.eclipse.core.databinding.beans;version="1.0.0",

--- a/bundles/org.eclipse.core.databinding.observable/.project
+++ b/bundles/org.eclipse.core.databinding.observable/.project
@@ -37,15 +37,4 @@
 		<nature>org.eclipse.jdt.core.javanature</nature>
 		<nature>org.eclipse.pde.api.tools.apiAnalysisNature</nature>
 	</natures>
-	<filteredResources>
-		<filter>
-			<id>1676382308269</id>
-			<name></name>
-			<type>30</type>
-			<matcher>
-				<id>org.eclipse.core.resources.regexFilterMatcher</id>
-				<arguments>node_modules|\.git|__CREATED_BY_JAVA_LANGUAGE_SERVER__</arguments>
-			</matcher>
-		</filter>
-	</filteredResources>
 </projectDescription>

--- a/bundles/org.eclipse.core.databinding.observable/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.core.databinding.observable/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.core.databinding.observable
-Bundle-Version: 1.13.500.qualifier
+Bundle-Version: 1.13.600.qualifier
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Export-Package: org.eclipse.core.databinding.observable;version="1.0.0",

--- a/bundles/org.eclipse.core.databinding.property/.project
+++ b/bundles/org.eclipse.core.databinding.property/.project
@@ -37,15 +37,4 @@
 		<nature>org.eclipse.jdt.core.javanature</nature>
 		<nature>org.eclipse.pde.api.tools.apiAnalysisNature</nature>
 	</natures>
-	<filteredResources>
-		<filter>
-			<id>1676382308274</id>
-			<name></name>
-			<type>30</type>
-			<matcher>
-				<id>org.eclipse.core.resources.regexFilterMatcher</id>
-				<arguments>node_modules|\.git|__CREATED_BY_JAVA_LANGUAGE_SERVER__</arguments>
-			</matcher>
-		</filter>
-	</filteredResources>
 </projectDescription>

--- a/bundles/org.eclipse.core.databinding.property/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.core.databinding.property/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.core.databinding.property
-Bundle-Version: 1.10.500.qualifier
+Bundle-Version: 1.10.600.qualifier
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Export-Package: org.eclipse.core.databinding.property;version="1.0.0",

--- a/bundles/org.eclipse.core.databinding/.project
+++ b/bundles/org.eclipse.core.databinding/.project
@@ -37,15 +37,4 @@
 		<nature>org.eclipse.jdt.core.javanature</nature>
 		<nature>org.eclipse.pde.api.tools.apiAnalysisNature</nature>
 	</natures>
-	<filteredResources>
-		<filter>
-			<id>1676382308261</id>
-			<name></name>
-			<type>30</type>
-			<matcher>
-				<id>org.eclipse.core.resources.regexFilterMatcher</id>
-				<arguments>node_modules|\.git|__CREATED_BY_JAVA_LANGUAGE_SERVER__</arguments>
-			</matcher>
-		</filter>
-	</filteredResources>
 </projectDescription>

--- a/bundles/org.eclipse.e4.core.commands/.project
+++ b/bundles/org.eclipse.e4.core.commands/.project
@@ -42,15 +42,4 @@
 		<nature>org.eclipse.jdt.core.javanature</nature>
 		<nature>org.eclipse.pde.api.tools.apiAnalysisNature</nature>
 	</natures>
-	<filteredResources>
-		<filter>
-			<id>1676382308280</id>
-			<name></name>
-			<type>30</type>
-			<matcher>
-				<id>org.eclipse.core.resources.regexFilterMatcher</id>
-				<arguments>node_modules|\.git|__CREATED_BY_JAVA_LANGUAGE_SERVER__</arguments>
-			</matcher>
-		</filter>
-	</filteredResources>
 </projectDescription>

--- a/bundles/org.eclipse.e4.core.commands/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.e4.core.commands/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-SymbolicName: org.eclipse.e4.core.commands;singleton:=true
 Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
-Bundle-Version: 1.1.800.qualifier
+Bundle-Version: 1.1.900.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Import-Package: jakarta.annotation;version="[2.0.0,4.0.0)",
  jakarta.inject;version="[2.0.0,3.0.0)",

--- a/bundles/org.eclipse.e4.ui.bindings/.project
+++ b/bundles/org.eclipse.e4.ui.bindings/.project
@@ -42,15 +42,4 @@
 		<nature>org.eclipse.jdt.core.javanature</nature>
 		<nature>org.eclipse.pde.api.tools.apiAnalysisNature</nature>
 	</natures>
-	<filteredResources>
-		<filter>
-			<id>1676382308298</id>
-			<name></name>
-			<type>30</type>
-			<matcher>
-				<id>org.eclipse.core.resources.regexFilterMatcher</id>
-				<arguments>node_modules|\.git|__CREATED_BY_JAVA_LANGUAGE_SERVER__</arguments>
-			</matcher>
-		</filter>
-	</filteredResources>
 </projectDescription>

--- a/bundles/org.eclipse.e4.ui.bindings/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.e4.ui.bindings/META-INF/MANIFEST.MF
@@ -1,7 +1,7 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-SymbolicName: org.eclipse.e4.ui.bindings;singleton:=true
-Bundle-Version: 0.15.200.qualifier
+Bundle-Version: 0.15.300.qualifier
 Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/bundles/org.eclipse.e4.ui.css.core/.project
+++ b/bundles/org.eclipse.e4.ui.css.core/.project
@@ -37,15 +37,4 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.pde.api.tools.apiAnalysisNature</nature>
 	</natures>
-	<filteredResources>
-		<filter>
-			<id>1676382308309</id>
-			<name></name>
-			<type>30</type>
-			<matcher>
-				<id>org.eclipse.core.resources.regexFilterMatcher</id>
-				<arguments>node_modules|\.git|__CREATED_BY_JAVA_LANGUAGE_SERVER__</arguments>
-			</matcher>
-		</filter>
-	</filteredResources>
 </projectDescription>

--- a/bundles/org.eclipse.e4.ui.css.swt.theme/.project
+++ b/bundles/org.eclipse.e4.ui.css.swt.theme/.project
@@ -42,15 +42,4 @@
 		<nature>org.eclipse.jdt.core.javanature</nature>
 		<nature>org.eclipse.pde.api.tools.apiAnalysisNature</nature>
 	</natures>
-	<filteredResources>
-		<filter>
-			<id>1676382308314</id>
-			<name></name>
-			<type>30</type>
-			<matcher>
-				<id>org.eclipse.core.resources.regexFilterMatcher</id>
-				<arguments>node_modules|\.git|__CREATED_BY_JAVA_LANGUAGE_SERVER__</arguments>
-			</matcher>
-		</filter>
-	</filteredResources>
 </projectDescription>

--- a/bundles/org.eclipse.e4.ui.css.swt.theme/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.e4.ui.css.swt.theme/META-INF/MANIFEST.MF
@@ -1,7 +1,7 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-SymbolicName: org.eclipse.e4.ui.css.swt.theme;singleton:=true
-Bundle-Version: 0.15.200.qualifier
+Bundle-Version: 0.15.300.qualifier
 Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/bundles/org.eclipse.e4.ui.css.swt/.project
+++ b/bundles/org.eclipse.e4.ui.css.swt/.project
@@ -37,15 +37,4 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.pde.api.tools.apiAnalysisNature</nature>
 	</natures>
-	<filteredResources>
-		<filter>
-			<id>1676382308312</id>
-			<name></name>
-			<type>30</type>
-			<matcher>
-				<id>org.eclipse.core.resources.regexFilterMatcher</id>
-				<arguments>node_modules|\.git|__CREATED_BY_JAVA_LANGUAGE_SERVER__</arguments>
-			</matcher>
-		</filter>
-	</filteredResources>
 </projectDescription>

--- a/bundles/org.eclipse.e4.ui.di/.project
+++ b/bundles/org.eclipse.e4.ui.di/.project
@@ -42,15 +42,4 @@
 		<nature>org.eclipse.jdt.core.javanature</nature>
 		<nature>org.eclipse.pde.api.tools.apiAnalysisNature</nature>
 	</natures>
-	<filteredResources>
-		<filter>
-			<id>1676382308317</id>
-			<name></name>
-			<type>30</type>
-			<matcher>
-				<id>org.eclipse.core.resources.regexFilterMatcher</id>
-				<arguments>node_modules|\.git|__CREATED_BY_JAVA_LANGUAGE_SERVER__</arguments>
-			</matcher>
-		</filter>
-	</filteredResources>
 </projectDescription>

--- a/bundles/org.eclipse.e4.ui.di/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.e4.ui.di/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Bundle-SymbolicName: org.eclipse.e4.ui.di
-Bundle-Version: 1.5.700.qualifier
+Bundle-Version: 1.5.800.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Bundle-ActivationPolicy: lazy
 Import-Package: jakarta.inject;version="[2.0.0,3.0.0)",

--- a/bundles/org.eclipse.e4.ui.dialogs/.project
+++ b/bundles/org.eclipse.e4.ui.dialogs/.project
@@ -37,15 +37,4 @@
 		<nature>org.eclipse.jdt.core.javanature</nature>
 		<nature>org.eclipse.pde.api.tools.apiAnalysisNature</nature>
 	</natures>
-	<filteredResources>
-		<filter>
-			<id>1676382308320</id>
-			<name></name>
-			<type>30</type>
-			<matcher>
-				<id>org.eclipse.core.resources.regexFilterMatcher</id>
-				<arguments>node_modules|\.git|__CREATED_BY_JAVA_LANGUAGE_SERVER__</arguments>
-			</matcher>
-		</filter>
-	</filteredResources>
 </projectDescription>

--- a/bundles/org.eclipse.e4.ui.ide/.project
+++ b/bundles/org.eclipse.e4.ui.ide/.project
@@ -37,15 +37,4 @@
 		<nature>org.eclipse.jdt.core.javanature</nature>
 		<nature>org.eclipse.pde.api.tools.apiAnalysisNature</nature>
 	</natures>
-	<filteredResources>
-		<filter>
-			<id>1676382308327</id>
-			<name></name>
-			<type>30</type>
-			<matcher>
-				<id>org.eclipse.core.resources.regexFilterMatcher</id>
-				<arguments>node_modules|\.git|__CREATED_BY_JAVA_LANGUAGE_SERVER__</arguments>
-			</matcher>
-		</filter>
-	</filteredResources>
 </projectDescription>

--- a/bundles/org.eclipse.e4.ui.ide/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.e4.ui.ide/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Automatic-Module-Name: org.eclipse.e4.ui.ide
 Bundle-ManifestVersion: 2
 Bundle-SymbolicName: org.eclipse.e4.ui.ide
-Bundle-Version: 3.18.0.qualifier
+Bundle-Version: 3.18.100.qualifier
 Bundle-Name: %Bundle-Name
 Bundle-Vendor: %Bundle-Vendor
 Bundle-RequiredExecutionEnvironment: JavaSE-21

--- a/bundles/org.eclipse.e4.ui.model.workbench/.project
+++ b/bundles/org.eclipse.e4.ui.model.workbench/.project
@@ -37,15 +37,4 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.pde.api.tools.apiAnalysisNature</nature>
 	</natures>
-	<filteredResources>
-		<filter>
-			<id>1676382308329</id>
-			<name></name>
-			<type>30</type>
-			<matcher>
-				<id>org.eclipse.core.resources.regexFilterMatcher</id>
-				<arguments>node_modules|\.git|__CREATED_BY_JAVA_LANGUAGE_SERVER__</arguments>
-			</matcher>
-		</filter>
-	</filteredResources>
 </projectDescription>

--- a/bundles/org.eclipse.e4.ui.progress/.project
+++ b/bundles/org.eclipse.e4.ui.progress/.project
@@ -36,15 +36,4 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
-	<filteredResources>
-		<filter>
-			<id>1676382308332</id>
-			<name></name>
-			<type>30</type>
-			<matcher>
-				<id>org.eclipse.core.resources.regexFilterMatcher</id>
-				<arguments>node_modules|\.git|__CREATED_BY_JAVA_LANGUAGE_SERVER__</arguments>
-			</matcher>
-		</filter>
-	</filteredResources>
 </projectDescription>

--- a/bundles/org.eclipse.e4.ui.services/.project
+++ b/bundles/org.eclipse.e4.ui.services/.project
@@ -42,15 +42,4 @@
 		<nature>org.eclipse.jdt.core.javanature</nature>
 		<nature>org.eclipse.pde.api.tools.apiAnalysisNature</nature>
 	</natures>
-	<filteredResources>
-		<filter>
-			<id>1676382308334</id>
-			<name></name>
-			<type>30</type>
-			<matcher>
-				<id>org.eclipse.core.resources.regexFilterMatcher</id>
-				<arguments>node_modules|\.git|__CREATED_BY_JAVA_LANGUAGE_SERVER__</arguments>
-			</matcher>
-		</filter>
-	</filteredResources>
 </projectDescription>

--- a/bundles/org.eclipse.e4.ui.services/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.e4.ui.services/META-INF/MANIFEST.MF
@@ -1,7 +1,7 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-SymbolicName: org.eclipse.e4.ui.services;singleton:=true
-Bundle-Version: 1.6.700.qualifier
+Bundle-Version: 1.6.800.qualifier
 Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/bundles/org.eclipse.e4.ui.widgets/.project
+++ b/bundles/org.eclipse.e4.ui.widgets/.project
@@ -37,15 +37,4 @@
 		<nature>org.eclipse.jdt.core.javanature</nature>
 		<nature>org.eclipse.pde.api.tools.apiAnalysisNature</nature>
 	</natures>
-	<filteredResources>
-		<filter>
-			<id>1676382308352</id>
-			<name></name>
-			<type>30</type>
-			<matcher>
-				<id>org.eclipse.core.resources.regexFilterMatcher</id>
-				<arguments>node_modules|\.git|__CREATED_BY_JAVA_LANGUAGE_SERVER__</arguments>
-			</matcher>
-		</filter>
-	</filteredResources>
 </projectDescription>

--- a/bundles/org.eclipse.e4.ui.widgets/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.e4.ui.widgets/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Bundle-SymbolicName: org.eclipse.e4.ui.widgets
-Bundle-Version: 1.5.0.qualifier
+Bundle-Version: 1.5.100.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-21
 Export-Package: org.eclipse.e4.ui.widgets;x-friends:="org.eclipse.e4.ui.workbench.swt,org.eclipse.e4.ui.workbench.addons.swt"
 Require-Bundle: org.eclipse.swt;bundle-version="[3.133.0,4.0.0)"

--- a/bundles/org.eclipse.e4.ui.workbench.addons.swt/.project
+++ b/bundles/org.eclipse.e4.ui.workbench.addons.swt/.project
@@ -42,15 +42,4 @@
 		<nature>org.eclipse.jdt.core.javanature</nature>
 		<nature>org.eclipse.pde.api.tools.apiAnalysisNature</nature>
 	</natures>
-	<filteredResources>
-		<filter>
-			<id>1676382308357</id>
-			<name></name>
-			<type>30</type>
-			<matcher>
-				<id>org.eclipse.core.resources.regexFilterMatcher</id>
-				<arguments>node_modules|\.git|__CREATED_BY_JAVA_LANGUAGE_SERVER__</arguments>
-			</matcher>
-		</filter>
-	</filteredResources>
 </projectDescription>

--- a/bundles/org.eclipse.e4.ui.workbench.addons.swt/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.e4.ui.workbench.addons.swt/META-INF/MANIFEST.MF
@@ -1,7 +1,7 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-SymbolicName: org.eclipse.e4.ui.workbench.addons.swt;singleton:=true
-Bundle-Version: 1.6.100.qualifier
+Bundle-Version: 1.6.200.qualifier
 Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/bundles/org.eclipse.e4.ui.workbench.renderers.swt.cocoa/.project
+++ b/bundles/org.eclipse.e4.ui.workbench.renderers.swt.cocoa/.project
@@ -37,15 +37,4 @@
 		<nature>org.eclipse.jdt.core.javanature</nature>
 		<nature>org.eclipse.pde.api.tools.apiAnalysisNature</nature>
 	</natures>
-	<filteredResources>
-		<filter>
-			<id>1676382308364</id>
-			<name></name>
-			<type>30</type>
-			<matcher>
-				<id>org.eclipse.core.resources.regexFilterMatcher</id>
-				<arguments>node_modules|\.git|__CREATED_BY_JAVA_LANGUAGE_SERVER__</arguments>
-			</matcher>
-		</filter>
-	</filteredResources>
 </projectDescription>

--- a/bundles/org.eclipse.e4.ui.workbench.renderers.swt.cocoa/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.e4.ui.workbench.renderers.swt.cocoa/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Eclipse-PlatformFilter: (osgi.ws=cocoa)
 Bundle-SymbolicName: org.eclipse.e4.ui.workbench.renderers.swt.cocoa;singleton:=true
-Bundle-Version: 0.14.700.qualifier
+Bundle-Version: 0.14.800.qualifier
 Bundle-Name: %fragmentName
 Bundle-Vendor: %providerName
 Fragment-Host: org.eclipse.e4.ui.workbench.renderers.swt;bundle-version="[0.10.0,1.0.0)"

--- a/bundles/org.eclipse.e4.ui.workbench.renderers.swt/.project
+++ b/bundles/org.eclipse.e4.ui.workbench.renderers.swt/.project
@@ -37,15 +37,4 @@
 		<nature>org.eclipse.jdt.core.javanature</nature>
 		<nature>org.eclipse.pde.api.tools.apiAnalysisNature</nature>
 	</natures>
-	<filteredResources>
-		<filter>
-			<id>1676382308361</id>
-			<name></name>
-			<type>30</type>
-			<matcher>
-				<id>org.eclipse.core.resources.regexFilterMatcher</id>
-				<arguments>node_modules|\.git|__CREATED_BY_JAVA_LANGUAGE_SERVER__</arguments>
-			</matcher>
-		</filter>
-	</filteredResources>
 </projectDescription>

--- a/bundles/org.eclipse.e4.ui.workbench.swt/.project
+++ b/bundles/org.eclipse.e4.ui.workbench.swt/.project
@@ -42,15 +42,4 @@
 		<nature>org.eclipse.jdt.core.javanature</nature>
 		<nature>org.eclipse.pde.api.tools.apiAnalysisNature</nature>
 	</natures>
-	<filteredResources>
-		<filter>
-			<id>1676382308366</id>
-			<name></name>
-			<type>30</type>
-			<matcher>
-				<id>org.eclipse.core.resources.regexFilterMatcher</id>
-				<arguments>node_modules|\.git|__CREATED_BY_JAVA_LANGUAGE_SERVER__</arguments>
-			</matcher>
-		</filter>
-	</filteredResources>
 </projectDescription>

--- a/bundles/org.eclipse.e4.ui.workbench/.project
+++ b/bundles/org.eclipse.e4.ui.workbench/.project
@@ -42,15 +42,4 @@
 		<nature>org.eclipse.jdt.core.javanature</nature>
 		<nature>org.eclipse.pde.api.tools.apiAnalysisNature</nature>
 	</natures>
-	<filteredResources>
-		<filter>
-			<id>1676382308355</id>
-			<name></name>
-			<type>30</type>
-			<matcher>
-				<id>org.eclipse.core.resources.regexFilterMatcher</id>
-				<arguments>node_modules|\.git|__CREATED_BY_JAVA_LANGUAGE_SERVER__</arguments>
-			</matcher>
-		</filter>
-	</filteredResources>
 </projectDescription>

--- a/bundles/org.eclipse.e4.ui.workbench3/.project
+++ b/bundles/org.eclipse.e4.ui.workbench3/.project
@@ -37,15 +37,4 @@
 		<nature>org.eclipse.jdt.core.javanature</nature>
 		<nature>org.eclipse.pde.api.tools.apiAnalysisNature</nature>
 	</natures>
-	<filteredResources>
-		<filter>
-			<id>1676382308368</id>
-			<name></name>
-			<type>30</type>
-			<matcher>
-				<id>org.eclipse.core.resources.regexFilterMatcher</id>
-				<arguments>node_modules|\.git|__CREATED_BY_JAVA_LANGUAGE_SERVER__</arguments>
-			</matcher>
-		</filter>
-	</filteredResources>
 </projectDescription>

--- a/bundles/org.eclipse.e4.ui.workbench3/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.e4.ui.workbench3/META-INF/MANIFEST.MF
@@ -1,7 +1,7 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-SymbolicName: org.eclipse.e4.ui.workbench3;singleton:=true
-Bundle-Version: 0.18.0.qualifier
+Bundle-Version: 0.18.100.qualifier
 Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/bundles/org.eclipse.jface.databinding/.project
+++ b/bundles/org.eclipse.jface.databinding/.project
@@ -37,15 +37,4 @@
 		<nature>org.eclipse.jdt.core.javanature</nature>
 		<nature>org.eclipse.pde.api.tools.apiAnalysisNature</nature>
 	</natures>
-	<filteredResources>
-		<filter>
-			<id>1676382308373</id>
-			<name></name>
-			<type>30</type>
-			<matcher>
-				<id>org.eclipse.core.resources.regexFilterMatcher</id>
-				<arguments>node_modules|\.git|__CREATED_BY_JAVA_LANGUAGE_SERVER__</arguments>
-			</matcher>
-		</filter>
-	</filteredResources>
 </projectDescription>

--- a/bundles/org.eclipse.jface.databinding/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.jface.databinding/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.jface.databinding
-Bundle-Version: 1.16.0.qualifier
+Bundle-Version: 1.16.100.qualifier
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Export-Package: org.eclipse.jface.databinding.dialog,

--- a/bundles/org.eclipse.jface.notifications/.project
+++ b/bundles/org.eclipse.jface.notifications/.project
@@ -42,15 +42,4 @@
 		<nature>org.eclipse.jdt.core.javanature</nature>
 		<nature>org.eclipse.pde.api.tools.apiAnalysisNature</nature>
 	</natures>
-	<filteredResources>
-		<filter>
-			<id>1676382308378</id>
-			<name></name>
-			<type>30</type>
-			<matcher>
-				<id>org.eclipse.core.resources.regexFilterMatcher</id>
-				<arguments>node_modules|\.git|__CREATED_BY_JAVA_LANGUAGE_SERVER__</arguments>
-			</matcher>
-		</filter>
-	</filteredResources>
 </projectDescription>

--- a/bundles/org.eclipse.jface.notifications/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.jface.notifications/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Bundle-SymbolicName: org.eclipse.jface.notifications
-Bundle-Version: 0.8.100.qualifier
+Bundle-Version: 0.8.200.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-21
 Export-Package: org.eclipse.jface.notifications,
  org.eclipse.jface.notifications.internal;x-internal:=true

--- a/bundles/org.eclipse.jface/.project
+++ b/bundles/org.eclipse.jface/.project
@@ -37,15 +37,4 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.pde.api.tools.apiAnalysisNature</nature>
 	</natures>
-	<filteredResources>
-		<filter>
-			<id>1676382308371</id>
-			<name></name>
-			<type>30</type>
-			<matcher>
-				<id>org.eclipse.core.resources.regexFilterMatcher</id>
-				<arguments>node_modules|\.git|__CREATED_BY_JAVA_LANGUAGE_SERVER__</arguments>
-			</matcher>
-		</filter>
-	</filteredResources>
 </projectDescription>

--- a/bundles/org.eclipse.ui.browser/.project
+++ b/bundles/org.eclipse.ui.browser/.project
@@ -37,15 +37,4 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.pde.api.tools.apiAnalysisNature</nature>
 	</natures>
-	<filteredResources>
-		<filter>
-			<id>1676382308400</id>
-			<name></name>
-			<type>30</type>
-			<matcher>
-				<id>org.eclipse.core.resources.regexFilterMatcher</id>
-				<arguments>node_modules|\.git|__CREATED_BY_JAVA_LANGUAGE_SERVER__</arguments>
-			</matcher>
-		</filter>
-	</filteredResources>
 </projectDescription>

--- a/bundles/org.eclipse.ui.cocoa/.project
+++ b/bundles/org.eclipse.ui.cocoa/.project
@@ -31,15 +31,4 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
-	<filteredResources>
-		<filter>
-			<id>1676382308402</id>
-			<name></name>
-			<type>30</type>
-			<matcher>
-				<id>org.eclipse.core.resources.regexFilterMatcher</id>
-				<arguments>node_modules|\.git|__CREATED_BY_JAVA_LANGUAGE_SERVER__</arguments>
-			</matcher>
-		</filter>
-	</filteredResources>
 </projectDescription>

--- a/bundles/org.eclipse.ui.cocoa/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.ui.cocoa/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %fragmentName
 Bundle-SymbolicName: org.eclipse.ui.cocoa;singleton:=true
-Bundle-Version: 1.3.500.qualifier
+Bundle-Version: 1.3.600.qualifier
 Bundle-Vendor: %providerName
 Fragment-Host: org.eclipse.ui;bundle-version="[3.5.0,4.0.0)"
 Bundle-Localization: fragment-cocoa

--- a/bundles/org.eclipse.ui.forms/.project
+++ b/bundles/org.eclipse.ui.forms/.project
@@ -37,15 +37,4 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.pde.api.tools.apiAnalysisNature</nature>
 	</natures>
-	<filteredResources>
-		<filter>
-			<id>1676382308429</id>
-			<name></name>
-			<type>30</type>
-			<matcher>
-				<id>org.eclipse.core.resources.regexFilterMatcher</id>
-				<arguments>node_modules|\.git|__CREATED_BY_JAVA_LANGUAGE_SERVER__</arguments>
-			</matcher>
-		</filter>
-	</filteredResources>
 </projectDescription>

--- a/bundles/org.eclipse.ui.forms/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.ui.forms/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %name
 Bundle-SymbolicName: org.eclipse.ui.forms;singleton:=true
-Bundle-Version: 3.14.200.qualifier
+Bundle-Version: 3.14.300.qualifier
 Bundle-Vendor: %provider-name
 Bundle-Localization: plugin
 Export-Package: org.eclipse.ui.forms,

--- a/bundles/org.eclipse.ui.ide.application/.project
+++ b/bundles/org.eclipse.ui.ide.application/.project
@@ -37,15 +37,4 @@
 		<nature>org.eclipse.jdt.core.javanature</nature>
 		<nature>org.eclipse.pde.api.tools.apiAnalysisNature</nature>
 	</natures>
-	<filteredResources>
-		<filter>
-			<id>1676382308433</id>
-			<name></name>
-			<type>30</type>
-			<matcher>
-				<id>org.eclipse.core.resources.regexFilterMatcher</id>
-				<arguments>node_modules|\.git|__CREATED_BY_JAVA_LANGUAGE_SERVER__</arguments>
-			</matcher>
-		</filter>
-	</filteredResources>
 </projectDescription>

--- a/bundles/org.eclipse.ui.ide/.project
+++ b/bundles/org.eclipse.ui.ide/.project
@@ -37,15 +37,4 @@
 		<nature>org.eclipse.jdt.core.javanature</nature>
 		<nature>org.eclipse.pde.api.tools.apiAnalysisNature</nature>
 	</natures>
-	<filteredResources>
-		<filter>
-			<id>1676382308432</id>
-			<name></name>
-			<type>30</type>
-			<matcher>
-				<id>org.eclipse.core.resources.regexFilterMatcher</id>
-				<arguments>node_modules|\.git|__CREATED_BY_JAVA_LANGUAGE_SERVER__</arguments>
-			</matcher>
-		</filter>
-	</filteredResources>
 </projectDescription>

--- a/bundles/org.eclipse.ui.monitoring/.project
+++ b/bundles/org.eclipse.ui.monitoring/.project
@@ -42,15 +42,4 @@
 		<nature>org.eclipse.jdt.core.javanature</nature>
 		<nature>org.eclipse.pde.api.tools.apiAnalysisNature</nature>
 	</natures>
-	<filteredResources>
-		<filter>
-			<id>1676382308448</id>
-			<name></name>
-			<type>30</type>
-			<matcher>
-				<id>org.eclipse.core.resources.regexFilterMatcher</id>
-				<arguments>node_modules|\.git|__CREATED_BY_JAVA_LANGUAGE_SERVER__</arguments>
-			</matcher>
-		</filter>
-	</filteredResources>
 </projectDescription>

--- a/bundles/org.eclipse.ui.monitoring/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.ui.monitoring/META-INF/MANIFEST.MF
@@ -6,7 +6,7 @@ Bundle-Name: %Bundle-Name
 Bundle-RequiredExecutionEnvironment: JavaSE-21
 Bundle-SymbolicName: org.eclipse.ui.monitoring;singleton:=true
 Bundle-Vendor: %Bundle-Vendor
-Bundle-Version: 1.4.0.qualifier
+Bundle-Version: 1.4.100.qualifier
 Export-Package: org.eclipse.ui.internal.monitoring;x-internal:=true,
  org.eclipse.ui.internal.monitoring.preferences;x-internal:=true,
  org.eclipse.ui.monitoring;x-internal:=true

--- a/bundles/org.eclipse.ui.navigator.resources/.project
+++ b/bundles/org.eclipse.ui.navigator.resources/.project
@@ -37,15 +37,4 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.pde.api.tools.apiAnalysisNature</nature>
 	</natures>
-	<filteredResources>
-		<filter>
-			<id>1676382308454</id>
-			<name></name>
-			<type>30</type>
-			<matcher>
-				<id>org.eclipse.core.resources.regexFilterMatcher</id>
-				<arguments>node_modules|\.git|__CREATED_BY_JAVA_LANGUAGE_SERVER__</arguments>
-			</matcher>
-		</filter>
-	</filteredResources>
 </projectDescription>

--- a/bundles/org.eclipse.ui.navigator/.project
+++ b/bundles/org.eclipse.ui.navigator/.project
@@ -37,15 +37,4 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.pde.api.tools.apiAnalysisNature</nature>
 	</natures>
-	<filteredResources>
-		<filter>
-			<id>1676382308452</id>
-			<name></name>
-			<type>30</type>
-			<matcher>
-				<id>org.eclipse.core.resources.regexFilterMatcher</id>
-				<arguments>node_modules|\.git|__CREATED_BY_JAVA_LANGUAGE_SERVER__</arguments>
-			</matcher>
-		</filter>
-	</filteredResources>
 </projectDescription>

--- a/bundles/org.eclipse.ui.themes/.project
+++ b/bundles/org.eclipse.ui.themes/.project
@@ -25,15 +25,4 @@
 		<nature>org.eclipse.m2e.core.maven2Nature</nature>
 		<nature>org.eclipse.pde.PluginNature</nature>
 	</natures>
-	<filteredResources>
-		<filter>
-			<id>1676382308482</id>
-			<name></name>
-			<type>30</type>
-			<matcher>
-				<id>org.eclipse.core.resources.regexFilterMatcher</id>
-				<arguments>node_modules|\.git|__CREATED_BY_JAVA_LANGUAGE_SERVER__</arguments>
-			</matcher>
-		</filter>
-	</filteredResources>
 </projectDescription>

--- a/bundles/org.eclipse.ui.views.log/.project
+++ b/bundles/org.eclipse.ui.views.log/.project
@@ -37,15 +37,4 @@
 		<nature>org.eclipse.jdt.core.javanature</nature>
 		<nature>org.eclipse.pde.api.tools.apiAnalysisNature</nature>
 	</natures>
-	<filteredResources>
-		<filter>
-			<id>1676382308487</id>
-			<name></name>
-			<type>30</type>
-			<matcher>
-				<id>org.eclipse.core.resources.regexFilterMatcher</id>
-				<arguments>node_modules|\.git|__CREATED_BY_JAVA_LANGUAGE_SERVER__</arguments>
-			</matcher>
-		</filter>
-	</filteredResources>
 </projectDescription>

--- a/bundles/org.eclipse.ui.views.log/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.ui.views.log/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %name
 Bundle-SymbolicName: org.eclipse.ui.views.log;singleton:=true
-Bundle-Version: 1.5.200.qualifier
+Bundle-Version: 1.5.300.qualifier
 Bundle-Activator: org.eclipse.ui.internal.views.log.Activator
 Bundle-Vendor: %provider-name
 Require-Bundle: org.eclipse.core.runtime;bundle-version="[3.29.0,4.0.0)",

--- a/bundles/org.eclipse.ui.views.properties.tabbed/.project
+++ b/bundles/org.eclipse.ui.views.properties.tabbed/.project
@@ -37,15 +37,4 @@
 		<nature>org.eclipse.jdt.core.javanature</nature>
 		<nature>org.eclipse.pde.api.tools.apiAnalysisNature</nature>
 	</natures>
-	<filteredResources>
-		<filter>
-			<id>1676382308489</id>
-			<name></name>
-			<type>30</type>
-			<matcher>
-				<id>org.eclipse.core.resources.regexFilterMatcher</id>
-				<arguments>node_modules|\.git|__CREATED_BY_JAVA_LANGUAGE_SERVER__</arguments>
-			</matcher>
-		</filter>
-	</filteredResources>
 </projectDescription>

--- a/bundles/org.eclipse.ui.views.properties.tabbed/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.ui.views.properties.tabbed/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Plugin.name
 Bundle-SymbolicName: org.eclipse.ui.views.properties.tabbed;singleton:=true
-Bundle-Version: 3.11.0.qualifier
+Bundle-Version: 3.11.100.qualifier
 Bundle-Vendor: %Plugin.providerName
 Bundle-Localization: plugin
 Export-Package: org.eclipse.ui.internal.views.properties.tabbed;x-internal:=true,

--- a/bundles/org.eclipse.ui.views/.project
+++ b/bundles/org.eclipse.ui.views/.project
@@ -37,15 +37,4 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.pde.api.tools.apiAnalysisNature</nature>
 	</natures>
-	<filteredResources>
-		<filter>
-			<id>1676382308484</id>
-			<name></name>
-			<type>30</type>
-			<matcher>
-				<id>org.eclipse.core.resources.regexFilterMatcher</id>
-				<arguments>node_modules|\.git|__CREATED_BY_JAVA_LANGUAGE_SERVER__</arguments>
-			</matcher>
-		</filter>
-	</filteredResources>
 </projectDescription>

--- a/bundles/org.eclipse.ui.views/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.ui.views/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.ui.views; singleton:=true
-Bundle-Version: 3.13.200.qualifier
+Bundle-Version: 3.13.300.qualifier
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Export-Package: org.eclipse.ui.internal.views.contentoutline;x-internal:=true,

--- a/bundles/org.eclipse.ui.win32/.project
+++ b/bundles/org.eclipse.ui.win32/.project
@@ -37,15 +37,4 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.pde.api.tools.apiAnalysisNature</nature>
 	</natures>
-	<filteredResources>
-		<filter>
-			<id>1676382308491</id>
-			<name></name>
-			<type>30</type>
-			<matcher>
-				<id>org.eclipse.core.resources.regexFilterMatcher</id>
-				<arguments>node_modules|\.git|__CREATED_BY_JAVA_LANGUAGE_SERVER__</arguments>
-			</matcher>
-		</filter>
-	</filteredResources>
 </projectDescription>

--- a/bundles/org.eclipse.ui.win32/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.ui.win32/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %fragmentName
 Bundle-SymbolicName: org.eclipse.ui.win32
-Bundle-Version: 3.5.400.qualifier
+Bundle-Version: 3.5.500.qualifier
 Bundle-Vendor: %providerName
 Fragment-Host: org.eclipse.ui.ide;bundle-version="[3.2.0,4.0.0)"
 Require-Bundle: org.eclipse.core.resources;resolution:=optional

--- a/bundles/org.eclipse.ui.workbench/.project
+++ b/bundles/org.eclipse.ui.workbench/.project
@@ -42,15 +42,4 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.pde.api.tools.apiAnalysisNature</nature>
 	</natures>
-	<filteredResources>
-		<filter>
-			<id>1676382308493</id>
-			<name></name>
-			<type>30</type>
-			<matcher>
-				<id>org.eclipse.core.resources.regexFilterMatcher</id>
-				<arguments>node_modules|\.git|__CREATED_BY_JAVA_LANGUAGE_SERVER__</arguments>
-			</matcher>
-		</filter>
-	</filteredResources>
 </projectDescription>

--- a/bundles/org.eclipse.ui/.project
+++ b/bundles/org.eclipse.ui/.project
@@ -37,15 +37,4 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.pde.api.tools.apiAnalysisNature</nature>
 	</natures>
-	<filteredResources>
-		<filter>
-			<id>1676382308398</id>
-			<name></name>
-			<type>30</type>
-			<matcher>
-				<id>org.eclipse.core.resources.regexFilterMatcher</id>
-				<arguments>node_modules|\.git|__CREATED_BY_JAVA_LANGUAGE_SERVER__</arguments>
-			</matcher>
-		</filter>
-	</filteredResources>
 </projectDescription>

--- a/bundles/org.eclipse.ui/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Plugin.name
 Bundle-SymbolicName: org.eclipse.ui; singleton:=true
-Bundle-Version: 3.209.100.qualifier
+Bundle-Version: 3.209.200.qualifier
 Bundle-Activator: org.eclipse.ui.internal.UIPlugin
 Bundle-ActivationPolicy: lazy
 Bundle-Vendor: %Plugin.providerName

--- a/bundles/org.eclipse.urischeme/.project
+++ b/bundles/org.eclipse.urischeme/.project
@@ -37,15 +37,4 @@
 		<nature>org.eclipse.jdt.core.javanature</nature>
 		<nature>org.eclipse.pde.api.tools.apiAnalysisNature</nature>
 	</natures>
-	<filteredResources>
-		<filter>
-			<id>1676382308495</id>
-			<name></name>
-			<type>30</type>
-			<matcher>
-				<id>org.eclipse.core.resources.regexFilterMatcher</id>
-				<arguments>node_modules|\.git|__CREATED_BY_JAVA_LANGUAGE_SERVER__</arguments>
-			</matcher>
-		</filter>
-	</filteredResources>
 </projectDescription>

--- a/bundles/org.eclipse.urischeme/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.urischeme/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Plugin.name
 Bundle-SymbolicName: org.eclipse.urischeme;singleton:=true
-Bundle-Version: 1.3.600.qualifier
+Bundle-Version: 1.3.700.qualifier
 Automatic-Module-Name: org.eclipse.urischeme
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Require-Bundle: org.eclipse.equinox.common;bundle-version="[3.8.0,4.0.0)",

--- a/examples/org.eclipse.e4.demo.cssbridge/.project
+++ b/examples/org.eclipse.e4.demo.cssbridge/.project
@@ -36,15 +36,4 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
-	<filteredResources>
-		<filter>
-			<id>1676382308288</id>
-			<name></name>
-			<type>30</type>
-			<matcher>
-				<id>org.eclipse.core.resources.regexFilterMatcher</id>
-				<arguments>node_modules|\.git|__CREATED_BY_JAVA_LANGUAGE_SERVER__</arguments>
-			</matcher>
-		</filter>
-	</filteredResources>
 </projectDescription>

--- a/examples/org.eclipse.e4.ui.examples.job/.project
+++ b/examples/org.eclipse.e4.ui.examples.job/.project
@@ -31,15 +31,4 @@
 		<nature>org.eclipse.jdt.core.javanature</nature>
 		<nature>org.eclipse.pde.PluginNature</nature>
 	</natures>
-	<filteredResources>
-		<filter>
-			<id>1676382308322</id>
-			<name></name>
-			<type>30</type>
-			<matcher>
-				<id>org.eclipse.core.resources.regexFilterMatcher</id>
-				<arguments>node_modules|\.git|__CREATED_BY_JAVA_LANGUAGE_SERVER__</arguments>
-			</matcher>
-		</filter>
-	</filteredResources>
 </projectDescription>

--- a/examples/org.eclipse.jface.examples.databinding/.project
+++ b/examples/org.eclipse.jface.examples.databinding/.project
@@ -31,15 +31,4 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
-	<filteredResources>
-		<filter>
-			<id>1676382308375</id>
-			<name></name>
-			<type>30</type>
-			<matcher>
-				<id>org.eclipse.core.resources.regexFilterMatcher</id>
-				<arguments>node_modules|\.git|__CREATED_BY_JAVA_LANGUAGE_SERVER__</arguments>
-			</matcher>
-		</filter>
-	</filteredResources>
 </projectDescription>

--- a/examples/org.eclipse.jface.examples.databinding/META-INF/MANIFEST.MF
+++ b/examples/org.eclipse.jface.examples.databinding/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.jface.examples.databinding
-Bundle-Version: 1.5.100.qualifier
+Bundle-Version: 1.5.200.qualifier
 Eclipse-BundleShape: dir
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/examples/org.eclipse.jface.snippets/.project
+++ b/examples/org.eclipse.jface.snippets/.project
@@ -31,15 +31,4 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
-	<filteredResources>
-		<filter>
-			<id>1676382308385</id>
-			<name></name>
-			<type>30</type>
-			<matcher>
-				<id>org.eclipse.core.resources.regexFilterMatcher</id>
-				<arguments>node_modules|\.git|__CREATED_BY_JAVA_LANGUAGE_SERVER__</arguments>
-			</matcher>
-		</filter>
-	</filteredResources>
 </projectDescription>

--- a/examples/org.eclipse.ui.examples.adapterservice/.project
+++ b/examples/org.eclipse.ui.examples.adapterservice/.project
@@ -31,15 +31,4 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
-	<filteredResources>
-		<filter>
-			<id>1676382308404</id>
-			<name></name>
-			<type>30</type>
-			<matcher>
-				<id>org.eclipse.core.resources.regexFilterMatcher</id>
-				<arguments>node_modules|\.git|__CREATED_BY_JAVA_LANGUAGE_SERVER__</arguments>
-			</matcher>
-		</filter>
-	</filteredResources>
 </projectDescription>

--- a/examples/org.eclipse.ui.examples.contributions/.project
+++ b/examples/org.eclipse.ui.examples.contributions/.project
@@ -31,15 +31,4 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
-	<filteredResources>
-		<filter>
-			<id>1676382308406</id>
-			<name></name>
-			<type>30</type>
-			<matcher>
-				<id>org.eclipse.core.resources.regexFilterMatcher</id>
-				<arguments>node_modules|\.git|__CREATED_BY_JAVA_LANGUAGE_SERVER__</arguments>
-			</matcher>
-		</filter>
-	</filteredResources>
 </projectDescription>

--- a/examples/org.eclipse.ui.examples.contributions/META-INF/MANIFEST.MF
+++ b/examples/org.eclipse.ui.examples.contributions/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %contributions.Activator.name
 Bundle-SymbolicName: org.eclipse.ui.examples.contributions; singleton:=true
-Bundle-Version: 3.7.0.qualifier
+Bundle-Version: 3.7.100.qualifier
 Bundle-Activator: org.eclipse.ui.examples.contributions.Activator
 Require-Bundle: org.eclipse.ui;bundle-version="[3.208.0,4.0.0)",
  org.eclipse.core.runtime,

--- a/examples/org.eclipse.ui.examples.fieldassist/.project
+++ b/examples/org.eclipse.ui.examples.fieldassist/.project
@@ -31,15 +31,4 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
-	<filteredResources>
-		<filter>
-			<id>1676382308408</id>
-			<name></name>
-			<type>30</type>
-			<matcher>
-				<id>org.eclipse.core.resources.regexFilterMatcher</id>
-				<arguments>node_modules|\.git|__CREATED_BY_JAVA_LANGUAGE_SERVER__</arguments>
-			</matcher>
-		</filter>
-	</filteredResources>
 </projectDescription>

--- a/examples/org.eclipse.ui.examples.fieldassist/META-INF/MANIFEST.MF
+++ b/examples/org.eclipse.ui.examples.fieldassist/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Plugin.name
 Bundle-SymbolicName: org.eclipse.ui.examples.fieldassist; singleton:=true
-Bundle-Version: 1.4.0.qualifier
+Bundle-Version: 1.4.100.qualifier
 Bundle-Activator: org.eclipse.ui.examples.fieldassist.FieldAssistPlugin
 Bundle-Localization: plugin
 Bundle-Vendor: %Bundle-Vendor

--- a/examples/org.eclipse.ui.examples.job/.project
+++ b/examples/org.eclipse.ui.examples.job/.project
@@ -31,15 +31,4 @@
 		<nature>org.eclipse.jdt.core.javanature</nature>
 		<nature>org.eclipse.pde.PluginNature</nature>
 	</natures>
-	<filteredResources>
-		<filter>
-			<id>1676382308410</id>
-			<name></name>
-			<type>30</type>
-			<matcher>
-				<id>org.eclipse.core.resources.regexFilterMatcher</id>
-				<arguments>node_modules|\.git|__CREATED_BY_JAVA_LANGUAGE_SERVER__</arguments>
-			</matcher>
-		</filter>
-	</filteredResources>
 </projectDescription>

--- a/examples/org.eclipse.ui.examples.markerHelp/.project
+++ b/examples/org.eclipse.ui.examples.markerHelp/.project
@@ -31,15 +31,4 @@
 		<nature>org.eclipse.jdt.core.javanature</nature>
 		<nature>org.eclipse.pde.PluginNature</nature>
 	</natures>
-	<filteredResources>
-		<filter>
-			<id>1676382308412</id>
-			<name></name>
-			<type>30</type>
-			<matcher>
-				<id>org.eclipse.core.resources.regexFilterMatcher</id>
-				<arguments>node_modules|\.git|__CREATED_BY_JAVA_LANGUAGE_SERVER__</arguments>
-			</matcher>
-		</filter>
-	</filteredResources>
 </projectDescription>

--- a/examples/org.eclipse.ui.examples.multipageeditor/.project
+++ b/examples/org.eclipse.ui.examples.multipageeditor/.project
@@ -31,15 +31,4 @@
 		<nature>org.eclipse.jdt.core.javanature</nature>
 		<nature>org.eclipse.pde.PluginNature</nature>
 	</natures>
-	<filteredResources>
-		<filter>
-			<id>1676382308414</id>
-			<name></name>
-			<type>30</type>
-			<matcher>
-				<id>org.eclipse.core.resources.regexFilterMatcher</id>
-				<arguments>node_modules|\.git|__CREATED_BY_JAVA_LANGUAGE_SERVER__</arguments>
-			</matcher>
-		</filter>
-	</filteredResources>
 </projectDescription>

--- a/examples/org.eclipse.ui.examples.multipageeditor/META-INF/MANIFEST.MF
+++ b/examples/org.eclipse.ui.examples.multipageeditor/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Plugin.name
 Bundle-SymbolicName: org.eclipse.ui.examples.multipageeditor; singleton:=true
-Bundle-Version: 3.5.0.qualifier
+Bundle-Version: 3.5.100.qualifier
 Bundle-Vendor: %Plugin.providerName
 Bundle-Localization: plugin
 Export-Package: org.eclipse.ui.examples.multipageeditor

--- a/examples/org.eclipse.ui.examples.navigator/.project
+++ b/examples/org.eclipse.ui.examples.navigator/.project
@@ -31,15 +31,4 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
-	<filteredResources>
-		<filter>
-			<id>1676382308417</id>
-			<name></name>
-			<type>30</type>
-			<matcher>
-				<id>org.eclipse.core.resources.regexFilterMatcher</id>
-				<arguments>node_modules|\.git|__CREATED_BY_JAVA_LANGUAGE_SERVER__</arguments>
-			</matcher>
-		</filter>
-	</filteredResources>
 </projectDescription>

--- a/examples/org.eclipse.ui.examples.propertysheet/.project
+++ b/examples/org.eclipse.ui.examples.propertysheet/.project
@@ -31,15 +31,4 @@
 		<nature>org.eclipse.jdt.core.javanature</nature>
 		<nature>org.eclipse.pde.PluginNature</nature>
 	</natures>
-	<filteredResources>
-		<filter>
-			<id>1676382308418</id>
-			<name></name>
-			<type>30</type>
-			<matcher>
-				<id>org.eclipse.core.resources.regexFilterMatcher</id>
-				<arguments>node_modules|\.git|__CREATED_BY_JAVA_LANGUAGE_SERVER__</arguments>
-			</matcher>
-		</filter>
-	</filteredResources>
 </projectDescription>

--- a/examples/org.eclipse.ui.examples.propertysheet/META-INF/MANIFEST.MF
+++ b/examples/org.eclipse.ui.examples.propertysheet/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Plugin.name
 Bundle-SymbolicName: org.eclipse.ui.examples.propertysheet; singleton:=true
-Bundle-Version: 3.6.0.qualifier
+Bundle-Version: 3.6.100.qualifier
 Bundle-Activator: org.eclipse.ui.examples.propertysheet.PropertySheetPlugin
 Bundle-Vendor: %Plugin.providerName
 Bundle-Localization: plugin

--- a/examples/org.eclipse.ui.examples.readmetool/.project
+++ b/examples/org.eclipse.ui.examples.readmetool/.project
@@ -31,15 +31,4 @@
 		<nature>org.eclipse.jdt.core.javanature</nature>
 		<nature>org.eclipse.pde.PluginNature</nature>
 	</natures>
-	<filteredResources>
-		<filter>
-			<id>1676382308420</id>
-			<name></name>
-			<type>30</type>
-			<matcher>
-				<id>org.eclipse.core.resources.regexFilterMatcher</id>
-				<arguments>node_modules|\.git|__CREATED_BY_JAVA_LANGUAGE_SERVER__</arguments>
-			</matcher>
-		</filter>
-	</filteredResources>
 </projectDescription>

--- a/examples/org.eclipse.ui.examples.readmetool/META-INF/MANIFEST.MF
+++ b/examples/org.eclipse.ui.examples.readmetool/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Plugin.name
 Bundle-SymbolicName: org.eclipse.ui.examples.readmetool; singleton:=true
-Bundle-Version: 3.8.0.qualifier
+Bundle-Version: 3.8.100.qualifier
 Bundle-Activator: org.eclipse.ui.examples.readmetool.ReadmePlugin
 Bundle-Vendor: %Plugin.providerName
 Bundle-Localization: plugin

--- a/examples/org.eclipse.ui.examples.undo/.project
+++ b/examples/org.eclipse.ui.examples.undo/.project
@@ -31,15 +31,4 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
-	<filteredResources>
-		<filter>
-			<id>1676382308422</id>
-			<name></name>
-			<type>30</type>
-			<matcher>
-				<id>org.eclipse.core.resources.regexFilterMatcher</id>
-				<arguments>node_modules|\.git|__CREATED_BY_JAVA_LANGUAGE_SERVER__</arguments>
-			</matcher>
-		</filter>
-	</filteredResources>
 </projectDescription>

--- a/examples/org.eclipse.ui.examples.undo/META-INF/MANIFEST.MF
+++ b/examples/org.eclipse.ui.examples.undo/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Plugin.name
 Bundle-SymbolicName: org.eclipse.ui.examples.undo; singleton:=true
-Bundle-Version: 3.6.0.qualifier
+Bundle-Version: 3.6.100.qualifier
 Bundle-Activator: org.eclipse.ui.examples.undo.UndoPlugin
 Bundle-Localization: plugin
 Require-Bundle: org.eclipse.ui;bundle-version="3.208.0",

--- a/examples/org.eclipse.ui.examples.uriSchemeHandler/.project
+++ b/examples/org.eclipse.ui.examples.uriSchemeHandler/.project
@@ -31,15 +31,4 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
-	<filteredResources>
-		<filter>
-			<id>1676382308425</id>
-			<name></name>
-			<type>30</type>
-			<matcher>
-				<id>org.eclipse.core.resources.regexFilterMatcher</id>
-				<arguments>node_modules|\.git|__CREATED_BY_JAVA_LANGUAGE_SERVER__</arguments>
-			</matcher>
-		</filter>
-	</filteredResources>
 </projectDescription>

--- a/examples/org.eclipse.ui.examples.uriSchemeHandler/META-INF/MANIFEST.MF
+++ b/examples/org.eclipse.ui.examples.uriSchemeHandler/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %Plugin.name
 Bundle-Vendor: %Plugin.Providername
 Bundle-SymbolicName: org.eclipse.ui.examples.uriSchemeHandler;singleton:=true
-Bundle-Version: 1.3.0.qualifier
+Bundle-Version: 1.3.100.qualifier
 Require-Bundle: org.eclipse.ui;bundle-version="3.208.0",
  org.eclipse.urischeme
 Bundle-Localization: plugin

--- a/examples/org.eclipse.ui.examples.views.properties.tabbed.article/.project
+++ b/examples/org.eclipse.ui.examples.views.properties.tabbed.article/.project
@@ -31,15 +31,4 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
-	<filteredResources>
-		<filter>
-			<id>1676382308427</id>
-			<name></name>
-			<type>30</type>
-			<matcher>
-				<id>org.eclipse.core.resources.regexFilterMatcher</id>
-				<arguments>node_modules|\.git|__CREATED_BY_JAVA_LANGUAGE_SERVER__</arguments>
-			</matcher>
-		</filter>
-	</filteredResources>
 </projectDescription>

--- a/examples/org.eclipse.ui.examples.views.properties.tabbed.article/META-INF/MANIFEST.MF
+++ b/examples/org.eclipse.ui.examples.views.properties.tabbed.article/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Plugin.name
 Bundle-SymbolicName: org.eclipse.ui.examples.views.properties.tabbed.article; singleton:=true
-Bundle-Version: 3.5.0.qualifier
+Bundle-Version: 3.5.100.qualifier
 Bundle-Localization: plugin
 Require-Bundle: org.eclipse.ui;bundle-version="3.208.0",
  org.eclipse.core.runtime,

--- a/examples/org.eclipse.ui.forms.examples/.project
+++ b/examples/org.eclipse.ui.forms.examples/.project
@@ -31,15 +31,4 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
-	<filteredResources>
-		<filter>
-			<id>1676382308431</id>
-			<name></name>
-			<type>30</type>
-			<matcher>
-				<id>org.eclipse.core.resources.regexFilterMatcher</id>
-				<arguments>node_modules|\.git|__CREATED_BY_JAVA_LANGUAGE_SERVER__</arguments>
-			</matcher>
-		</filter>
-	</filteredResources>
 </projectDescription>

--- a/features/org.eclipse.e4.rcp/.project
+++ b/features/org.eclipse.e4.rcp/.project
@@ -20,15 +20,4 @@
 		<nature>org.eclipse.m2e.core.maven2Nature</nature>
 		<nature>org.eclipse.pde.FeatureNature</nature>
 	</natures>
-	<filteredResources>
-		<filter>
-			<id>1676382308294</id>
-			<name></name>
-			<type>30</type>
-			<matcher>
-				<id>org.eclipse.core.resources.regexFilterMatcher</id>
-				<arguments>node_modules|\.git|__CREATED_BY_JAVA_LANGUAGE_SERVER__</arguments>
-			</matcher>
-		</filter>
-	</filteredResources>
 </projectDescription>

--- a/tests/org.eclipse.e4.core.commands.tests/.project
+++ b/tests/org.eclipse.e4.core.commands.tests/.project
@@ -31,15 +31,4 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
-	<filteredResources>
-		<filter>
-			<id>1676382308282</id>
-			<name></name>
-			<type>30</type>
-			<matcher>
-				<id>org.eclipse.core.resources.regexFilterMatcher</id>
-				<arguments>node_modules|\.git|__CREATED_BY_JAVA_LANGUAGE_SERVER__</arguments>
-			</matcher>
-		</filter>
-	</filteredResources>
 </projectDescription>

--- a/tests/org.eclipse.e4.emf.xpath.test/.project
+++ b/tests/org.eclipse.e4.emf.xpath.test/.project
@@ -31,15 +31,4 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
-	<filteredResources>
-		<filter>
-			<id>1676382308291</id>
-			<name></name>
-			<type>30</type>
-			<matcher>
-				<id>org.eclipse.core.resources.regexFilterMatcher</id>
-				<arguments>node_modules|\.git|__CREATED_BY_JAVA_LANGUAGE_SERVER__</arguments>
-			</matcher>
-		</filter>
-	</filteredResources>
 </projectDescription>

--- a/tests/org.eclipse.e4.ui.bindings.tests/.project
+++ b/tests/org.eclipse.e4.ui.bindings.tests/.project
@@ -31,15 +31,4 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
-	<filteredResources>
-		<filter>
-			<id>1676382308306</id>
-			<name></name>
-			<type>30</type>
-			<matcher>
-				<id>org.eclipse.core.resources.regexFilterMatcher</id>
-				<arguments>node_modules|\.git|__CREATED_BY_JAVA_LANGUAGE_SERVER__</arguments>
-			</matcher>
-		</filter>
-	</filteredResources>
 </projectDescription>

--- a/tests/org.eclipse.e4.ui.tests.css.core/.project
+++ b/tests/org.eclipse.e4.ui.tests.css.core/.project
@@ -31,15 +31,4 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
-	<filteredResources>
-		<filter>
-			<id>1676382308348</id>
-			<name></name>
-			<type>30</type>
-			<matcher>
-				<id>org.eclipse.core.resources.regexFilterMatcher</id>
-				<arguments>node_modules|\.git|__CREATED_BY_JAVA_LANGUAGE_SERVER__</arguments>
-			</matcher>
-		</filter>
-	</filteredResources>
 </projectDescription>

--- a/tests/org.eclipse.e4.ui.tests.css.swt/.project
+++ b/tests/org.eclipse.e4.ui.tests.css.swt/.project
@@ -31,15 +31,4 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
-	<filteredResources>
-		<filter>
-			<id>1676382308350</id>
-			<name></name>
-			<type>30</type>
-			<matcher>
-				<id>org.eclipse.core.resources.regexFilterMatcher</id>
-				<arguments>node_modules|\.git|__CREATED_BY_JAVA_LANGUAGE_SERVER__</arguments>
-			</matcher>
-		</filter>
-	</filteredResources>
 </projectDescription>

--- a/tests/org.eclipse.e4.ui.tests/.project
+++ b/tests/org.eclipse.e4.ui.tests/.project
@@ -31,15 +31,4 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
-	<filteredResources>
-		<filter>
-			<id>1676382308341</id>
-			<name></name>
-			<type>30</type>
-			<matcher>
-				<id>org.eclipse.core.resources.regexFilterMatcher</id>
-				<arguments>node_modules|\.git|__CREATED_BY_JAVA_LANGUAGE_SERVER__</arguments>
-			</matcher>
-		</filter>
-	</filteredResources>
 </projectDescription>

--- a/tests/org.eclipse.e4.ui.workbench.addons.swt.test/.project
+++ b/tests/org.eclipse.e4.ui.workbench.addons.swt.test/.project
@@ -31,15 +31,4 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
-	<filteredResources>
-		<filter>
-			<id>1676382308360</id>
-			<name></name>
-			<type>30</type>
-			<matcher>
-				<id>org.eclipse.core.resources.regexFilterMatcher</id>
-				<arguments>node_modules|\.git|__CREATED_BY_JAVA_LANGUAGE_SERVER__</arguments>
-			</matcher>
-		</filter>
-	</filteredResources>
 </projectDescription>

--- a/tests/org.eclipse.jface.tests.databinding.conformance/.project
+++ b/tests/org.eclipse.jface.tests.databinding.conformance/.project
@@ -31,15 +31,4 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
-	<filteredResources>
-		<filter>
-			<id>1676382308392</id>
-			<name></name>
-			<type>30</type>
-			<matcher>
-				<id>org.eclipse.core.resources.regexFilterMatcher</id>
-				<arguments>node_modules|\.git|__CREATED_BY_JAVA_LANGUAGE_SERVER__</arguments>
-			</matcher>
-		</filter>
-	</filteredResources>
 </projectDescription>

--- a/tests/org.eclipse.jface.tests.databinding/.project
+++ b/tests/org.eclipse.jface.tests.databinding/.project
@@ -31,15 +31,4 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
-	<filteredResources>
-		<filter>
-			<id>1676382308390</id>
-			<name></name>
-			<type>30</type>
-			<matcher>
-				<id>org.eclipse.core.resources.regexFilterMatcher</id>
-				<arguments>node_modules|\.git|__CREATED_BY_JAVA_LANGUAGE_SERVER__</arguments>
-			</matcher>
-		</filter>
-	</filteredResources>
 </projectDescription>

--- a/tests/org.eclipse.jface.tests.notifications/.project
+++ b/tests/org.eclipse.jface.tests.notifications/.project
@@ -31,15 +31,4 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
-	<filteredResources>
-		<filter>
-			<id>1676382308394</id>
-			<name></name>
-			<type>30</type>
-			<matcher>
-				<id>org.eclipse.core.resources.regexFilterMatcher</id>
-				<arguments>node_modules|\.git|__CREATED_BY_JAVA_LANGUAGE_SERVER__</arguments>
-			</matcher>
-		</filter>
-	</filteredResources>
 </projectDescription>

--- a/tests/org.eclipse.jface.tests/.project
+++ b/tests/org.eclipse.jface.tests/.project
@@ -31,15 +31,4 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
-	<filteredResources>
-		<filter>
-			<id>1676382308388</id>
-			<name></name>
-			<type>30</type>
-			<matcher>
-				<id>org.eclipse.core.resources.regexFilterMatcher</id>
-				<arguments>node_modules|\.git|__CREATED_BY_JAVA_LANGUAGE_SERVER__</arguments>
-			</matcher>
-		</filter>
-	</filteredResources>
 </projectDescription>

--- a/tests/org.eclipse.tests.urischeme/.project
+++ b/tests/org.eclipse.tests.urischeme/.project
@@ -31,15 +31,4 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
-	<filteredResources>
-		<filter>
-			<id>1676382308396</id>
-			<name></name>
-			<type>30</type>
-			<matcher>
-				<id>org.eclipse.core.resources.regexFilterMatcher</id>
-				<arguments>node_modules|\.git|__CREATED_BY_JAVA_LANGUAGE_SERVER__</arguments>
-			</matcher>
-		</filter>
-	</filteredResources>
 </projectDescription>

--- a/tests/org.eclipse.ui.ide.application.tests/.project
+++ b/tests/org.eclipse.ui.ide.application.tests/.project
@@ -31,15 +31,4 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
-	<filteredResources>
-		<filter>
-			<id>1676382308446</id>
-			<name></name>
-			<type>30</type>
-			<matcher>
-				<id>org.eclipse.core.resources.regexFilterMatcher</id>
-				<arguments>node_modules|\.git|__CREATED_BY_JAVA_LANGUAGE_SERVER__</arguments>
-			</matcher>
-		</filter>
-	</filteredResources>
 </projectDescription>

--- a/tests/org.eclipse.ui.monitoring.tests/.project
+++ b/tests/org.eclipse.ui.monitoring.tests/.project
@@ -31,15 +31,4 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
-	<filteredResources>
-		<filter>
-			<id>1676382308450</id>
-			<name></name>
-			<type>30</type>
-			<matcher>
-				<id>org.eclipse.core.resources.regexFilterMatcher</id>
-				<arguments>node_modules|\.git|__CREATED_BY_JAVA_LANGUAGE_SERVER__</arguments>
-			</matcher>
-		</filter>
-	</filteredResources>
 </projectDescription>

--- a/tests/org.eclipse.ui.tests.browser/.project
+++ b/tests/org.eclipse.ui.tests.browser/.project
@@ -31,15 +31,4 @@
 		<nature>org.eclipse.jdt.core.javanature</nature>
 		<nature>org.eclipse.pde.PluginNature</nature>
 	</natures>
-	<filteredResources>
-		<filter>
-			<id>1676382308460</id>
-			<name></name>
-			<type>30</type>
-			<matcher>
-				<id>org.eclipse.core.resources.regexFilterMatcher</id>
-				<arguments>node_modules|\.git|__CREATED_BY_JAVA_LANGUAGE_SERVER__</arguments>
-			</matcher>
-		</filter>
-	</filteredResources>
 </projectDescription>

--- a/tests/org.eclipse.ui.tests.forms/.project
+++ b/tests/org.eclipse.ui.tests.forms/.project
@@ -31,15 +31,4 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
-	<filteredResources>
-		<filter>
-			<id>1676382308467</id>
-			<name></name>
-			<type>30</type>
-			<matcher>
-				<id>org.eclipse.core.resources.regexFilterMatcher</id>
-				<arguments>node_modules|\.git|__CREATED_BY_JAVA_LANGUAGE_SERVER__</arguments>
-			</matcher>
-		</filter>
-	</filteredResources>
 </projectDescription>

--- a/tests/org.eclipse.ui.tests.harness/.project
+++ b/tests/org.eclipse.ui.tests.harness/.project
@@ -31,15 +31,4 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
-	<filteredResources>
-		<filter>
-			<id>1676382308469</id>
-			<name></name>
-			<type>30</type>
-			<matcher>
-				<id>org.eclipse.core.resources.regexFilterMatcher</id>
-				<arguments>node_modules|\.git|__CREATED_BY_JAVA_LANGUAGE_SERVER__</arguments>
-			</matcher>
-		</filter>
-	</filteredResources>
 </projectDescription>

--- a/tests/org.eclipse.ui.tests.navigator/.project
+++ b/tests/org.eclipse.ui.tests.navigator/.project
@@ -31,15 +31,4 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
-	<filteredResources>
-		<filter>
-			<id>1676382308472</id>
-			<name></name>
-			<type>30</type>
-			<matcher>
-				<id>org.eclipse.core.resources.regexFilterMatcher</id>
-				<arguments>node_modules|\.git|__CREATED_BY_JAVA_LANGUAGE_SERVER__</arguments>
-			</matcher>
-		</filter>
-	</filteredResources>
 </projectDescription>

--- a/tests/org.eclipse.ui.tests.performance/.project
+++ b/tests/org.eclipse.ui.tests.performance/.project
@@ -31,15 +31,4 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
-	<filteredResources>
-		<filter>
-			<id>1676382308474</id>
-			<name></name>
-			<type>30</type>
-			<matcher>
-				<id>org.eclipse.core.resources.regexFilterMatcher</id>
-				<arguments>node_modules|\.git|__CREATED_BY_JAVA_LANGUAGE_SERVER__</arguments>
-			</matcher>
-		</filter>
-	</filteredResources>
 </projectDescription>

--- a/tests/org.eclipse.ui.tests.pluginchecks/.project
+++ b/tests/org.eclipse.ui.tests.pluginchecks/.project
@@ -31,15 +31,4 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
-	<filteredResources>
-		<filter>
-			<id>1676382308476</id>
-			<name></name>
-			<type>30</type>
-			<matcher>
-				<id>org.eclipse.core.resources.regexFilterMatcher</id>
-				<arguments>node_modules|\.git|__CREATED_BY_JAVA_LANGUAGE_SERVER__</arguments>
-			</matcher>
-		</filter>
-	</filteredResources>
 </projectDescription>

--- a/tests/org.eclipse.ui.tests.rcp/.project
+++ b/tests/org.eclipse.ui.tests.rcp/.project
@@ -34,15 +34,4 @@
 		<nature>org.eclipse.jdt.core.javanature</nature>
 		<nature>org.eclipse.pde.PluginNature</nature>
 	</natures>
-	<filteredResources>
-		<filter>
-			<id>1676382308478</id>
-			<name></name>
-			<type>30</type>
-			<matcher>
-				<id>org.eclipse.core.resources.regexFilterMatcher</id>
-				<arguments>node_modules|\.git|__CREATED_BY_JAVA_LANGUAGE_SERVER__</arguments>
-			</matcher>
-		</filter>
-	</filteredResources>
 </projectDescription>

--- a/tests/org.eclipse.ui.tests.views.properties.tabbed/.project
+++ b/tests/org.eclipse.ui.tests.views.properties.tabbed/.project
@@ -31,15 +31,4 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
-	<filteredResources>
-		<filter>
-			<id>1676382308480</id>
-			<name></name>
-			<type>30</type>
-			<matcher>
-				<id>org.eclipse.core.resources.regexFilterMatcher</id>
-				<arguments>node_modules|\.git|__CREATED_BY_JAVA_LANGUAGE_SERVER__</arguments>
-			</matcher>
-		</filter>
-	</filteredResources>
 </projectDescription>

--- a/tests/org.eclipse.ui.tests/.project
+++ b/tests/org.eclipse.ui.tests/.project
@@ -31,15 +31,4 @@
 		<nature>org.eclipse.jdt.core.javanature</nature>
 		<nature>org.eclipse.pde.PluginNature</nature>
 	</natures>
-	<filteredResources>
-		<filter>
-			<id>1676382308456</id>
-			<name></name>
-			<type>30</type>
-			<matcher>
-				<id>org.eclipse.core.resources.regexFilterMatcher</id>
-				<arguments>node_modules|\.git|__CREATED_BY_JAVA_LANGUAGE_SERVER__</arguments>
-			</matcher>
-		</filter>
-	</filteredResources>
 </projectDescription>


### PR DESCRIPTION
83 .project files carry the same generated resource filter excluding node_modules, .git and the __CREATED_BY_JAVA_LANGUAGE_SERVER__ sentinel. That filter is written by the JDT Language Server behind the VS Code Java extension into every project it imports, and it reached master accidentally in 2023 with 6af77694a28. Nobody asked for it and it does not describe anything about these projects.

It is also the worst shape a filter can have: inheritable, anchored at the project root, excluding both files and folders, so the workspace runs the regex matcher against every child of every directory it refreshes, in every one of those 83 projects, for no benefit. Removing it makes resource refresh cheaper and stops the files from drifting whenever someone opens the repo in another editor.

The hand-authored filter in org.eclipse.text.quicksearch, which excludes target, is deliberate and stays. Only XML metadata is removed, no code or build input is touched, and all 83 files still parse.