### PR TITLE
Find/Replace overlay: read the theme colors from a shell of its own

### DIFF
--- a/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/overlay/FindReplaceOverlay.java
+++ b/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/overlay/FindReplaceOverlay.java
@@ -13,8 +13,6 @@
  *******************************************************************************/
 package org.eclipse.ui.internal.findandreplace.overlay;
 
-import java.util.concurrent.atomic.AtomicReference;
-
 import org.osgi.framework.FrameworkUtil;
 
 import org.eclipse.swt.SWT;
@@ -43,7 +41,6 @@ import org.eclipse.swt.widgets.ToolBar;
 import org.eclipse.swt.widgets.ToolItem;
 import org.eclipse.swt.widgets.Widget;
 
-import org.eclipse.jface.dialogs.Dialog;
 import org.eclipse.jface.dialogs.IDialogSettings;
 import org.eclipse.jface.fieldassist.ControlDecoration;
 import org.eclipse.jface.fieldassist.TextContentAdapter;
@@ -394,40 +391,47 @@ public class FindReplaceOverlay {
 	}
 
 	/**
-	 * HACK: In order to not introduce a hard-coded color, we need to retrieve the
-	 * background color of text widgets and composite to color those widgets that
-	 * would otherwise inherit non-fitting custom colors from the containing
-	 * StyledText.
+	 * The overlay hard-codes no colors: its text fields blend into the part it is
+	 * placed on, and everything around them takes the color the theme gives to
+	 * widgets of the respective kind.
+	 * <p>
+	 * The theme applies its colors through the CSS engine, which offers nothing to
+	 * ask for the color a widget would be given, so they are read off throwaway
+	 * widgets created for that purpose. Those are put into a shell of their own,
+	 * which is never opened: it keeps them out of the shell the user is looking at,
+	 * and it keeps the colors independent of the kind of part the overlay is opened
+	 * in, which is what the CSS rules of the shipped themes key on.
 	 */
 	private void retrieveColors() {
-		if (targetPart instanceof StatusTextEditor textEditor) {
-			Control targetWidget = textEditor.getAdapter(ITextViewer.class).getTextWidget();
-			widgetBackgroundColor = targetWidget.getBackground();
-			normalTextForegroundColor = targetWidget.getForeground();
-		} else {
-			Text textBarForRetrievingTheRightColor = new Text(targetControl.getShell(), SWT.SINGLE | SWT.SEARCH);
-			targetControl.getShell().layout();
-			widgetBackgroundColor = textBarForRetrievingTheRightColor.getBackground();
-			normalTextForegroundColor = textBarForRetrievingTheRightColor.getForeground();
-			textBarForRetrievingTheRightColor.dispose();
+		Shell colorProbeShell = new Shell(targetControl.getShell(), SWT.NONE);
+		try {
+			Composite compositeColorProbe = new Composite(colorProbeShell, SWT.NONE);
+			Text textColorProbe = new Text(colorProbeShell, SWT.SINGLE | SWT.SEARCH);
+			applyPendingStyling(colorProbeShell);
+
+			overlayBackgroundColor = compositeColorProbe.getBackground();
+			Control textColorSource = targetPart instanceof StatusTextEditor textEditor
+					? textEditor.getAdapter(ITextViewer.class).getTextWidget()
+					: textColorProbe;
+			widgetBackgroundColor = textColorSource.getBackground();
+			normalTextForegroundColor = textColorSource.getForeground();
+		} finally {
+			colorProbeShell.dispose();
 		}
-		overlayBackgroundColor = retrieveDefaultCompositeBackground();
 		errorTextForegroundColor = JFaceColors.getErrorText(targetControl.getShell().getDisplay());
 	}
 
-	private Color retrieveDefaultCompositeBackground() {
-		AtomicReference<Color> colorReference = new AtomicReference<>();
-		Dialog dummyDialogForColorRetrieval = new Dialog(targetControl.getShell()) {
-			@Override
-			public void create() {
-				super.create();
-				colorReference.set(getContents().getBackground());
-			}
-
-		};
-		dummyDialogForColorRetrieval.create();
-		dummyDialogForColorRetrieval.close();
-		return colorReference.get();
+	/**
+	 * Has the CSS engine style the widgets created so far, so that their colors can
+	 * be read without returning to the event loop first.
+	 * <p>
+	 * The engine styles a widget in reaction to the {@link SWT#Skin} event SWT
+	 * queues when the widget is created. SWT delivers those events from its event
+	 * loop, but also whenever a composite computes its size, which is why computing
+	 * a size that is not needed for anything is what makes the colors readable here.
+	 */
+	private static void applyPendingStyling(Composite widgets) {
+		widgets.computeSize(SWT.DEFAULT, SWT.DEFAULT, true);
 	}
 
 	private static Composite createColoredComposite(Composite parent, Color backgroundColor) {


### PR DESCRIPTION
## What the overlay does

The Find/Replace overlay hard-codes no colors. Its input fields take the colors of the part it floats over, and everything around them takes the color the current theme gives to widgets of the respective kind. The theme applies its colors through the CSS engine, which offers no way to ask what color a widget would be given, so the overlay reads the colors off throwaway widgets created for that purpose.

## What is wrong with how it does that

The color of the composites is read from a JFace dialog that is created and closed again for no other purpose. Where the part exposes no text widget to take the text colors from, a `Text` is temporarily inserted into the shell the user is looking at, laid out, read and disposed again.

Both probes also rely on a subtlety that nothing in the code mentions. The CSS engine styles a widget in reaction to the `SWT.Skin` event that SWT queues when the widget is created, and SWT delivers those events from its event loop, so a widget read right after creating it still carries the platform default rather than the themed color. What makes the retrieval work regardless is that SWT delivers them whenever a composite computes its size or is laid out: `Window.initializeBounds` computes the dialog's initial size while creating it, and the text probe is followed by a `layout()` call on the shell. Both look like incidental lines that a cleanup would happily remove, and removing them would silently give the overlay platform colors instead of themed ones, which is invisible in the light theme and wrong in the dark one.

## The change

Both probes now live in a single shell of their own that is never opened. That keeps them out of the shell the user is looking at, and it keeps the colors independent of the kind of part the overlay is opened in, which is what the CSS rules of the shipped themes key on.

The step that makes the engine style the probes is taken deliberately and named, with the reason in its javadoc, rather than being a side effect of creating a dialog. It is still a size computation, since that is what SWT offers: `Composite.computeSize` runs `Display.runSkin` in the win32, gtk and cocoa ports alike.

No visible change is intended. The same colors are read, from widgets of the same kinds.

## Testing

The `org.eclipse.ui.workbench.texteditor` test suite passes.

The colors themselves are not covered automatically, for the same reason as in #4339: reproducing anything about them requires an active CSS theme, and the test runtime of `org.eclipse.ui.workbench.texteditor.tests` has no theme registered at all.

Verified that nothing visually changed on Windows, macOS and Linux (WSL).
