### PR TITLE
Remove the font properties the CSS engine never implemented

### DIFF
--- a/bundles/org.eclipse.e4.ui.css.core/src/org/eclipse/e4/ui/css/core/dom/properties/css2/AbstractCSSPropertyFontCompositeHandler.java
+++ b/bundles/org.eclipse.e4.ui.css.core/src/org/eclipse/e4/ui/css/core/dom/properties/css2/AbstractCSSPropertyFontCompositeHandler.java
@@ -30,8 +30,8 @@ import org.w3c.dom.css.CSSValue;
 public abstract class AbstractCSSPropertyFontCompositeHandler extends
 		AbstractCSSPropertyCompositeHandler {
 
-	private static final String[] FONT_CSSPROPERTIES = { "font-style",
-			"font-variant", "font-weight", "font-size", "font-family" };
+	private static final String[] FONT_CSSPROPERTIES = { "font-style", "font-weight", "font-size",
+			"font-family" };
 
 	@Override
 	public void applyCSSProperty(Object element, CSSValue value, String pseudo,

--- a/bundles/org.eclipse.e4.ui.css.core/src/org/eclipse/e4/ui/css/core/dom/properties/css2/AbstractCSSPropertyFontHandler.java
+++ b/bundles/org.eclipse.e4.ui.css.core/src/org/eclipse/e4/ui/css/core/dom/properties/css2/AbstractCSSPropertyFontHandler.java
@@ -39,17 +39,8 @@ ICSSPropertyFontHandler {
 		case "font-size":
 			applyCSSPropertyFontSize(element, value, pseudo, engine);
 			break;
-		case "font-adjust":
-			applyCSSPropertyFontSizeAdjust(element, value, pseudo, engine);
-			break;
-		case "font-stretch":
-			applyCSSPropertyFontStretch(element, value, pseudo, engine);
-			break;
 		case "font-style":
 			applyCSSPropertyFontStyle(element, value, pseudo, engine);
-			break;
-		case "font-variant":
-			applyCSSPropertyFontVariant(element, value, pseudo, engine);
 			break;
 		case "font-weight":
 			applyCSSPropertyFontWeight(element, value, pseudo, engine);
@@ -72,14 +63,8 @@ ICSSPropertyFontHandler {
 			return retrieveCSSPropertyFontFamily(element, pseudo, engine);
 		case "font-size":
 			return retrieveCSSPropertyFontSize(element, pseudo, engine);
-		case "font-adjust":
-			return retrieveCSSPropertyFontAdjust(element, pseudo, engine);
-		case "font-stretch":
-			return retrieveCSSPropertyFontStretch(element, pseudo, engine);
 		case "font-style":
 			return retrieveCSSPropertyFontStyle(element, pseudo, engine);
-		case "font-variant":
-			return retrieveCSSPropertyFontVariant(element, pseudo, engine);
 		case "font-weight":
 			return retrieveCSSPropertyFontWeight(element, pseudo, engine);
 		}
@@ -130,18 +115,6 @@ ICSSPropertyFontHandler {
 	}
 
 	@Override
-	public void applyCSSPropertyFontSizeAdjust(Object element, CSSValue value,
-			String pseudo, CSSEngine engine) throws Exception {
-		throw new UnsupportedPropertyException("font-adjust");
-	}
-
-	@Override
-	public void applyCSSPropertyFontStretch(Object element, CSSValue value,
-			String pseudo, CSSEngine engine) throws Exception {
-		throw new UnsupportedPropertyException("font-stretch");
-	}
-
-	@Override
 	public void applyCSSPropertyFontStyle(Object element, CSSValue value,
 			String pseudo, CSSEngine engine) throws Exception {
 		if (element instanceof CSS2FontProperties) {
@@ -157,12 +130,6 @@ ICSSPropertyFontHandler {
 		if (value instanceof CssPrimitive primitive) {
 			font.setStyle(primitive);
 		}
-	}
-
-	@Override
-	public void applyCSSPropertyFontVariant(Object element, CSSValue value,
-			String pseudo, CSSEngine engine) throws Exception {
-		throw new UnsupportedPropertyException("font-variant");
 	}
 
 	@Override

--- a/bundles/org.eclipse.e4.ui.css.core/src/org/eclipse/e4/ui/css/core/dom/properties/css2/CSS2FontProperties.java
+++ b/bundles/org.eclipse.e4.ui.css.core/src/org/eclipse/e4/ui/css/core/dom/properties/css2/CSS2FontProperties.java
@@ -35,10 +35,6 @@ public interface CSS2FontProperties extends CSSValue {
 
 	void setSizeFromCSS(boolean sizeFromCSS);
 
-	CssPrimitive getSizeAdjust();
-
-	void setSizeAdjust(CssPrimitive sizeAdjust);
-
 	CssPrimitive getWeight();
 
 	void setWeight(CssPrimitive weight);
@@ -46,12 +42,4 @@ public interface CSS2FontProperties extends CSSValue {
 	CssPrimitive getStyle();
 
 	void setStyle(CssPrimitive style);
-
-	CssPrimitive getVariant();
-
-	void setVariant(CssPrimitive variant);
-
-	CssPrimitive getStretch();
-
-	void setStretch(CssPrimitive stretch);
 }

--- a/bundles/org.eclipse.e4.ui.css.core/src/org/eclipse/e4/ui/css/core/dom/properties/css2/CSS2FontPropertiesImpl.java
+++ b/bundles/org.eclipse.e4.ui.css.core/src/org/eclipse/e4/ui/css/core/dom/properties/css2/CSS2FontPropertiesImpl.java
@@ -25,15 +25,9 @@ public class CSS2FontPropertiesImpl implements CSS2FontProperties {
 
 	private boolean sizeFromCSS;
 
-	private CssPrimitive sizeAdjust;
-
 	private CssPrimitive weight;
 
 	private CssPrimitive style;
-
-	private CssPrimitive variant;
-
-	private CssPrimitive stretch;
 
 	@Override
 	public CssPrimitive getFamily() {
@@ -66,16 +60,6 @@ public class CSS2FontPropertiesImpl implements CSS2FontProperties {
 	}
 
 	@Override
-	public CssPrimitive getSizeAdjust() {
-		return sizeAdjust;
-	}
-
-	@Override
-	public void setSizeAdjust(CssPrimitive sizeAdjust) {
-		this.sizeAdjust = sizeAdjust;
-	}
-
-	@Override
 	public CssPrimitive getWeight() {
 		return weight;
 	}
@@ -93,26 +77,6 @@ public class CSS2FontPropertiesImpl implements CSS2FontProperties {
 	@Override
 	public void setStyle(CssPrimitive style) {
 		this.style = style;
-	}
-
-	@Override
-	public CssPrimitive getVariant() {
-		return variant;
-	}
-
-	@Override
-	public void setVariant(CssPrimitive variant) {
-		this.variant = variant;
-	}
-
-	@Override
-	public CssPrimitive getStretch() {
-		return stretch;
-	}
-
-	@Override
-	public void setStretch(CssPrimitive stretch) {
-		this.stretch = stretch;
 	}
 
 	@Override

--- a/bundles/org.eclipse.e4.ui.css.core/src/org/eclipse/e4/ui/css/core/dom/properties/css2/ICSSPropertyFontHandler.java
+++ b/bundles/org.eclipse.e4.ui.css.core/src/org/eclipse/e4/ui/css/core/dom/properties/css2/ICSSPropertyFontHandler.java
@@ -26,7 +26,7 @@ public interface ICSSPropertyFontHandler extends ICSSPropertyHandler {
 
 	/**
 	 * A shorthand property for setting all of the properties for a font in one
-	 * declaration. Available values are=font-style font-variant font-weight
+	 * declaration. Available values are=font-style font-weight
 	 * font-size/line-height font-family caption icon menu message-box
 	 * small-caption status-bar
 	 */
@@ -47,28 +47,9 @@ public interface ICSSPropertyFontHandler extends ICSSPropertyHandler {
 			String pseudo, CSSEngine engine) throws Exception;
 
 	/**
-	 * Specifies an aspect value for an element that will preserve the x-height
-	 * of the first-choice font.
-	 */
-	void applyCSSPropertyFontSizeAdjust(Object element, CSSValue value,
-			String pseudo, CSSEngine engine) throws Exception;
-
-	/**
-	 * Condenses or expands the current font-family.
-	 */
-	void applyCSSPropertyFontStretch(Object element, CSSValue value,
-			String pseudo, CSSEngine engine) throws Exception;
-
-	/**
 	 * Sets the style of the font.
 	 */
 	void applyCSSPropertyFontStyle(Object element, CSSValue value,
-			String pseudo, CSSEngine engine) throws Exception;
-
-	/**
-	 * Displays text in a small-caps font or a normal font.
-	 */
-	void applyCSSPropertyFontVariant(Object element, CSSValue value,
 			String pseudo, CSSEngine engine) throws Exception;
 
 	/**
@@ -83,16 +64,7 @@ public interface ICSSPropertyFontHandler extends ICSSPropertyHandler {
 	String retrieveCSSPropertyFontSize(Object element, String pseudo,
 			CSSEngine engine) throws Exception;
 
-	String retrieveCSSPropertyFontAdjust(Object element, String pseudo,
-			CSSEngine engine) throws Exception;
-
-	String retrieveCSSPropertyFontStretch(Object element, String pseudo,
-			CSSEngine engine) throws Exception;
-
 	String retrieveCSSPropertyFontStyle(Object element, String pseudo,
-			CSSEngine engine) throws Exception;
-
-	String retrieveCSSPropertyFontVariant(Object element, String pseudo,
 			CSSEngine engine) throws Exception;
 
 	String retrieveCSSPropertyFontWeight(Object element, String pseudo,

--- a/bundles/org.eclipse.e4.ui.css.swt/plugin.xml
+++ b/bundles/org.eclipse.e4.ui.css.swt/plugin.xml
@@ -182,16 +182,7 @@
                name="font-size">
          </property-name>
          <property-name
-               name="font-adjust">
-         </property-name>
-         <property-name
-               name="font-stretch">
-         </property-name>
-         <property-name
                name="font-style">
-         </property-name>
-         <property-name
-               name="font-variant">
          </property-name>
          <property-name
                name="font-weight">
@@ -270,16 +261,7 @@
                name="font-size">
          </property-name>
          <property-name
-               name="font-adjust">
-         </property-name>
-         <property-name
-               name="font-stretch">
-         </property-name>
-         <property-name
                name="font-style">
-         </property-name>
-         <property-name
-               name="font-variant">
          </property-name>
          <property-name
                name="font-weight">

--- a/bundles/org.eclipse.e4.ui.css.swt/src/org/eclipse/e4/ui/css/swt/helpers/CSSSWTFontHelper.java
+++ b/bundles/org.eclipse.e4.ui.css.swt/src/org/eclipse/e4/ui/css/swt/helpers/CSSSWTFontHelper.java
@@ -278,11 +278,8 @@ public class CSSSWTFontHelper {
 		resolved.setFamily(fontProperties.getFamily());
 		resolved.setSize(new CssDimension(height.getAsInt(), CssUnit.PT));
 		resolved.setSizeFromCSS(true);
-		resolved.setSizeAdjust(fontProperties.getSizeAdjust());
 		resolved.setWeight(fontProperties.getWeight());
 		resolved.setStyle(fontProperties.getStyle());
-		resolved.setVariant(fontProperties.getVariant());
-		resolved.setStretch(fontProperties.getStretch());
 		return resolved;
 	}
 

--- a/bundles/org.eclipse.e4.ui.css.swt/src/org/eclipse/e4/ui/css/swt/properties/css2/CSSPropertyFontSWTHandler.java
+++ b/bundles/org.eclipse.e4.ui.css.swt/src/org/eclipse/e4/ui/css/swt/properties/css2/CSSPropertyFontSWTHandler.java
@@ -194,12 +194,6 @@ public class CSSPropertyFontSWTHandler extends AbstractCSSPropertyFontHandler {
 	}
 
 	@Override
-	public String retrieveCSSPropertyFontAdjust(Object element, String pseudo,
-			CSSEngine engine) throws Exception {
-		return null;
-	}
-
-	@Override
 	public String retrieveCSSPropertyFontFamily(Object element, String pseudo,
 			CSSEngine engine) throws Exception {
 		Widget widget = (Widget) element;
@@ -214,23 +208,11 @@ public class CSSPropertyFontSWTHandler extends AbstractCSSPropertyFontHandler {
 	}
 
 	@Override
-	public String retrieveCSSPropertyFontStretch(Object element, String pseudo,
-			CSSEngine engine) throws Exception {
-		return null;
-	}
-
-	@Override
 	public String retrieveCSSPropertyFontStyle(Object element, String pseudo,
 			CSSEngine engine) throws Exception {
 		Widget widget = (Widget) element;
 		return CSSSWTFontHelper.getFontStyle(widget);
 
-	}
-
-	@Override
-	public String retrieveCSSPropertyFontVariant(Object element, String pseudo,
-			CSSEngine engine) throws Exception {
-		return null;
 	}
 
 	@Override
@@ -263,9 +245,8 @@ public class CSSPropertyFontSWTHandler extends AbstractCSSPropertyFontHandler {
 		 * retrieved from the style sheet. This list must be updated if
 		 * AbstractCSSPropertyFontHandler's listing changes.
 		 */
-		private final String[] fontAttributes = { "font", "font-family", "font-size",
-				"font-adjust", "font-stretch", "font-style", "font-variant",
-		"font-weight" };
+		private final String[] fontAttributes = { "font", "font-family", "font-size", "font-style",
+				"font-weight" };
 
 		private CSSEngine engine;
 
@@ -390,11 +371,8 @@ public class CSSPropertyFontSWTHandler extends AbstractCSSPropertyFontHandler {
 			properties.setFamily(null);
 			properties.setSize(null);
 			properties.setSizeFromCSS(false);
-			properties.setSizeAdjust(null);
 			properties.setWeight(null);
 			properties.setStyle(null);
-			properties.setVariant(null);
-			properties.setStretch(null);
 		}
 
 		@Override

--- a/bundles/org.eclipse.e4.ui.css.swt/src/org/eclipse/e4/ui/css/swt/properties/definition/CSSPropertyFontDefinitionHandler.java
+++ b/bundles/org.eclipse.e4.ui.css.swt/src/org/eclipse/e4/ui/css/swt/properties/definition/CSSPropertyFontDefinitionHandler.java
@@ -83,25 +83,7 @@ public class CSSPropertyFontDefinitionHandler extends AbstractCSSPropertyFontHan
 	}
 
 	@Override
-	public String retrieveCSSPropertyFontAdjust(Object element, String pseudo,
-			CSSEngine engine) throws Exception {
-		return null;
-	}
-
-	@Override
-	public String retrieveCSSPropertyFontStretch(Object element, String pseudo,
-			CSSEngine engine) throws Exception {
-		return null;
-	}
-
-	@Override
 	public String retrieveCSSPropertyFontStyle(Object element, String pseudo,
-			CSSEngine engine) throws Exception {
-		return null;
-	}
-
-	@Override
-	public String retrieveCSSPropertyFontVariant(Object element, String pseudo,
 			CSSEngine engine) throws Exception {
 		return null;
 	}


### PR DESCRIPTION
`font-adjust`, `font-stretch` and `font-variant` were registered as handled properties, but every apply method threw `UnsupportedPropertyException` and every retrieve method returned `null`. The engine swallows that exception, so a style sheet using one of them was ignored without a warning.

SWT `FontData` has no stretch axis, no small-caps and no size-adjust, so none of the three can be implemented. This drops the registrations, the handler methods and the `CSS2FontProperties` fields, which were only ever set to `null`. No shipped style sheet used them, the affected package is `x-friends`, and there is no visual change.