### PR TITLE
Close Find/Replace test's Welcome page without leaving it maximized

### DIFF
--- a/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/internal/findandreplace/FindReplaceTestUtil.java
+++ b/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/internal/findandreplace/FindReplaceTestUtil.java
@@ -113,7 +113,13 @@ public final class FindReplaceTestUtil {
 		}
 		if (!hasFocusValidator.get()) {
 			String screenshotPath= ScreenshotTest.takeScreenshot(FindReplaceUITest.class, testName, System.out);
-			fail("The find/replace UI did not receive focus. Screenshot: " + screenshotPath);
+			Display display= PlatformUI.getWorkbench().getDisplay();
+			// Where the focus ended up instead tells apart the usual causes: no focus
+			// control at all means the window is not active, a control of the workbench
+			// means something took the focus away, and an invisible widget tree means the
+			// focus was never given away in the first place.
+			fail("The find/replace UI did not receive focus. Focused control: " + display.getFocusControl()
+					+ ", active shell: " + display.getActiveShell() + ". Screenshot: " + screenshotPath);
 		}
 	}
 

--- a/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/internal/findandreplace/overlay/FindReplaceOverlayInEditorTest.java
+++ b/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/internal/findandreplace/overlay/FindReplaceOverlayInEditorTest.java
@@ -23,6 +23,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.util.ResourceBundle;
 
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
@@ -84,7 +85,6 @@ public class FindReplaceOverlayInEditorTest {
 	void openEditorWithOverlay(TestInfo testInfo) throws PartInitException {
 		testName = testInfo.getTestMethod().get().getName();
 		PlatformUI.getWorkbench().getWorkbenchWindows()[0].getShell().forceActive();
-		closeWelcomePage();
 		IWorkbenchPage page = PlatformUI.getWorkbench().getActiveWorkbenchWindow().getActivePage();
 		editor = (StatusTextEditor) page.openEditor(new TestTextEditorInput(CONTENT), TestTextEditor.ID);
 		runEventQueue();
@@ -103,11 +103,23 @@ public class FindReplaceOverlayInEditorTest {
 	 * bundle's own dependencies, the workbench opens its Welcome page over the whole
 	 * window on a fresh workspace. It would cover the editor and keep the focus, so
 	 * that the overlay never receives it. Nothing to close where no such page exists.
+	 * <p>
+	 * The page is put into standby before it is closed, because it is shown
+	 * maximized: closing it right away leaves the window maximized on a part that is
+	 * gone, and an editor opened afterwards is then never rendered into the window.
+	 * It remains in the rendering engine's limbo instead, where it is invisible, and
+	 * nothing inside an invisible widget tree can take the focus, so the overlay
+	 * would never receive it. Standby restores the window's regular layout.
+	 * <p>
+	 * Closing once for the whole class is enough, since the page does not come back.
 	 */
-	private static void closeWelcomePage() {
+	@BeforeAll
+	static void closeWelcomePage() {
 		IIntroManager introManager = PlatformUI.getWorkbench().getIntroManager();
 		IIntroPart welcomePage = introManager.getIntro();
 		if (welcomePage != null) {
+			introManager.setIntroStandby(welcomePage, true);
+			runEventQueue();
 			introManager.closeIntro(welcomePage);
 			runEventQueue();
 		}


### PR DESCRIPTION
`FindReplaceOverlayInEditorTest` opens an editor and expects the Find/Replace overlay placed on it to take the focus. In a full product on a fresh workspace, the workbench shows its Welcome page first, which the test closes beforehand. That page is shown maximized, so closing it leaves the window maximized on a part that is gone. An editor opened afterwards is never rendered into the window but remains in the rendering engine's limbo, where it is invisible, and nothing inside an invisible widget tree can take the focus. The overlay therefore never received it, and the first test of the class failed.

This only happens where a Welcome page exists at all, which is the Ant-based test execution in the full SDK, and neither in the IDE nor via Maven Tycho. Putting the page into standby restores the window's regular layout before the page is closed, which makes the editor render as expected. Since the page does not come back afterwards, closing it once per class instead of before every test is sufficient.

The message reported when the focus is missed now also names the control holding it instead, so that a comparable failure can be told apart from an inactive window or a competing focus request without having to reproduce it first.

To find this, the Jenkins setup was rebuilt locally: the SDK and the automated tests of the failing I-build were installed the way the Ant harness does, and the suite was run through `org.eclipse.test.uitestapplication` with a fresh workspace, so that the Welcome page is present. The failure reproduced in all 9 runs of the unchanged build and disappeared in all runs with this change.

Fixes https://github.com/eclipse-platform/eclipse.platform.ui/issues/4349
