### PR TITLE
End a CSS string at an unescaped newline

### DIFF
--- a/bundles/org.eclipse.e4.ui.css.core/src/org/eclipse/e4/ui/css/core/impl/parser/CssTokenizer.java
+++ b/bundles/org.eclipse.e4.ui.css.core/src/org/eclipse/e4/ui/css/core/impl/parser/CssTokenizer.java
@@ -27,7 +27,7 @@ import java.util.List;
 final class CssTokenizer {
 
 	enum Kind {
-		IDENT, FUNCTION, AT_KEYWORD, HASH, STRING, NUMBER, PERCENTAGE, DIMENSION, URI,
+		IDENT, FUNCTION, AT_KEYWORD, HASH, STRING, BAD_STRING, NUMBER, PERCENTAGE, DIMENSION, URI,
 		COLON, SEMICOLON, COMMA, LBRACE, RBRACE, LBRACKET, RBRACKET, RPAREN,
 		DOT, STAR, GT, PLUS, TILDE, BAR, EQUALS, INCLUDE_MATCH, DASH_MATCH, BANG,
 		WS, EOF
@@ -161,6 +161,11 @@ final class CssTokenizer {
 				advance();
 				break;
 			}
+			if (c == '\n' || c == '\r') {
+				// CSS 2.1 section 4.2: an unescaped newline ends the string and drops
+				// its construct. The newline stays so recovery can resync on it.
+				return new Token(Kind.BAD_STRING, sb.toString(), 0, false, null, startLine, startColumn);
+			}
 			if (c == '\\' && pos + 1 < input.length()) {
 				advance();
 				sb.append(input.charAt(pos));
@@ -170,6 +175,7 @@ final class CssTokenizer {
 			sb.append(c);
 			advance();
 		}
+		// A string still open at the end of the sheet is closed, not dropped.
 		return new Token(Kind.STRING, sb.toString(), 0, false, null, startLine, startColumn);
 	}
 

--- a/tests/org.eclipse.e4.ui.tests.css.core/src/org/eclipse/e4/ui/tests/css/core/parser/StyleSheetStructureTest.java
+++ b/tests/org.eclipse.e4.ui.tests.css.core/src/org/eclipse/e4/ui/tests/css/core/parser/StyleSheetStructureTest.java
@@ -17,6 +17,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
@@ -249,6 +250,25 @@ public class StyleSheetStructureTest {
 		assertEquals("red", style.getPropertyCSSValue("color").getCssText());
 		assertEquals("blue", style.getPropertyCSSValue("background-color").getCssText());
 		assertEquals(1, sheet.getProblems().size());
+	}
+
+	@Test
+	void testUnterminatedStringDropsOnlyItsDeclaration() throws Exception {
+		CSSStyleSheetImpl sheet = ParserTestUtil.parseCssWithoutImports("""
+				Button { color: red; content: "abc
+				background-color: blue; }
+				Text { color: green; }
+				""");
+
+		// The string ends at the newline and takes its declaration with it,
+		// up to the next semicolon. The following rule still applies.
+		assertEquals(2, sheet.getRules().size());
+		CSSStyleDeclaration button = ((CSSStyleRuleImpl) sheet.getRules().get(0)).getStyle();
+		assertEquals("red", button.getPropertyCSSValue("color").getCssText());
+		assertNull(button.getPropertyCSSValue("background-color"));
+		assertEquals("green",
+				((CSSStyleRuleImpl) sheet.getRules().get(1)).getStyle().getPropertyCSSValue("color").getCssText());
+		assertFalse(sheet.getProblems().isEmpty());
 	}
 
 	@Test


### PR DESCRIPTION
An unterminated string in a theme file ran to the next quote or to the end of the sheet, so one missing quote silently swallowed every rule after it. CSS 2.1 section 4.2 ends a string at an unescaped newline and drops the construct containing it.

The tokenizer now emits a BAD_STRING token at the newline. The parser rejects it and the rule recovery from #4321 drops just that declaration, so the rest of the rule and the following rules still apply. A string still open at the end of the sheet is closed instead of dropped, as the spec asks.

Verified locally with StyleSheetStructureTest, which gains a case for the unterminated string.