### PR TITLE
Find/Replace overlay: color it independently of its surroundings

### DIFF
--- a/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/overlay/FindReplaceOverlay.java
+++ b/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/overlay/FindReplaceOverlay.java
@@ -39,6 +39,7 @@ import org.eclipse.swt.widgets.ScrollBar;
 import org.eclipse.swt.widgets.Scrollable;
 import org.eclipse.swt.widgets.Shell;
 import org.eclipse.swt.widgets.Text;
+import org.eclipse.swt.widgets.ToolBar;
 import org.eclipse.swt.widgets.ToolItem;
 import org.eclipse.swt.widgets.Widget;
 
@@ -74,6 +75,8 @@ import org.eclipse.ui.texteditor.StatusTextEditor;
 public class FindReplaceOverlay {
 
 	public static final String ID_DATA_KEY = "org.eclipse.ui.internal.findreplace.overlay.FindReplaceOverlay.id"; //$NON-NLS-1$
+
+	private static final String DISABLE_CSS = "org.eclipse.e4.ui.css.disabled"; //$NON-NLS-1$
 
 	private static final String REPLACE_BAR_OPEN_DIALOG_SETTING = "replaceBarOpen"; //$NON-NLS-1$
 	private static final double WORST_CASE_RATIO_EDITOR_TO_OVERLAY = 0.95;
@@ -355,7 +358,39 @@ public class FindReplaceOverlay {
 		}
 		retrieveColors();
 		createMainContainer(parent);
+		disableCssStyling(containerControl);
 		containerControl.layout();
+	}
+
+	/**
+	 * Excludes the overlay from the styling performed by the Eclipse UI CSS engine.
+	 * <p>
+	 * The overlay derives its colors from the part it is placed on, so that it
+	 * blends into that part rather than into the surrounding workbench. The CSS
+	 * engine, however, styles widgets according to the kind of part they are
+	 * contained in: rules like {@code .View ToolBar} apply to everything inside a
+	 * view but to nothing inside an editor. Leaving the overlay to the CSS engine
+	 * would thus give it a different look depending on where it is opened, and would
+	 * overwrite the colors derived here.
+	 * <p>
+	 * The exclusion has to be marked on every single widget, because the engine
+	 * styles each newly created widget individually in reaction to its
+	 * {@link SWT#Skin} event, rather than only traversing the widget tree top-down.
+	 * It therefore only covers the widgets that exist by the time it is called, so
+	 * it has to be called once the overlay is fully built, and any widget added to
+	 * it afterwards has to be excluded as well.
+	 */
+	private static void disableCssStyling(Control control) {
+		control.setData(DISABLE_CSS, Boolean.TRUE);
+		if (control instanceof ToolBar toolBar) {
+			for (ToolItem toolItem : toolBar.getItems()) {
+				toolItem.setData(DISABLE_CSS, Boolean.TRUE);
+			}
+		} else if (control instanceof Composite composite) {
+			for (Control child : composite.getChildren()) {
+				disableCssStyling(child);
+			}
+		}
 	}
 
 	/**
@@ -395,26 +430,20 @@ public class FindReplaceOverlay {
 		return colorReference.get();
 	}
 
-	/**
-	 * A composite with a fixed background color, not adapting to theming.
-	 */
-	private class FixedColorComposite extends Composite {
-		private final Color fixColor;
-
-		public FixedColorComposite(Composite parent, int style, Color backgroundColor) {
-			super(parent, style);
-			this.fixColor = backgroundColor;
-			setBackground(backgroundColor);
-		}
-
-		@Override
-		public void setBackground(Color unusedColor) {
-			super.setBackground(fixColor);
-		}
+	private static Composite createColoredComposite(Composite parent, Color backgroundColor) {
+		Composite composite = new Composite(parent, SWT.NONE);
+		composite.setBackground(backgroundColor);
+		return composite;
 	}
 
 	private void createMainContainer(final Composite parent) {
-		containerControl = new FixedColorComposite(parent, SWT.NONE, overlayBackgroundColor);
+		containerControl = createColoredComposite(parent, overlayBackgroundColor);
+		// Every widget of the overlay takes the background of the container it sits in,
+		// rather than whatever SWT would fall back to for a widget without one. That
+		// fallback is decided by the widget hierarchy the overlay is placed in, so
+		// without this the tool bars and input fields look different depending on the
+		// kind of editor or view the overlay was opened on.
+		containerControl.setBackgroundMode(SWT.INHERIT_FORCE);
 		GridDataFactory.fillDefaults().grab(true, true).align(GridData.FILL, GridData.FILL).applyTo(containerControl);
 		GridLayoutFactory.fillDefaults().numColumns(2).equalWidth(false).margins(2, 2).spacing(2, 0)
 				.applyTo(containerControl);
@@ -441,7 +470,7 @@ public class FindReplaceOverlay {
 	}
 
 	private void createContentsContainer() {
-		contentGroup = new FixedColorComposite(containerControl, SWT.NONE, overlayBackgroundColor);
+		contentGroup = createColoredComposite(containerControl, overlayBackgroundColor);
 		GridLayoutFactory.fillDefaults().numColumns(1).equalWidth(false).spacing(0, 2).applyTo(contentGroup);
 		GridDataFactory.fillDefaults().grab(true, true).align(GridData.FILL, GridData.FILL).applyTo(contentGroup);
 
@@ -666,7 +695,7 @@ public class FindReplaceOverlay {
 	}
 
 	private void createSearchContainer() {
-		searchContainer = new FixedColorComposite(contentGroup, SWT.NONE, widgetBackgroundColor);
+		searchContainer = createColoredComposite(contentGroup, widgetBackgroundColor);
 		GridDataFactory.fillDefaults().grab(true, true).align(GridData.FILL, GridData.FILL).applyTo(searchContainer);
 		GridLayoutFactory.fillDefaults().numColumns(3).extendedMargins(7, 4, 3, 5).equalWidth(false)
 				.applyTo(searchContainer);
@@ -677,7 +706,7 @@ public class FindReplaceOverlay {
 	}
 
 	private void createReplaceContainer() {
-		replaceContainer = new FixedColorComposite(contentGroup, SWT.NONE, widgetBackgroundColor);
+		replaceContainer = createColoredComposite(contentGroup, widgetBackgroundColor);
 		GridDataFactory.fillDefaults().grab(true, true).align(GridData.FILL, GridData.FILL).applyTo(replaceContainer);
 		GridLayoutFactory.fillDefaults().margins(0, 0).numColumns(2).extendedMargins(7, 4, 3, 5).equalWidth(false)
 				.applyTo(replaceContainer);


### PR DESCRIPTION
Fixes https://github.com/eclipse-platform/eclipse.platform.ui/issues/3865

## The problems

The Find/Replace overlay floats over the text of the part it is opened on and takes the colors of that part, so that it blends into the text rather than into the surrounding workbench. Several of its widgets never got a color that way, and what they ended up with depended on where the overlay was opened. That shows up as two symptoms, which turn out to have a common root.

**Tool bars and the area around the input fields turn grey in form-based editors**, such as EGit's commit viewer, while the same overlay in a plain text editor looks as intended.

**The input fields do not match the overlay in the dark theme.** They are drawn in a noticeably lighter shade than everything around them. In the light theme this goes unnoticed, because there the two colors involved both happen to be white.

## What causes them

The overlay wants the colors of the current theme, and the CSS engine is how the theme applies colors. The overlay therefore reads them off widgets the engine has styled and colors itself with them. What it must avoid is being styled by the engine itself, because the engine's rules key on the kind of part a widget is contained in, as in `.View ToolBar`, which reaches everything inside a view and nothing inside an editor. Being styled makes the overlay look like the surroundings it is supposed to float over, and differ depending on where it was opened. Guarding individual composites against being recolored, which is what the overlay did so far, cannot achieve that, because the engine styles every widget individually rather than only traversing the widget tree from the top. It is also the only thing that ever colored the input fields, which is why they carry the theme's generic widget background instead of the part background the overlay uses around them.

The widgets the engine does not reach have no background of their own at all, so SWT resolves one from the widget hierarchy above the overlay, and that hierarchy differs per part. Tool bars are hit hardest, since unlike composites they have no themed background to fall back to and end up in the platform's default grey, unless some ancestor happens to establish an inherited background. That is precisely what differs between a plain text editor and a form-based one.

## The fix

The overlay defines its own colors, so it has to be the one that applies them. Two halves, which are only effective together:

* **The overlay is excluded from CSS styling**, by marking every widget in it with the `org.eclipse.e4.ui.css.disabled` data flag, the mechanism `AbstractTextEditor` and `StickyScrollingControl` already use. The flag has to be set per widget rather than only on the container, for the reason given above. With the engine out, the composites no longer need to defend their color against being overwritten, so the `FixedColorComposite` guard disappears and they become plain composites again.
* **The overlay's container passes its background down** to everything inside it, via `setBackgroundMode(SWT.INHERIT_FORCE)`. This replaces SWT's hierarchy-dependent fallback with the colors the overlay derived for itself, so no widget in the overlay depends on what the overlay was placed in any more.

The second half is what fixes the input fields, and it is why the two cannot be split: excluding the overlay from CSS on its own would take away the only color the fields ever had and leave them at the platform default, which is white even in the dark theme.

The tool bars deliberately keep no background of their own even now. Setting one would make SWT draw their items with colors derived from it instead of letting the platform theme render them.

## Screenshots

### Form-based editor (EGit commit viewer)

Before:
<img width="1070" height="150" alt="image" src="https://github.com/user-attachments/assets/34fa5002-a6bb-4576-adb1-8ced9dc2c2cd" />

After:
<img width="1072" height="140" alt="image" src="https://github.com/user-attachments/assets/a3554b61-cc65-4b4b-9ab7-8e17c36d41cf" />

### Dark theme

Before:
<img width="552" height="89" alt="image" src="https://github.com/user-attachments/assets/27e69d06-b27e-478b-a004-ab21f7d0505f" />

After:
<img width="561" height="94" alt="image" src="https://github.com/user-attachments/assets/bd30d793-6470-4d28-becb-f3e8ccc6f20b" />

## Testing

Verified manually in a Java editor and in EGit's commit viewer, in both the light and the dark theme, on Windows. Also tested this on macOS and Linux (WSL).

There is no automated test. Reproducing the defect requires an active CSS theme, and the test runtime of `org.eclipse.ui.workbench.texteditor.tests` has no theme registered at all, so an assertion on the resolved widget colors passes there with and without the fix. Making it fail would mean shipping a stylesheet, a dependency on `org.eclipse.e4.ui.css.swt.theme` and theme switching in the test bundle, which seems disproportionate for the guarantee gained.
