### PR TITLE
Find/Replace overlay: remove color plumbing that has become redundant

### DIFF
--- a/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/overlay/AccessibleToolBar.java
+++ b/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/overlay/AccessibleToolBar.java
@@ -13,11 +13,7 @@
  *******************************************************************************/
 package org.eclipse.ui.internal.findandreplace.overlay;
 
-import java.util.ArrayList;
-import java.util.List;
-
 import org.eclipse.swt.SWT;
-import org.eclipse.swt.graphics.Color;
 import org.eclipse.swt.layout.GridLayout;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;
@@ -31,8 +27,6 @@ import org.eclipse.jface.layout.GridLayoutFactory;
  * into a Composite.
  */
 class AccessibleToolBar extends Composite {
-
-	private final List<AccessibleToolItem> accessibleToolItems = new ArrayList<>();
 
 	private final GridLayout layout;
 
@@ -50,21 +44,9 @@ class AccessibleToolBar extends Composite {
 	 */
 	public AccessibleToolItem createToolItem(int styleBits) {
 		AccessibleToolItem toolItem = new AccessibleToolItem(this, styleBits);
-		accessibleToolItems.add(toolItem);
 		layout.numColumns++;
 		return toolItem;
 	}
-
-	@Override
-	public void setBackground(Color color) {
-		super.setBackground(color);
-		// some ToolItems (like SWT.SEPARATOR) don't easily inherit the color from the
-		// parent control
-		for (AccessibleToolItem item : accessibleToolItems) {
-			item.setBackground(color);
-		}
-	}
-
 
 	Control getFirstControl() {
 		Control[] children = getChildren();

--- a/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/overlay/AccessibleToolItem.java
+++ b/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/overlay/AccessibleToolItem.java
@@ -12,7 +12,6 @@ package org.eclipse.ui.internal.findandreplace.overlay;
 
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.events.SelectionListener;
-import org.eclipse.swt.graphics.Color;
 import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.ToolBar;
@@ -36,10 +35,6 @@ class AccessibleToolItem {
 
 	ToolItem getToolItem() {
 		return toolItem;
-	}
-
-	void setBackground(Color color) {
-		toolItem.getParent().setBackground(color);
 	}
 
 	void setImage(Image image) {

--- a/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/overlay/FindReplaceOverlay.java
+++ b/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/overlay/FindReplaceOverlay.java
@@ -434,6 +434,11 @@ public class FindReplaceOverlay {
 		widgets.computeSize(SWT.DEFAULT, SWT.DEFAULT, true);
 	}
 
+	/**
+	 * Creates a composite that introduces a background color. Only the composites
+	 * that start an area of a different color need one, since the overlay's
+	 * container passes its background on to everything inside it.
+	 */
 	private static Composite createColoredComposite(Composite parent, Color backgroundColor) {
 		Composite composite = new Composite(parent, SWT.NONE);
 		composite.setBackground(backgroundColor);
@@ -474,7 +479,7 @@ public class FindReplaceOverlay {
 	}
 
 	private void createContentsContainer() {
-		contentGroup = createColoredComposite(containerControl, overlayBackgroundColor);
+		contentGroup = new Composite(containerControl, SWT.NONE);
 		GridLayoutFactory.fillDefaults().numColumns(1).equalWidth(false).spacing(0, 2).applyTo(contentGroup);
 		GridDataFactory.fillDefaults().grab(true, true).align(GridData.FILL, GridData.FILL).applyTo(contentGroup);
 

--- a/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/overlay/HistoryTextWrapper.java
+++ b/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/overlay/HistoryTextWrapper.java
@@ -175,20 +175,16 @@ public class HistoryTextWrapper extends Composite {
 		textBar.setText(str);
 	}
 
-	@Override
-	public void setBackground(Color color) {
-		super.setBackground(color);
-
-		textBar.setBackground(color);
-		tools.setBackground(color);
-	}
-
+	/**
+	 * Passes the foreground on to the text bar, the only widget in here that shows
+	 * text. There is no counterpart for the background: the container this wrapper
+	 * sits in passes its background on to everything inside it.
+	 */
 	@Override
 	public void setForeground(Color color) {
 		super.setForeground(color);
 
 		textBar.setForeground(color);
-		tools.setForeground(color);
 	}
 
 	@Override


### PR DESCRIPTION
## Why

With the overlay excluded from CSS styling and its container passing its background on to everything inside it (#4339), the ways in which colors used to be pushed through the overlay by hand have lost their purpose. None of this was dead before #4339, which is why it is a separate change rather than part of it.

## What is removed

Code that handed a color from one widget of the overlay to the next, so that widgets which do not inherit a background from their parent, separators in particular, would receive one anyway. Passing the background down from the container covers exactly that, and it does so wherever the color enters the widget tree: a background set on one of the wrappers would now reach the widgets inside it by itself. The forwarding is therefore not merely without a caller since the CSS engine stopped reaching the overlay, it cannot make a difference any more.

Along with it goes a piece of forwarding whose effect was never visible, a foreground handed to tool bars whose items show no text, and a composite that was given the background its container already has. A composite only needs one where it starts an area of a different color, which the code now says: exactly three do.

## Testing

The `org.eclipse.ui.workbench.texteditor` test suite passes. No visible change is intended, and the colors of the overlay are not covered automatically, for the reason given in #4339.
