### PR TITLE
Skip javadoc generation for test bundles

### DIFF
--- a/tests/org.eclipse.core.filebuffers.tests/build.properties
+++ b/tests/org.eclipse.core.filebuffers.tests/build.properties
@@ -28,3 +28,4 @@ output.. = bin/
 
 # Maven/Tycho pom model adjustments
 pom.model.property.testClass = org.eclipse.core.filebuffers.tests.FileBuffersTestSuite
+pom.model.property.maven.javadoc.skip = true

--- a/tests/org.eclipse.e4.core.commands.tests/build.properties
+++ b/tests/org.eclipse.e4.core.commands.tests/build.properties
@@ -20,3 +20,4 @@ bin.includes = META-INF/,\
                about.html,\
                plugin.properties
 src.includes = about.html
+pom.model.property.maven.javadoc.skip = true

--- a/tests/org.eclipse.e4.emf.xpath.test/build.properties
+++ b/tests/org.eclipse.e4.emf.xpath.test/build.properties
@@ -25,3 +25,4 @@ bin.includes = .,\
 jars.compile.order = .
 source.. = src/
 output.. = bin/
+pom.model.property.maven.javadoc.skip = true

--- a/tests/org.eclipse.e4.ui.bindings.tests/build.properties
+++ b/tests/org.eclipse.e4.ui.bindings.tests/build.properties
@@ -20,3 +20,4 @@ bin.includes = META-INF/,\
                about.html,\
                OSGI-INF/
 src.includes = about.html
+pom.model.property.maven.javadoc.skip = true

--- a/tests/org.eclipse.e4.ui.tests.css.core/build.properties
+++ b/tests/org.eclipse.e4.ui.tests.css.core/build.properties
@@ -24,3 +24,4 @@ src.includes = about.html
 # Maven properties, see https://github.com/eclipse/tycho/wiki/Tycho-Pomless
 # This plug-in's name does not comply with Tycho's naming convention for test-plugins -> packaging type has to be specified explicitly
 pom.model.packaging = eclipse-test-plugin
+pom.model.property.maven.javadoc.skip = true

--- a/tests/org.eclipse.e4.ui.tests.css.swt/build.properties
+++ b/tests/org.eclipse.e4.ui.tests.css.swt/build.properties
@@ -24,3 +24,4 @@ src.includes = about.html
 # Maven properties, see https://github.com/eclipse/tycho/wiki/Tycho-Pomless
 # This plug-in's name does not comply with Tycho's naming convention for test-plugins -> packaging type has to be specified explicitly
 pom.model.packaging = eclipse-test-plugin
+pom.model.property.maven.javadoc.skip = true

--- a/tests/org.eclipse.e4.ui.tests/build.properties
+++ b/tests/org.eclipse.e4.ui.tests/build.properties
@@ -37,3 +37,4 @@ src.includes = about.html
 pom.model.property.testClass = org.eclipse.e4.ui.tests.UIAllTests
 pom.model.property.tycho.surefire.useUIHarness = false
 pom.model.property.tycho.surefire.useUIThread = false
+pom.model.property.maven.javadoc.skip = true

--- a/tests/org.eclipse.e4.ui.workbench.addons.swt.test/build.properties
+++ b/tests/org.eclipse.e4.ui.workbench.addons.swt.test/build.properties
@@ -5,3 +5,4 @@ bin.includes = META-INF/,\
 
 # Maven properties, see https://github.com/eclipse/tycho/wiki/Tycho-Pomless
 pom.model.property.testClass = org.eclipse.e4.ui.workbench.addons.AllTests
+pom.model.property.maven.javadoc.skip = true

--- a/tests/org.eclipse.jface.tests.databinding.conformance/build.properties
+++ b/tests/org.eclipse.jface.tests.databinding.conformance/build.properties
@@ -25,3 +25,4 @@ source.. = src/
 pom.model.packaging = eclipse-test-plugin
 #All test classes are not mentioned to be executed stand-alone. They only make sense, if they are used by other tests.
 pom.model.property.skipTests = true
+pom.model.property.maven.javadoc.skip = true

--- a/tests/org.eclipse.jface.tests.databinding/build.properties
+++ b/tests/org.eclipse.jface.tests.databinding/build.properties
@@ -25,3 +25,4 @@ bin.includes = META-INF/,\
 # Maven properties, see https://github.com/eclipse/tycho/wiki/Tycho-Pomless
 # This plug-in's name does not comply with Tycho's naming convention for test-plugins -> packaging type has to be specified explicitly
 pom.model.packaging = eclipse-test-plugin
+pom.model.property.maven.javadoc.skip = true

--- a/tests/org.eclipse.jface.tests.notifications/build.properties
+++ b/tests/org.eclipse.jface.tests.notifications/build.properties
@@ -5,3 +5,4 @@ bin.includes = META-INF/,\
 # Maven properties, see https://github.com/eclipse/tycho/wiki/Tycho-Pomless
 # This plug-in's name does not comply with Tycho's naming convention for test-plugins -> packaging type has to be specified explicitly
 pom.model.packaging = eclipse-test-plugin
+pom.model.property.maven.javadoc.skip = true

--- a/tests/org.eclipse.jface.tests/build.properties
+++ b/tests/org.eclipse.jface.tests/build.properties
@@ -8,3 +8,4 @@ bin.includes = META-INF/,\
                OSGI-INF/
 # Maven properties, see https://github.com/eclipse/tycho/wiki/Tycho-Pomless
 pom.model.property.testClass = org.eclipse.jface.tests.AllTests
+pom.model.property.maven.javadoc.skip = true

--- a/tests/org.eclipse.jface.text.tests/build.properties
+++ b/tests/org.eclipse.jface.text.tests/build.properties
@@ -28,3 +28,4 @@ output.. = bin/
 pom.model.property.testClass = org.eclipse.jface.text.tests.JFaceTextTestSuite
 pom.model.property.tycho.surefire.useUIHarness = true
 pom.model.property.tycho.surefire.useUIThread = true
+pom.model.property.maven.javadoc.skip = true

--- a/tests/org.eclipse.ltk.core.refactoring.tests/build.properties
+++ b/tests/org.eclipse.ltk.core.refactoring.tests/build.properties
@@ -21,3 +21,4 @@ src.includes = about.html
 source.. = src/
 output.. = bin/
 pom.model.property.testClass=org.eclipse.ltk.core.refactoring.tests.AllTests
+pom.model.property.maven.javadoc.skip = true

--- a/tests/org.eclipse.ltk.ui.refactoring.tests/build.properties
+++ b/tests/org.eclipse.ltk.ui.refactoring.tests/build.properties
@@ -21,3 +21,4 @@ src.includes = about.html
 source.. = src/
 output.. = bin/
 pom.model.property.testClass=org.eclipse.ltk.ui.refactoring.tests.AllTests
+pom.model.property.maven.javadoc.skip = true

--- a/tests/org.eclipse.search.tests/build.properties
+++ b/tests/org.eclipse.search.tests/build.properties
@@ -27,3 +27,4 @@ bin.includes = plugin.properties,\
 pom.model.property.testClass = org.eclipse.search.tests.AllSearchTests
 pom.model.property.tycho.surefire.useUIHarness = true
 pom.model.property.tycho.surefire.useUIThread = true
+pom.model.property.maven.javadoc.skip = true

--- a/tests/org.eclipse.tests.urischeme/build.properties
+++ b/tests/org.eclipse.tests.urischeme/build.properties
@@ -10,3 +10,4 @@ src.includes = about.html
 # Maven properties, see https://github.com/eclipse/tycho/wiki/Tycho-Pomless
 # This plug-in's name does not comply with Tycho's naming convention for test-plugins -> packaging type has to be specified explicitly
 pom.model.packaging = eclipse-test-plugin
+pom.model.property.maven.javadoc.skip = true

--- a/tests/org.eclipse.text.quicksearch.tests/build.properties
+++ b/tests/org.eclipse.text.quicksearch.tests/build.properties
@@ -22,3 +22,4 @@ bin.includes = META-INF/,\
 pom.model.property.testClass = org.eclipse.text.quicksearch.tests.*Test
 pom.model.property.tycho.surefire.useUIHarness = true
 pom.model.property.tycho.surefire.useUIThread = true
+pom.model.property.maven.javadoc.skip = true

--- a/tests/org.eclipse.text.tests/build.properties
+++ b/tests/org.eclipse.text.tests/build.properties
@@ -26,3 +26,4 @@ output.. = bin/
 
 # Maven/Tycho pom model adjustments
 pom.model.property.testClass = org.eclipse.text.tests.EclipseTextTestSuite
+pom.model.property.maven.javadoc.skip = true

--- a/tests/org.eclipse.ui.editors.tests/build.properties
+++ b/tests/org.eclipse.ui.editors.tests/build.properties
@@ -29,3 +29,4 @@ output.. = bin/
 pom.model.property.testClass = org.eclipse.ui.editors.tests.EditorsTestSuite
 pom.model.property.tycho.surefire.useUIHarness = true
 pom.model.property.tycho.surefire.useUIThread = true
+pom.model.property.maven.javadoc.skip = true

--- a/tests/org.eclipse.ui.genericeditor.tests/build.properties
+++ b/tests/org.eclipse.ui.genericeditor.tests/build.properties
@@ -30,3 +30,4 @@ output.. = bin/
 pom.model.property.testClass = org.eclipse.ui.genericeditor.tests.GenericEditorTestSuite
 pom.model.property.tycho.surefire.useUIHarness = true
 pom.model.property.tycho.surefire.useUIThread = true
+pom.model.property.maven.javadoc.skip = true

--- a/tests/org.eclipse.ui.ide.application.tests/build.properties
+++ b/tests/org.eclipse.ui.ide.application.tests/build.properties
@@ -20,3 +20,4 @@ src.includes = about.html
 # Maven properties, see https://github.com/eclipse/tycho/wiki/Tycho-Pomless
 pom.model.property.tycho.surefire.useUIHarness = false
 pom.model.property.tycho.surefire.useUIThread = false
+pom.model.property.maven.javadoc.skip = true

--- a/tests/org.eclipse.ui.monitoring.tests/build.properties
+++ b/tests/org.eclipse.ui.monitoring.tests/build.properties
@@ -25,3 +25,4 @@ src.includes = about.html
 
 # Maven properties, see https://github.com/eclipse/tycho/wiki/Tycho-Pomless
 pom.model.property.testClass = org.eclipse.ui.internal.monitoring.MonitoringTestSuite
+pom.model.property.maven.javadoc.skip = true

--- a/tests/org.eclipse.ui.tests.browser/build.properties
+++ b/tests/org.eclipse.ui.tests.browser/build.properties
@@ -25,3 +25,4 @@ output.. = bin/
 pom.model.packaging = eclipse-test-plugin
 # Test not yet ready for Surefire
 pom.model.property.skipTests = true
+pom.model.property.maven.javadoc.skip = true

--- a/tests/org.eclipse.ui.tests.forms/build.properties
+++ b/tests/org.eclipse.ui.tests.forms/build.properties
@@ -21,3 +21,4 @@ source.. = forms/
 # Maven properties, see https://github.com/eclipse/tycho/wiki/Tycho-Pomless
 pom.model.packaging = eclipse-test-plugin
 pom.model.property.testClass = org.eclipse.ui.tests.forms.AllFormsTests
+pom.model.property.maven.javadoc.skip = true

--- a/tests/org.eclipse.ui.tests.harness/build.properties
+++ b/tests/org.eclipse.ui.tests.harness/build.properties
@@ -22,3 +22,4 @@ bin.includes = META-INF/,\
 # Maven properties, see https://github.com/eclipse/tycho/wiki/Tycho-Pomless
 # This plug-in's name does not comply with Tycho's naming convention for test-plugins -> packaging type has to be specified explicitly
 pom.model.packaging = eclipse-test-plugin
+pom.model.property.maven.javadoc.skip = true

--- a/tests/org.eclipse.ui.tests.navigator/build.properties
+++ b/tests/org.eclipse.ui.tests.navigator/build.properties
@@ -33,3 +33,4 @@ bin.includes = testdata/,\
 # This plug-in's name does not comply with Tycho's naming convention for test-plugins -> packaging type has to be specified explicitly
 pom.model.packaging = eclipse-test-plugin
 pom.model.property.testClass = org.eclipse.ui.tests.navigator.NavigatorTestSuite
+pom.model.property.maven.javadoc.skip = true

--- a/tests/org.eclipse.ui.tests.performance/build.properties
+++ b/tests/org.eclipse.ui.tests.performance/build.properties
@@ -28,3 +28,4 @@ bin.includes = plugin.xml,\
 pom.model.packaging = eclipse-test-plugin
 # Test not yet ready for Surefire
 pom.model.property.skipTests = true
+pom.model.property.maven.javadoc.skip = true

--- a/tests/org.eclipse.ui.tests.pluginchecks/build.properties
+++ b/tests/org.eclipse.ui.tests.pluginchecks/build.properties
@@ -9,3 +9,4 @@ src.includes = about.html
 # Maven properties, see https://github.com/eclipse/tycho/wiki/Tycho-Pomless
 # This plug-in's name does not comply with Tycho's naming convention for test-plugins -> packaging type has to be specified explicitly
 pom.model.packaging = eclipse-test-plugin
+pom.model.property.maven.javadoc.skip = true

--- a/tests/org.eclipse.ui.tests.rcp/build.properties
+++ b/tests/org.eclipse.ui.tests.rcp/build.properties
@@ -30,3 +30,4 @@ pom.model.property.testClass = org.eclipse.ui.tests.rcp.RcpTestSuite
 # Tests have to run headless, with an application
 pom.model.property.tycho.surefire.useUIHarness = false
 pom.model.property.tycho.surefire.useUIThread = true
+pom.model.property.maven.javadoc.skip = true

--- a/tests/org.eclipse.ui.tests.views.properties.tabbed/build.properties
+++ b/tests/org.eclipse.ui.tests.views.properties.tabbed/build.properties
@@ -27,3 +27,4 @@ output.. = bin/
 # Maven properties, see https://github.com/eclipse/tycho/wiki/Tycho-Pomless
 # This plug-in's name does not comply with Tycho's naming convention for test-plugins -> packaging type has to be specified explicitly
 pom.model.packaging = eclipse-test-plugin
+pom.model.property.maven.javadoc.skip = true

--- a/tests/org.eclipse.ui.tests/build.properties
+++ b/tests/org.eclipse.ui.tests/build.properties
@@ -34,3 +34,4 @@ pom.model.property.defaultSigning-excludeInnerJars = true
 # This suite runs ~7 min on Linux but ~3x slower on the macOS CI runners, where it
 # exceeds the inherited 1200s surefire.timeout and the forked test VM is killed.
 pom.model.property.surefire.timeout = 1800
+pom.model.property.maven.javadoc.skip = true

--- a/tests/org.eclipse.ui.workbench.texteditor.tests/build.properties
+++ b/tests/org.eclipse.ui.workbench.texteditor.tests/build.properties
@@ -29,3 +29,4 @@ output.. = bin/
 pom.model.property.testClass = org.eclipse.ui.workbench.texteditor.tests.WorkbenchTextEditorTestSuite
 pom.model.property.tycho.surefire.useUIHarness = true
 pom.model.property.tycho.surefire.useUIThread = true
+pom.model.property.maven.javadoc.skip = true


### PR DESCRIPTION
The `javadoc` profile that the Jenkins job enables generates and jars API docs for every module in the reactor, including the 33 test bundles. Nobody publishes those docs and the Jenkinsfile archives only logs, so the jars are built and then thrown away.

Measured locally, javadoc for the test and example bundles takes 123 s of the 411 s the whole reactor spends on javadoc, roughly 5 to 6 minutes on the slower CI agent. That is a useful cut for a job running against an 80 minute timeout that has been hitting it lately.

Javadoc stays enabled for the published bundles. Its doclint HTML and syntax checks are the only validation of doc comment markup in CI, since the GitHub Actions builds do not pass `-Pjavadoc` at all.