### PR TITLE
Remove the misspelled tab keyline declaration from the default themes

### DIFF
--- a/bundles/org.eclipse.ui.themes/css/e4_default_gtk.css
+++ b/bundles/org.eclipse.ui.themes/css/e4_default_gtk.css
@@ -204,7 +204,6 @@ CTabFolder Canvas {
 	swt-selected-tab-highlight: #8a8a8a;
 	swt-selected-highlight-top: true;	
 	swt-tab-outline:#e5e5e5; 
-	swt-tab-outer-keyline: #e5e5e5;
 	swt-draw-custom-tab-content-background: true;
 	swt-unselected-hot-tab-color-background:#ffffff;
 }

--- a/bundles/org.eclipse.ui.themes/css/e4_default_mac.css
+++ b/bundles/org.eclipse.ui.themes/css/e4_default_mac.css
@@ -181,7 +181,6 @@ CTabFolder Canvas {
 	swt-selected-tab-highlight: #8a8a8a;
 	swt-selected-highlight-top: true;	
 	swt-tab-outline:#eaeaea; 
-	swt-tab-outer-keyline: #eaeaea;
 	swt-draw-custom-tab-content-background: true;
 	swt-unselected-hot-tab-color-background:#ffffff;
 }

--- a/bundles/org.eclipse.ui.themes/css/e4_default_win.css
+++ b/bundles/org.eclipse.ui.themes/css/e4_default_win.css
@@ -183,7 +183,6 @@ CTabFolder Canvas {
 	swt-selected-tab-highlight: #8a8a8a;
 	swt-selected-highlight-top: true;	
 	swt-tab-outline:#e5e5e5; 
-	swt-tab-outer-keyline: #e5e5e5;
 	swt-draw-custom-tab-content-background: true;
 	swt-unselected-hot-tab-color-background:#ffffff;
 }


### PR DESCRIPTION
The editor stack rule in `e4_default_gtk.css`, `e4_default_win.css` and `e4_default_mac.css` sets `swt-tab-outer-keyline`, which is not a registered CSS property. An unknown property finds no handler and is skipped without an exception or a log entry, so the declaration has had no effect since it was added in 2024.

Removing it changes nothing visually. The outer keyline of that stack is already set by `.MPartStack` and `.MPartStack.active` in `css/light/e4-light_tabstyle.css`, which point at the `ACTIVE_TAB_OUTER_KEYLINE_COLOR` and `INACTIVE_TAB_OUTER_KEYLINE_COLOR` definitions, and those already hold the same color the dead declaration repeated. Correcting the spelling instead would replace a color definition users can edit under Colors and Fonts with a hard coded hex, so deleting the line is the better fix.