### PR TITLE
Stop leaking handled statuses in StatusManager

### DIFF
--- a/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/statushandlers/StatusManager.java
+++ b/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/statushandlers/StatusManager.java
@@ -15,8 +15,9 @@
 
 package org.eclipse.ui.statushandlers;
 
-import java.util.List;
-import java.util.Vector;
+import java.util.Collections;
+import java.util.Set;
+import java.util.WeakHashMap;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.ILogListener;
 import org.eclipse.core.runtime.IStatus;
@@ -116,7 +117,9 @@ public class StatusManager {
 
 	private volatile AbstractStatusHandler statusHandler;
 
-	private final List<IStatus> loggedStatuses = new Vector<>();
+	// Weakly held so that a status which never reaches the log listener cannot accumulate.
+	private final Set<IStatus> loggedStatuses = Collections
+			.newSetFromMap(Collections.synchronizedMap(new WeakHashMap<IStatus, Boolean>()));
 
 	private final ListenerList<INotificationListener> listeners = new ListenerList<>();
 

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/statushandlers/StatusHandlingTestSuite.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/statushandlers/StatusHandlingTestSuite.java
@@ -29,6 +29,7 @@ import org.junit.platform.suite.api.Suite;
 	SupportTrayTest.class,
 	WorkbenchStatusDialogManagerImplTest.class,
 	WizardsStatusHandlingTestCase.class,
+	StatusManagerTest.class,
 })
 public class StatusHandlingTestSuite {
 	//

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/statushandlers/StatusManagerTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/statushandlers/StatusManagerTest.java
@@ -1,0 +1,47 @@
+/*******************************************************************************
+ * Copyright (c) 2026 vogella GmbH and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Lars Vogel <Lars.Vogel@vogella.com> - initial API and implementation
+ ******************************************************************************/
+
+package org.eclipse.ui.tests.statushandlers;
+
+import java.lang.ref.ReferenceQueue;
+import java.lang.ref.WeakReference;
+
+import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.Status;
+import org.eclipse.ui.statushandlers.StatusManager;
+import org.eclipse.ui.tests.leaks.LeakTests;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests that the {@link StatusManager} singleton does not retain the statuses it
+ * is told about.
+ */
+public class StatusManagerTest {
+
+	/**
+	 * The entry is only dropped again once the very same instance comes back
+	 * through the log listener, which does not happen for every caller.
+	 */
+	@Test
+	public void testStatusNeverReachingTheLogListenerIsNotRetained() throws Exception {
+		ReferenceQueue<IStatus> queue = new ReferenceQueue<>();
+		IStatus status = new Status(IStatus.ERROR, "org.eclipse.ui.tests", "never logged"); //$NON-NLS-1$ //$NON-NLS-2$
+		WeakReference<IStatus> ref = new WeakReference<>(status, queue);
+
+		StatusManager.getManager().addLoggedStatus(status);
+		status = null; // drop the only strong reference
+
+		LeakTests.checkRef(queue, ref);
+	}
+}


### PR DESCRIPTION
`StatusManager` parks every status handled with the `LOG` style in a list and only drops it again once that very same instance comes back through its own log listener. For callers where that never happens the entry stays for the life of the singleton, and each one can keep an exception and its stack trace alive. Two such cases exist today: the listener is only registered when the platform is running, and the public `addLoggedStatus` can be called without a following log.

Holding the entries in a weak set fixes that without changing the handshake, and it lets the `Vector` go, whose per-call locking never made the `contains`-then-`remove` pair atomic anyway.

The new `StatusManagerTest` fails on the old implementation (the reference is never enqueued) and passes on the new one.