### PR TITLE
Show every line header code mining after a fold collapsed

### DIFF
--- a/bundles/org.eclipse.jface.text/src/org/eclipse/jface/text/source/inlined/InlinedAnnotationSupport.java
+++ b/bundles/org.eclipse.jface.text/src/org/eclipse/jface/text/source/inlined/InlinedAnnotationSupport.java
@@ -52,6 +52,7 @@ import org.eclipse.jface.text.IDocument;
 import org.eclipse.jface.text.IDocumentListener;
 import org.eclipse.jface.text.IRegion;
 import org.eclipse.jface.text.ISynchronizable;
+import org.eclipse.jface.text.ITextListener;
 import org.eclipse.jface.text.ITextPresentationListener;
 import org.eclipse.jface.text.ITextViewerExtension4;
 import org.eclipse.jface.text.ITextViewerExtension5;
@@ -59,6 +60,7 @@ import org.eclipse.jface.text.IViewportListener;
 import org.eclipse.jface.text.JFaceTextUtil;
 import org.eclipse.jface.text.Position;
 import org.eclipse.jface.text.Region;
+import org.eclipse.jface.text.TextEvent;
 import org.eclipse.jface.text.TextPresentation;
 import org.eclipse.jface.text.source.Annotation;
 import org.eclipse.jface.text.source.AnnotationPainter;
@@ -139,11 +141,13 @@ public class InlinedAnnotationSupport {
 	/**
 	 * Class to track start/end offset of visible lines.
 	 */
-	private class VisibleLines implements IViewportListener, IDocumentListener, ControlListener {
+	private class VisibleLines implements IViewportListener, IDocumentListener, ControlListener, ITextListener {
 
-		private int startOffset;
+		/** The document offsets of the first and the last visible line. */
+		private record Range(int start, int end) {}
 
-		private Integer endOffset;
+		/** Published as a whole, so that a reader never pairs a start with a foreign end. */
+		private volatile Range range;
 
 		public VisibleLines() {
 			install();
@@ -159,13 +163,20 @@ public class InlinedAnnotationSupport {
 
 		@Override
 		public void documentAboutToBeChanged(DocumentEvent event) {
-			endOffset= null;
+			range= null;
+		}
+
+		@Override
+		public void textChanged(TextEvent event) {
+			// folding changes what is shown without a view port or document event
+			range= null;
 		}
 
 		@Override
 		public void documentChanged(DocumentEvent event) {
-			if (endOffset != null && event != null && event.fDocument != null && event.fDocument.getLength() > endOffset) {
-				endOffset= null;
+			Range current= range;
+			if (current != null && event != null && event.fDocument != null && event.fDocument.getLength() > current.end()) {
+				range= null;
 			}
 		}
 
@@ -180,8 +191,7 @@ public class InlinedAnnotationSupport {
 		}
 
 		private void compute() {
-			startOffset= getInclusiveTopIndexStartOffset();
-			endOffset= getExclusiveBottomIndexEndOffset();
+			range= new Range(getInclusiveTopIndexStartOffset(), getExclusiveBottomIndexEndOffset());
 		}
 
 		/**
@@ -233,15 +243,17 @@ public class InlinedAnnotationSupport {
 		 *         otherwise.
 		 */
 		boolean isInVisibleLines(int documentOffset) {
-			if (endOffset == null) {
-				Display display= fViewer.getTextWidget().getDisplay();
-				if (display.getThread() == Thread.currentThread()) {
-					endOffset= getExclusiveBottomIndexEndOffset();
-				} else {
-					display.syncExec(() -> endOffset= getExclusiveBottomIndexEndOffset());
-				}
+			Display display= fViewer.getTextWidget().getDisplay();
+			if (display.getThread() == Thread.currentThread()) {
+				// a scroll that reports no view port event, such as a programmatic one,
+				// is only noticed by asking the widget again
+				compute();
+			} else if (range == null) {
+				display.syncExec(this::compute);
 			}
-			return documentOffset >= startOffset && documentOffset <= endOffset;
+			// another thread may have invalidated the range in between
+			Range current= range;
+			return current != null && documentOffset >= current.start() && documentOffset <= current.end();
 		}
 
 		/**
@@ -250,6 +262,7 @@ public class InlinedAnnotationSupport {
 		void uninstall() {
 			if (fViewer != null) {
 				fViewer.removeViewportListener(this);
+				fViewer.removeTextListener(this);
 				if (fViewer.getDocument() != null) {
 					fViewer.getDocument().removeDocumentListener(this);
 				}
@@ -261,6 +274,7 @@ public class InlinedAnnotationSupport {
 
 		void install() {
 			fViewer.addViewportListener(this);
+			fViewer.addTextListener(this);
 			fViewer.getDocument().addDocumentListener(this);
 			fViewer.getTextWidget().addControlListener(this);
 		}

--- a/tests/org.eclipse.jface.text.tests/src/org/eclipse/jface/text/tests/codemining/CodeMiningProjectionViewerTest.java
+++ b/tests/org.eclipse.jface.text.tests/src/org/eclipse/jface/text/tests/codemining/CodeMiningProjectionViewerTest.java
@@ -13,6 +13,7 @@
  */
 package org.eclipse.jface.text.tests.codemining;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
@@ -29,6 +30,7 @@ import org.junit.jupiter.api.Test;
 import org.osgi.framework.Bundle;
 
 import org.eclipse.swt.SWT;
+import org.eclipse.swt.custom.StyledText;
 import org.eclipse.swt.layout.FillLayout;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Event;
@@ -48,6 +50,7 @@ import org.eclipse.jface.text.Position;
 import org.eclipse.jface.text.codemining.ICodeMining;
 import org.eclipse.jface.text.codemining.ICodeMiningProvider;
 import org.eclipse.jface.text.codemining.LineContentCodeMining;
+import org.eclipse.jface.text.codemining.LineHeaderCodeMining;
 import org.eclipse.jface.text.contentassist.ContentAssistant;
 import org.eclipse.jface.text.contentassist.IContentAssistant;
 import org.eclipse.jface.text.source.AnnotationPainter;
@@ -80,6 +83,36 @@ public class CodeMiningProjectionViewerTest {
 				}
 			}
 			return CompletableFuture.completedFuture(codeMinings);
+		}
+
+		@Override
+		public void dispose() {
+		}
+	}
+
+	private static final class LineHeaderMiningProvider implements ICodeMiningProvider {
+		private final int[] fLines;
+
+		LineHeaderMiningProvider(int... lines) {
+			fLines= lines;
+		}
+
+		@Override
+		public CompletableFuture<List<? extends ICodeMining>> provideCodeMinings(ITextViewer viewer, IProgressMonitor monitor) {
+			List<ICodeMining> minings= new ArrayList<>();
+			for (int line : fLines) {
+				try {
+					minings.add(new LineHeaderCodeMining(line, viewer.getDocument(), this) {
+						@Override
+						public String getLabel() {
+							return "header of line " + line; //$NON-NLS-1$
+						}
+					});
+				} catch (BadLocationException e) {
+					throw new AssertionError(e);
+				}
+			}
+			return CompletableFuture.completedFuture(minings);
 		}
 
 		@Override
@@ -221,4 +254,69 @@ public class CodeMiningProjectionViewerTest {
 		fViewer.getTextWidget().notifyListeners(SWT.KeyDown, e);
 		assertTrue(completionShell.isVisible());
 	}
+
+	@Test
+	public void testLineHeaderMiningsShowUpAfterCollapsing() throws Exception {
+		StyledText widget= collapsedViewerWithMiningsOn(0, 151, 155);
+
+		// collapsing brought the lines 151 and 155 into the view port
+		assertReservesSpace(widget, 151);
+		assertReservesSpace(widget, 155);
+	}
+
+	@Test
+	public void testLineHeaderMiningsShowUpAfterScrolling() throws Exception {
+		StyledText widget= collapsedViewerWithMiningsOn(0, 151, 199);
+		assertReservesSpace(widget, 151);
+		assertFalse(reservesSpace(widget, 199), "line 199 is not in the view port yet");
+
+		// a programmatic scroll notifies no view port listener
+		widget.setTopIndex(widget.getLineCount() - 1);
+
+		assertReservesSpace(widget, 199);
+	}
+
+	/**
+	 * Opens a viewer on 200 lines with a line header mining on each of the given lines and one
+	 * collapsed region over the lines 5 to 150, so that the lines behind it come into the view port
+	 * only once that region is folded away.
+	 *
+	 * @return the text widget of the viewer
+	 */
+	private StyledText collapsedViewerWithMiningsOn(int... lines) throws BadLocationException {
+		StringBuilder text= new StringBuilder();
+		for (int i= 0; i < 200; i++) {
+			text.append("line").append(i).append('\n');
+		}
+		fParent.setSize(500, 600);
+		fViewer.getDocument().set(text.toString());
+		fViewer.setCodeMiningProviders(new ICodeMiningProvider[] { new LineHeaderMiningProvider(lines) });
+		IDocument doc= fViewer.getDocument();
+		fViewer.getProjectionAnnotationModel().addAnnotation(new ProjectionAnnotation(false),
+				new Position(doc.getLineOffset(5), doc.getLineOffset(150) - doc.getLineOffset(5)));
+		fParent.open();
+		StyledText widget= fViewer.getTextWidget();
+		fViewer.updateCodeMinings();
+		// only the mining of line 0 is in the view port while the document is expanded
+		assertReservesSpace(widget, 0);
+
+		fViewer.doOperation(ProjectionViewer.COLLAPSE_ALL);
+		fViewer.updateCodeMinings();
+		return widget;
+	}
+
+	private void assertReservesSpace(StyledText widget, int modelLine) {
+		assertTrue(new DisplayHelper() {
+			@Override
+			protected boolean condition() {
+				return reservesSpace(widget, modelLine);
+			}
+		}.waitForCondition(fParent.getDisplay(), 3000), "no code mining drawn on line " + modelLine);
+	}
+
+	private boolean reservesSpace(StyledText widget, int modelLine) {
+		int widgetLine= fViewer.modelLine2WidgetLine(modelLine);
+		return widgetLine >= 0 && widget.getLineVerticalIndent(widgetLine) > 0;
+	}
+
 }

--- a/tests/org.eclipse.jface.text.tests/src/org/eclipse/jface/text/tests/codemining/CodeMiningTest.java
+++ b/tests/org.eclipse.jface.text.tests/src/org/eclipse/jface/text/tests/codemining/CodeMiningTest.java
@@ -771,7 +771,7 @@ public class CodeMiningTest {
 		Assertions.assertTrue(new DisplayHelper() {
 			@Override
 			protected boolean condition() {
-				return widget.getLineVerticalIndent(151) > 0;
+				return reservesSpaceFrom(widget, 150);
 			}
 		}.waitForCondition(widget.getDisplay(), 3000), "no code mining below the view port");
 		widget.setTopIndex(0);
@@ -816,6 +816,19 @@ public class CodeMiningTest {
 			this.setLabel(label);
 		}
 
+	}
+
+	/**
+	 * Reserving the space of a code mining moves the view port by a line or two, so which line ends
+	 * up on top after a scroll is not fixed.
+	 */
+	private static boolean reservesSpaceFrom(StyledText widget, int firstLine) {
+		for (int line= firstLine; line < widget.getLineCount(); line++) {
+			if (widget.getLineVerticalIndent(line) > 0) {
+				return true;
+			}
+		}
+		return false;
 	}
 
 	private static class ReferenceLineHeaderCodeMining extends LineHeaderCodeMining {


### PR DESCRIPTION
In a `ProjectionViewer` with collapsed folds only a single `LineHeaderCodeMining` was drawn, even though every mining was created and attached to the annotation model. On screen the line numbers jumped across a collapsed region with nothing in the gap, and a mining that came into view later never appeared at all.

`InlinedAnnotationSupport` caches the document offset range the view port shows and the drawing strategy skips annotations outside it. That cache is refreshed on a view port, resize or document event. Collapsing a fold is none of those, since the document is untouched and the view port does not move, and a programmatic scroll reports no view port event either. So the range kept an old value and every mining behind it was silently dropped.

The range is now recomputed on each use from the display thread, which is cheap and self correcting, and invalidated on a text change for the uses off the display thread.