### PR TITLE
Simplify FontRegistry's font lookup to direct fallbacks

### DIFF
--- a/bundles/org.eclipse.jface/src/org/eclipse/jface/resource/FontRegistry.java
+++ b/bundles/org.eclipse.jface/src/org/eclipse/jface/resource/FontRegistry.java
@@ -856,25 +856,27 @@ public class FontRegistry extends ResourceRegistry {
 			return existingRecord.get(style);
 		}
 
-		FontData[] existingFontData = stringToFontData.get(symbolicName);
-
-		FontRecord fontRecord;
-
-		if (existingFontData == null) {
-			fontRecord = defaultFontRecord(style);
-		} else {
-			fontRecord = createFont(symbolicName, existingFontData);
+		FontData[] registeredFontData = stringToFontData.get(symbolicName);
+		if (registeredFontData == null) {
+			return defaultFont(style);
 		}
 
-		if (fontRecord == null) {
-			fontRecord = defaultFontRecord(style);
-			if (Display.getCurrent() == null) { // log error but don't throw an exception to preserve existing functionality
-				String msg = "Unable to create font \"" + symbolicName + "\" in a non-UI thread. Using default font instead."; //$NON-NLS-1$ //$NON-NLS-2$
-				Policy.logException(new SWTException(msg));
-			}
+		FontRecord createdRecord = createFont(symbolicName, registeredFontData);
+		if (createdRecord != null) {
+			return createdRecord.get(style);
 		}
 
-		return fontRecord.get(style);
+		// If the name is registered, but no font could be realized for it (e.g. there
+		// is no current Display to create it on, or the registered FontData is
+		// empty/invalid), the default font is used as fallback. Resolve the fallback
+		// before logging, so the message is only emitted once a default font is
+		// actually available to return, and not on a path that ends up failing anyway.
+		Font fallbackFont = defaultFont(style);
+		if (Display.getCurrent() == null) { // log error but don't throw an exception to preserve existing functionality
+			String msg = "Unable to create font \"" + symbolicName + "\" in a non-UI thread. Using default font instead."; //$NON-NLS-1$ //$NON-NLS-2$
+			Policy.logException(new SWTException(msg));
+		}
+		return fallbackFont;
 	}
 
 	@Override


### PR DESCRIPTION
Looking up a font for a symbolic name assembled its result in a mutable record variable across a chain of null checks, which conflated the two distinct reasons for ending up with the default font: no font data being registered for the name at all, and no font being creatable from the data that is registered. Only the latter is an error worth logging, which the chained conditions made hard to see.

Each case now returns its font directly, and both fallbacks go through the accessor for the default font in a given style rather than resolving a record and applying the style afterwards.

The fallback for the error case is still resolved before the error is logged, but now includes realizing the requested style rather than only looking up the record providing it. As a result, the message announcing that the default font is used instead can no longer be logged on a path that fails to provide any font at all and thus ends in an exception.