### PR TITLE
Re-add inlined annotations a client removed from the annotation model

### DIFF
--- a/bundles/org.eclipse.jface.text/src/org/eclipse/jface/text/source/inlined/InlinedAnnotationSupport.java
+++ b/bundles/org.eclipse.jface.text/src/org/eclipse/jface/text/source/inlined/InlinedAnnotationSupport.java
@@ -16,7 +16,6 @@ package org.eclipse.jface.text.source.inlined;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -524,8 +523,10 @@ public class InlinedAnnotationSupport {
 				: Collections.emptyList();
 		// Loop for annotations to update
 		for (AbstractInlinedAnnotation ann : annotations) {
-			if (!annotationsToRemove.remove(ann)) {
-				// The annotation was not created, add it
+			boolean known= annotationsToRemove.remove(ann);
+			// An annotation a client removed from the annotation model behind our back is
+			// still known here, but invisible, so add it again.
+			if (!known || annotationModel.getPosition(ann) == null) {
 				annotationsToAdd.put(ann, ann.getPosition());
 			}
 		}
@@ -547,10 +548,10 @@ public class InlinedAnnotationSupport {
 					((IAnnotationModelExtension) annotationModel).replaceAnnotations(
 							annotationsToRemove.toArray(new Annotation[annotationsToRemove.size()]), annotationsToAdd);
 				} else {
-					removeInlinedAnnotations();
-					Iterator<Entry<AbstractInlinedAnnotation, Position>> iter= annotationsToAdd.entrySet().iterator();
-					while (iter.hasNext()) {
-						Entry<AbstractInlinedAnnotation, Position> mapEntry= iter.next();
+					for (AbstractInlinedAnnotation ann : annotationsToRemove) {
+						annotationModel.removeAnnotation(ann);
+					}
+					for (Entry<AbstractInlinedAnnotation, Position> mapEntry : annotationsToAdd.entrySet()) {
 						annotationModel.addAnnotation(mapEntry.getKey(), mapEntry.getValue());
 					}
 				}

--- a/tests/org.eclipse.jface.text.tests/src/org/eclipse/jface/text/tests/JFaceTextTestSuite.java
+++ b/tests/org.eclipse.jface.text.tests/src/org/eclipse/jface/text/tests/JFaceTextTestSuite.java
@@ -16,6 +16,7 @@ package org.eclipse.jface.text.tests;
 import org.junit.platform.suite.api.Suite;
 import org.junit.platform.suite.api.SelectClasses;
 
+import org.eclipse.jface.text.tests.codemining.CodeMiningAnnotationReattachTest;
 import org.eclipse.jface.text.tests.codemining.CodeMiningLineHeaderAnnotationTest;
 import org.eclipse.jface.text.tests.codemining.CodeMiningProjectionViewerTest;
 import org.eclipse.jface.text.tests.codemining.CodeMiningTest;
@@ -79,6 +80,7 @@ import org.eclipse.jface.text.tests.templates.persistence.TemplatePersistenceDat
 		CodeMiningTest.class,
 		CodeMiningLineHeaderAnnotationTest.class,
 		CodeMiningProjectionViewerTest.class,
+		CodeMiningAnnotationReattachTest.class,
 
 		TabsToSpacesConverterTest.class,
 		DefaultTextDoubleClickStrategyTest.class,

--- a/tests/org.eclipse.jface.text.tests/src/org/eclipse/jface/text/tests/codemining/CodeMiningAnnotationReattachTest.java
+++ b/tests/org.eclipse.jface.text.tests/src/org/eclipse/jface/text/tests/codemining/CodeMiningAnnotationReattachTest.java
@@ -1,0 +1,206 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Vogella GmbH and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.jface.text.tests.codemining;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.custom.StyledText;
+import org.eclipse.swt.layout.FillLayout;
+import org.eclipse.swt.widgets.Display;
+import org.eclipse.swt.widgets.Shell;
+
+import org.eclipse.core.runtime.IProgressMonitor;
+
+import org.eclipse.jface.text.BadLocationException;
+import org.eclipse.jface.text.Document;
+import org.eclipse.jface.text.ITextViewer;
+import org.eclipse.jface.text.Position;
+import org.eclipse.jface.text.codemining.AbstractCodeMiningProvider;
+import org.eclipse.jface.text.codemining.ICodeMining;
+import org.eclipse.jface.text.codemining.ICodeMiningProvider;
+import org.eclipse.jface.text.codemining.LineHeaderCodeMining;
+import org.eclipse.jface.text.source.Annotation;
+import org.eclipse.jface.text.source.AnnotationModel;
+import org.eclipse.jface.text.source.AnnotationPainter;
+import org.eclipse.jface.text.source.SourceViewer;
+import org.eclipse.jface.text.source.inlined.LineHeaderAnnotation;
+import org.eclipse.jface.text.source.inlined.Positions;
+
+import org.eclipse.ui.tests.harness.util.DisplayHelper;
+
+/**
+ * Tests that code minings reappear after a client removed their annotation.
+ */
+public class CodeMiningAnnotationReattachTest {
+
+	private static final String LABEL= "mining";
+
+	private static final int LINE= 1;
+
+	private Shell fShell;
+
+	private SourceViewer fViewer;
+
+	private AnnotationModel fAnnotationModel;
+
+	@BeforeEach
+	public void setUp() {
+		fShell= new Shell(Display.getDefault());
+		fShell.setSize(500, 200);
+		fShell.setLayout(new FillLayout());
+		fViewer= new SourceViewer(fShell, null, SWT.NONE);
+		StyledText textWidget= fViewer.getTextWidget();
+		fAnnotationModel= new AnnotationModel();
+		fViewer.setDocument(new Document("line0\nline1\nline2"), fAnnotationModel);
+		fShell.open();
+		assertTrue(new DisplayHelper() {
+			@Override
+			protected boolean condition() {
+				return fViewer.getTextWidget().isVisible();
+			}
+		}.waitForCondition(textWidget.getDisplay(), 3000));
+	}
+
+	@AfterEach
+	public void tearDown() {
+		fViewer.setCodeMiningProviders(null);
+		fShell.dispose();
+		fShell= null;
+		fViewer= null;
+		fAnnotationModel= null;
+	}
+
+	@Test
+	public void testSynchronousProviderReAddsAnnotationRemovedByClient() throws Exception {
+		TestCodeMiningProvider provider= new TestCodeMiningProvider(true);
+		install(provider);
+
+		Position pos= miningPosition();
+		LineHeaderAnnotation annotation= waitForAnnotation(pos);
+		assertEquals(LABEL, annotation.getMinings().get(0).getLabel());
+
+		// a client outside the framework drops the annotation
+		fAnnotationModel.removeAnnotation(annotation);
+		assertTrue(findAnnotations(pos).isEmpty());
+
+		fViewer.updateCodeMinings();
+
+		LineHeaderAnnotation reattached= waitForAnnotation(pos);
+		assertEquals(LABEL, reattached.getMinings().get(0).getLabel());
+	}
+
+	@Test
+	public void testAsynchronousProviderReAddsAnnotationRemovedByClient() throws Exception {
+		TestCodeMiningProvider provider= new TestCodeMiningProvider(false);
+		install(provider);
+		provider.completePending();
+
+		Position pos= miningPosition();
+		LineHeaderAnnotation annotation= waitForAnnotation(pos);
+		assertEquals(LABEL, annotation.getMinings().get(0).getLabel());
+
+		fAnnotationModel.removeAnnotation(annotation);
+		assertTrue(findAnnotations(pos).isEmpty());
+
+		// the second request cancels the first one, so the first one never renders
+		fViewer.updateCodeMinings();
+		fViewer.updateCodeMinings();
+		provider.completePending();
+
+		LineHeaderAnnotation reattached= waitForAnnotation(pos);
+		assertEquals(LABEL, reattached.getMinings().get(0).getLabel());
+	}
+
+	private void install(ICodeMiningProvider provider) {
+		AnnotationPainter painter= new AnnotationPainter(fViewer, null);
+		fViewer.setCodeMiningAnnotationPainter(painter);
+		fViewer.addPainter(painter);
+		fViewer.setCodeMiningProviders(new ICodeMiningProvider[] { provider });
+	}
+
+	private Position miningPosition() throws BadLocationException {
+		return Positions.of(LINE, fViewer.getDocument(), true);
+	}
+
+	private LineHeaderAnnotation waitForAnnotation(Position pos) {
+		assertTrue(new DisplayHelper() {
+			@Override
+			protected boolean condition() {
+				return !findAnnotations(pos).isEmpty();
+			}
+		}.waitForCondition(fViewer.getTextWidget().getDisplay(), 3000), "No line header annotation at " + pos);
+		List<LineHeaderAnnotation> annotations= findAnnotations(pos);
+		assertEquals(1, annotations.size(), "Unexpected number of line header annotations at " + pos);
+		return annotations.get(0);
+	}
+
+	private List<LineHeaderAnnotation> findAnnotations(Position pos) {
+		List<LineHeaderAnnotation> result= new ArrayList<>();
+		for (Iterator<Annotation> it= fAnnotationModel.getAnnotationIterator(); it.hasNext();) {
+			Annotation annotation= it.next();
+			if (annotation instanceof LineHeaderAnnotation lineHeader && pos.equals(fAnnotationModel.getPosition(annotation))) {
+				result.add(lineHeader);
+			}
+		}
+		return result;
+	}
+
+	/** Provides a single line header mining, synchronously or through futures the test completes. */
+	private final class TestCodeMiningProvider extends AbstractCodeMiningProvider {
+
+		private final boolean fSynchronous;
+
+		private final List<CompletableFuture<List<? extends ICodeMining>>> fPending= new ArrayList<>();
+
+		TestCodeMiningProvider(boolean synchronous) {
+			fSynchronous= synchronous;
+		}
+
+		@Override
+		public CompletableFuture<List<? extends ICodeMining>> provideCodeMinings(ITextViewer viewer, IProgressMonitor monitor) {
+			if (fSynchronous) {
+				return CompletableFuture.completedFuture(createMinings());
+			}
+			CompletableFuture<List<? extends ICodeMining>> future= new CompletableFuture<>();
+			fPending.add(future);
+			return future;
+		}
+
+		void completePending() {
+			List<CompletableFuture<List<? extends ICodeMining>>> pending= new ArrayList<>(fPending);
+			fPending.clear();
+			pending.forEach(future -> future.complete(createMinings()));
+		}
+
+		private List<ICodeMining> createMinings() {
+			try {
+				LineHeaderCodeMining mining= new LineHeaderCodeMining(LINE, fViewer.getDocument(), this) {
+					// no additional behavior
+				};
+				mining.setLabel(LABEL);
+				return new ArrayList<>(List.of(mining));
+			} catch (BadLocationException e) {
+				throw new AssertionError(e);
+			}
+		}
+	}
+}


### PR DESCRIPTION
InlinedAnnotationSupport kept every annotation of its last render in `fInlinedAnnotations` and treated all of them as attached. Once a client removed a code mining annotation from the annotation model directly, that annotation object was reused for every later render at the same position but never put back into the model, so the minings there stayed invisible for the rest of the editor session. Annotations the model no longer knows are now added again; the removal side is unchanged. The fallback for annotation models without `IAnnotationModelExtension` now removes only the annotations that are actually gone, rather than dropping all of them and restoring only the newly added ones.

Found while working on the unified diff of `org.eclipse.compare` (https://github.com/eclipse-platform/eclipse.platform/pull/2791), whose side is already fixed. The framework still swallowed the minings for any other client doing the same, which the new `CodeMiningAnnotationReattachTest` covers for a synchronous and an asynchronous provider.