### PR TITLE
Coalesce editor re-styles caused by preference bursts

### DIFF
--- a/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/texteditor/AbstractTextEditor.java
+++ b/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/texteditor/AbstractTextEditor.java
@@ -2543,6 +2543,8 @@ public abstract class AbstractTextEditor extends EditorPart
 	private SourceViewerConfiguration fConfiguration;
 	/** The editor's source viewer. */
 	private ISourceViewer fSourceViewer;
+	/** Whether a full re-style of the text presentation is already scheduled. */
+	private boolean fInvalidateTextPresentationPending;
 	/**
 	 * The editor's selection provider.
 	 *
@@ -4749,6 +4751,28 @@ public abstract class AbstractTextEditor extends EditorPart
 	}
 
 	/**
+	 * Re-styles the whole document once per UI event loop turn, so a burst of
+	 * preference changes costs one re-style instead of one per key.
+	 */
+	private void invalidateTextPresentationLater() {
+		if (fInvalidateTextPresentationPending) {
+			return;
+		}
+		StyledText widget= fSourceViewer.getTextWidget();
+		if (widget == null || widget.isDisposed()) {
+			return;
+		}
+		fInvalidateTextPresentationPending= true;
+		widget.getDisplay().asyncExec(() -> {
+			fInvalidateTextPresentationPending= false;
+			ISourceViewer viewer= fSourceViewer;
+			if (viewer != null && viewer.getTextWidget() != null && !viewer.getTextWidget().isDisposed()) {
+				viewer.invalidateTextPresentation();
+			}
+		});
+	}
+
+	/**
 	 * Determines whether the given preference change affects the editor's
 	 * presentation. This implementation always returns <code>false</code>. May be
 	 * reimplemented by subclasses.
@@ -4843,7 +4867,7 @@ public abstract class AbstractTextEditor extends EditorPart
 		}
 
 		if (affectsTextPresentation(event)) {
-			fSourceViewer.invalidateTextPresentation();
+			invalidateTextPresentationLater();
 		}
 
 		if (PREFERENCE_HYPERLINKS_ENABLED.equals(property)) {

--- a/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/texteditor/SourceViewerDecorationSupport.java
+++ b/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/texteditor/SourceViewerDecorationSupport.java
@@ -209,6 +209,8 @@ public class SourceViewerDecorationSupport {
 	private MarginPainter fMarginPainter;
 	/** The editor's annotation painter */
 	private AnnotationPainter fAnnotationPainter;
+	/** Whether a repaint of the annotation painter is already scheduled. */
+	private boolean fAnnotationPainterRepaintPending;
 	/** The editor's peer character painter */
 	private MatchingCharacterPainter fMatchingCharacterPainter;
 	/** The character painter's pair matcher */
@@ -617,7 +619,7 @@ public class SourceViewerDecorationSupport {
 				Color color= getColor(info.getColorPreferenceKey());
 				if (fAnnotationPainter != null) {
 					fAnnotationPainter.setAnnotationTypeColor(info.getAnnotationType(), color);
-					fAnnotationPainter.paint(IPainter.CONFIGURATION);
+					repaintAnnotationPainterLater();
 				}
 				setAnnotationOverviewColor(info.getAnnotationType(), color);
 				return;
@@ -649,9 +651,30 @@ public class SourceViewerDecorationSupport {
 				Color color = registry.get(fInlineAnnotationColorKey);
 				fAnnotationPainter.setInlineAnnotationColor(color);
 				fAnnotationPainter.setAnnotationTypeColor(AbstractInlinedAnnotation.TYPE, color);
-				fAnnotationPainter.paint(IPainter.CONFIGURATION);
+				repaintAnnotationPainterLater();
 			}
 		}
+	}
+
+	/**
+	 * Repaints the annotation painter once per UI event loop turn, so a burst of
+	 * color changes costs one repaint instead of one per color.
+	 */
+	private void repaintAnnotationPainterLater() {
+		if (fAnnotationPainterRepaintPending) {
+			return;
+		}
+		StyledText widget= fSourceViewer.getTextWidget();
+		if (widget == null || widget.isDisposed()) {
+			return;
+		}
+		fAnnotationPainterRepaintPending= true;
+		widget.getDisplay().asyncExec(() -> {
+			fAnnotationPainterRepaintPending= false;
+			if (fAnnotationPainter != null && !widget.isDisposed()) {
+				fAnnotationPainter.paint(IPainter.CONFIGURATION);
+			}
+		});
 	}
 
 	/**


### PR DESCRIPTION
A theme switch writes every preference key on its own, and each key made every open editor re-run its presentation reconciler: `AbstractTextEditor` invalidated the whole document, `SourceViewerDecorationSupport` repainted the annotation painter over the highlighted range. With dozens of keys per switch that cost adds up per editor.

Both listeners now schedule at most one re-style per UI event loop turn, so a burst of preference changes costs one whole-document and one annotation re-style per editor instead of one per key. The painter's colors are still applied synchronously, only the repaint is deferred, so nothing is displayed with stale colors.

Verified that `org.eclipse.ui.workbench.texteditor` compiles. Note that in the theme-switch profile I took, the platform path this changes is only a small share of the stall; the bulk sits in JDT's semantic highlighting, which is https://github.com/eclipse-jdt/eclipse.jdt.ui/pull/3142.