### PR TITLE
Use workspace root rule when deleting file in ResultUpdaterTest

### DIFF
--- a/tests/org.eclipse.search.tests/src/org/eclipse/search/tests/ResourceHelper.java
+++ b/tests/org.eclipse.search.tests/src/org/eclipse/search/tests/ResourceHelper.java
@@ -29,6 +29,7 @@ import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.core.runtime.Platform;
 import org.eclipse.core.runtime.Plugin;
+import org.eclipse.core.runtime.jobs.ISchedulingRule;
 
 import org.eclipse.core.resources.IContainer;
 import org.eclipse.core.resources.IFile;
@@ -72,6 +73,10 @@ public class ResourceHelper {
 	}
 
 	public static void delete(final IResource resource) throws CoreException {
+		delete(resource, null);
+	}
+
+	public static void delete(final IResource resource, ISchedulingRule rule) throws CoreException {
 		IWorkspaceRunnable runnable= monitor -> {
 			for (int i= 0; i < MAX_RETRY; i++) {
 				try {
@@ -90,7 +95,7 @@ public class ResourceHelper {
 				}
 			}
 		};
-		ResourcesPlugin.getWorkspace().run(runnable, null);
+		ResourcesPlugin.getWorkspace().run(runnable, rule, 0, null);
 
 	}
 

--- a/tests/org.eclipse.search.tests/src/org/eclipse/search/tests/filesearch/ResultUpdaterTest.java
+++ b/tests/org.eclipse.search.tests/src/org/eclipse/search/tests/filesearch/ResultUpdaterTest.java
@@ -23,6 +23,7 @@ import org.junit.jupiter.api.Test;
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IResource;
+import org.eclipse.core.resources.ResourcesPlugin;
 
 import org.eclipse.search.internal.ui.text.FileSearchQuery;
 import org.eclipse.search.tests.ResourceHelper;
@@ -60,7 +61,7 @@ public class ResultUpdaterTest {
 		Object[] elements= result.getElements();
 		int fileCount= result.getMatchCount(elements[0]);
 		int totalCount= result.getMatchCount();
-		ResourceHelper.delete((IFile)elements[0]);
+		ResourceHelper.delete((IFile)elements[0], ResourcesPlugin.getWorkspace().getRoot());
 		assertEquals(totalCount-fileCount, result.getMatchCount());
 		assertEquals(0, result.getMatchCount(elements[0]));
 	}


### PR DESCRIPTION
`ResultUpdaterTest.testRemoveFile()` depends on a delta notification to update search result match count. To avoid potential concurrent jobs propagating this notification, causing the test to check match count too early, this change sets the workspace root as scheduling rule for the delete operation.

Fixes: https://github.com/eclipse-platform/eclipse.platform.ui/issues/4340