### PR TITLE
Support the full CSS font-weight grammar

### DIFF
--- a/bundles/org.eclipse.e4.ui.css.core/src/org/eclipse/e4/ui/css/core/css2/CSS2FontHelper.java
+++ b/bundles/org.eclipse.e4.ui.css.core/src/org/eclipse/e4/ui/css/core/css2/CSS2FontHelper.java
@@ -13,6 +13,9 @@
  *******************************************************************************/
 package org.eclipse.e4.ui.css.core.css2;
 
+import java.util.Locale;
+import java.util.OptionalInt;
+
 import org.eclipse.e4.ui.css.core.impl.dom.CssValues.CssNumeric;
 import org.eclipse.e4.ui.css.core.impl.dom.CssValues.CssPrimitive;
 import org.eclipse.e4.ui.css.core.impl.dom.CssValues.CssText;
@@ -25,6 +28,16 @@ import org.eclipse.e4.ui.css.core.impl.dom.CssValues.CssUnit;
  * @author <a href="mailto:angelo.zerr@gmail.com">Angelo ZERR</a>
  */
 public class CSS2FontHelper {
+
+	/** CSS font-weight of a regular face. */
+	public static final int FONT_WEIGHT_NORMAL = 400;
+
+	/** CSS font-weight of a bold face. */
+	public static final int FONT_WEIGHT_BOLD = 700;
+
+	private static final int MIN_FONT_WEIGHT = 1;
+
+	private static final int MAX_FONT_WEIGHT = 1000;
 
 	/**
 	 * Return CSS2 font-family. Escape font <code>family</code> with " if need.
@@ -67,8 +80,52 @@ public class CSS2FontHelper {
 	}
 
 	/**
+	 * Numeric font-weight of <code>value</code>, empty if it is not a weight.
+	 * Relative keywords are resolved against <code>inheritedWeight</code>.
+	 */
+	public static OptionalInt getFontWeight(CssPrimitive value, int inheritedWeight) {
+		if (value instanceof CssNumeric numeric && numeric.unit() == CssUnit.NUMBER) {
+			int weight = (int) Math.round(numeric.value());
+			return weight >= MIN_FONT_WEIGHT && weight <= MAX_FONT_WEIGHT ? OptionalInt.of(weight)
+					: OptionalInt.empty();
+		}
+		if (value instanceof CssText text) {
+			return switch (text.value().toLowerCase(Locale.ENGLISH)) {
+			case "normal" -> OptionalInt.of(FONT_WEIGHT_NORMAL);
+			case "bold" -> OptionalInt.of(FONT_WEIGHT_BOLD);
+			case "bolder" -> OptionalInt.of(bolder(inheritedWeight));
+			case "lighter" -> OptionalInt.of(lighter(inheritedWeight));
+			default -> OptionalInt.empty();
+			};
+		}
+		return OptionalInt.empty();
+	}
+
+	// CSS Fonts 4: relative weights step between the anchors 100/400/700/900
+	private static int bolder(int inheritedWeight) {
+		if (inheritedWeight < 350) {
+			return 400;
+		}
+		if (inheritedWeight < 550) {
+			return 700;
+		}
+		return inheritedWeight < 900 ? 900 : inheritedWeight;
+	}
+
+	private static int lighter(int inheritedWeight) {
+		if (inheritedWeight < 100) {
+			return inheritedWeight;
+		}
+		if (inheritedWeight < 550) {
+			return 100;
+		}
+		return inheritedWeight < 750 ? 400 : 700;
+	}
+
+	/**
 	 * Return the CSS Font Property name (font-style, font-weight, font-size,
-	 * font-family) for the given <code>value</code>.
+	 * font-family) for the given <code>value</code>, <code>null</code> if the value
+	 * belongs to none of them.
 	 */
 	public static String getCSSFontPropertyName(CssPrimitive value) {
 		if (value instanceof CssText text && (text.kind() == CssText.Kind.STRING || text.kind() == CssText.Kind.IDENT)) {
@@ -79,16 +136,26 @@ public class CSS2FontHelper {
 			case "normal":
 			case "bold":
 			case "bolder":
+			case "lighter":
 				return "font-weight";
 			default:
 				return "font-family";
 			}
 		}
-		if (value instanceof CssNumeric numeric
-				&& (numeric.unit() == CssUnit.PT || numeric.unit() == CssUnit.NUMBER || numeric.unit() == CssUnit.PX
-						|| numeric.unit() == CssUnit.EM || numeric.unit() == CssUnit.PERCENT)) {
-			return "font-size";
+		if (value instanceof CssNumeric numeric) {
+			// In the shorthand a bare 100..900 is a weight, not a size
+			if (numeric.unit() == CssUnit.NUMBER && isWeightStep(numeric.value())) {
+				return "font-weight";
+			}
+			if (numeric.unit() == CssUnit.PT || numeric.unit() == CssUnit.NUMBER || numeric.unit() == CssUnit.PX
+					|| numeric.unit() == CssUnit.EM || numeric.unit() == CssUnit.PERCENT) {
+				return "font-size";
+			}
 		}
 		return null;
+	}
+
+	private static boolean isWeightStep(double value) {
+		return value >= 100 && value <= 900 && value % 100 == 0;
 	}
 }

--- a/bundles/org.eclipse.e4.ui.css.core/src/org/eclipse/e4/ui/css/core/css2/CSS2FontPropertiesHelpers.java
+++ b/bundles/org.eclipse.e4.ui.css.core/src/org/eclipse/e4/ui/css/core/css2/CSS2FontPropertiesHelpers.java
@@ -99,7 +99,9 @@ public class CSS2FontPropertiesHelpers {
 			}
 		} else if (value instanceof CssPrimitive primitive) {
 			String property = CSS2FontHelper.getCSSFontPropertyName(primitive);
-			updateCSSPropertyFont(font, property, value);
+			if (property != null) {
+				updateCSSPropertyFont(font, property, value);
+			}
 		}
 	}
 

--- a/bundles/org.eclipse.e4.ui.css.swt/src/org/eclipse/e4/ui/css/swt/helpers/CSSSWTFontHelper.java
+++ b/bundles/org.eclipse.e4.ui.css.swt/src/org/eclipse/e4/ui/css/swt/helpers/CSSSWTFontHelper.java
@@ -56,6 +56,9 @@ public class CSSSWTFontHelper {
 	/** Lower bound so that a small factor cannot shrink a font away. */
 	private static final int MIN_FONT_HEIGHT = 1;
 
+	/** SWT has no weight axis, so from this weight up a face is bold. */
+	private static final int BOLD_WEIGHT_THRESHOLD = 600;
+
 	/** A CSS pixel is 1/96 inch, an SWT font height is 1/72 inch. */
 	private static final double PX_TO_PT = 72d / 96d;
 
@@ -330,13 +333,14 @@ public class CSSSWTFontHelper {
 			}
 		}
 		// CSS font-weight
-		CssPrimitive cssFontWeight = fontProperties.getWeight();
-		if (cssFontWeight instanceof CssText weightText) {
-			String weight = weightText.value();
-			if ("bold".equals(weight.toLowerCase())) {
+		int inheritedWeight = fontData != null && isBold(fontData) ? CSS2FontHelper.FONT_WEIGHT_BOLD
+				: CSS2FontHelper.FONT_WEIGHT_NORMAL;
+		OptionalInt cssFontWeight = CSS2FontHelper.getFontWeight(fontProperties.getWeight(), inheritedWeight);
+		if (cssFontWeight.isPresent()) {
+			if (cssFontWeight.getAsInt() >= BOLD_WEIGHT_THRESHOLD) {
 				fontStyle = fontStyle | SWT.BOLD;
-			} else if (fontStyle == (fontStyle | SWT.BOLD)) {
-				fontStyle = fontStyle ^ SWT.BOLD;
+			} else {
+				fontStyle = fontStyle & ~SWT.BOLD;
 			}
 		}
 		return fontStyle;

--- a/docs/CSS.md
+++ b/docs/CSS.md
@@ -102,6 +102,15 @@ These tables show the equivalent mapping from SWT method to CSS property.
 They also show pseudo selectors which can be used to choose styling based on widget state.
 
 
+### Font weight
+
+`font-weight` accepts `normal`, `bold`, `bolder`, `lighter` and the numbers
+`100` to `900`.
+SWT fonts have no weight axis, so a weight of `600` or more selects a bold face
+and anything below it a regular one.
+In the `font` shorthand a bare `100` to `900` is read as a weight, any other
+bare number as a size in points.
+
 ### Widget: Control
 
 | SWT Method | CSS Property Name | CSS Example |

--- a/tests/org.eclipse.e4.ui.tests.css.core/src/org/eclipse/e4/ui/tests/css/core/CSS2FontHelperTest.java
+++ b/tests/org.eclipse.e4.ui.tests.css.core/src/org/eclipse/e4/ui/tests/css/core/CSS2FontHelperTest.java
@@ -1,0 +1,111 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Lars Vogel and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Lars Vogel <Lars.Vogel@vogella.com> - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.e4.ui.tests.css.core;
+
+import static org.eclipse.e4.ui.css.core.css2.CSS2FontHelper.FONT_WEIGHT_BOLD;
+import static org.eclipse.e4.ui.css.core.css2.CSS2FontHelper.FONT_WEIGHT_NORMAL;
+import static org.eclipse.e4.ui.css.core.css2.CSS2FontHelper.getCSSFontPropertyName;
+import static org.eclipse.e4.ui.css.core.css2.CSS2FontHelper.getFontWeight;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.OptionalInt;
+
+import org.eclipse.e4.ui.css.core.impl.dom.CssValues.CssDimension;
+import org.eclipse.e4.ui.css.core.impl.dom.CssValues.CssNumber;
+import org.eclipse.e4.ui.css.core.impl.dom.CssValues.CssPrimitive;
+import org.eclipse.e4.ui.css.core.impl.dom.CssValues.CssText;
+import org.eclipse.e4.ui.css.core.impl.dom.CssValues.CssUnit;
+import org.junit.jupiter.api.Test;
+
+public class CSS2FontHelperTest {
+
+	private static CssPrimitive keyword(String value) {
+		return new CssText(CssText.Kind.IDENT, value);
+	}
+
+	private static CssPrimitive number(double value) {
+		return new CssNumber(value, true);
+	}
+
+	@Test
+	void testKeywordWeights() {
+		assertEquals(OptionalInt.of(FONT_WEIGHT_NORMAL), getFontWeight(keyword("normal"), FONT_WEIGHT_NORMAL));
+		assertEquals(OptionalInt.of(FONT_WEIGHT_BOLD), getFontWeight(keyword("bold"), FONT_WEIGHT_NORMAL));
+		assertEquals(OptionalInt.of(FONT_WEIGHT_BOLD), getFontWeight(keyword("BOLD"), FONT_WEIGHT_NORMAL));
+	}
+
+	@Test
+	void testNumericWeights() {
+		assertEquals(OptionalInt.of(100), getFontWeight(number(100), FONT_WEIGHT_NORMAL));
+		assertEquals(OptionalInt.of(600), getFontWeight(number(600), FONT_WEIGHT_NORMAL));
+		assertEquals(OptionalInt.of(900), getFontWeight(number(900), FONT_WEIGHT_NORMAL));
+	}
+
+	@Test
+	void testWeightsOutsideTheAllowedRange() {
+		assertFalse(getFontWeight(number(0), FONT_WEIGHT_NORMAL).isPresent());
+		assertFalse(getFontWeight(number(1001), FONT_WEIGHT_NORMAL).isPresent());
+	}
+
+	@Test
+	void testUnknownWeightIsNotAWeight() {
+		assertFalse(getFontWeight(keyword("semibold"), FONT_WEIGHT_NORMAL).isPresent());
+		assertFalse(getFontWeight(new CssDimension(600, CssUnit.PT), FONT_WEIGHT_NORMAL).isPresent());
+	}
+
+	@Test
+	void testBolderAndLighterStepFromTheInheritedWeight() {
+		assertEquals(OptionalInt.of(FONT_WEIGHT_BOLD), getFontWeight(keyword("bolder"), FONT_WEIGHT_NORMAL));
+		assertEquals(OptionalInt.of(900), getFontWeight(keyword("bolder"), FONT_WEIGHT_BOLD));
+		assertEquals(OptionalInt.of(900), getFontWeight(keyword("bolder"), 900));
+
+		assertEquals(OptionalInt.of(100), getFontWeight(keyword("lighter"), FONT_WEIGHT_NORMAL));
+		assertEquals(OptionalInt.of(FONT_WEIGHT_NORMAL), getFontWeight(keyword("lighter"), FONT_WEIGHT_BOLD));
+		assertEquals(OptionalInt.of(100), getFontWeight(keyword("lighter"), 100));
+	}
+
+	@Test
+	void testShorthandRoutesWeightKeywords() {
+		for (String keyword : new String[] { "normal", "bold", "bolder", "lighter" }) {
+			assertEquals("font-weight", getCSSFontPropertyName(keyword(keyword)), keyword);
+		}
+	}
+
+	@Test
+	void testShorthandRoutesBareWeightSteps() {
+		assertEquals("font-weight", getCSSFontPropertyName(number(600)));
+		assertEquals("font-weight", getCSSFontPropertyName(number(900)));
+	}
+
+	@Test
+	void testShorthandRoutesOtherBareNumbersToSize() {
+		assertEquals("font-size", getCSSFontPropertyName(number(12)));
+		assertEquals("font-size", getCSSFontPropertyName(number(650)));
+		assertEquals("font-size", getCSSFontPropertyName(new CssDimension(600, CssUnit.PT)));
+	}
+
+	@Test
+	void testShorthandRejectsValuesThatAreNoFontProperty() {
+		assertNull(getCSSFontPropertyName(new CssDimension(1, CssUnit.CM)));
+	}
+
+	@Test
+	void testShorthandRoutesRemainingIdentifiersToFamily() {
+		assertEquals("font-family", getCSSFontPropertyName(keyword("Terminal")));
+		assertTrue(getFontWeight(keyword("Terminal"), FONT_WEIGHT_NORMAL).isEmpty());
+	}
+}

--- a/tests/org.eclipse.e4.ui.tests.css.core/src/org/eclipse/e4/ui/tests/css/core/CssCoreTestSuite.java
+++ b/tests/org.eclipse.e4.ui.tests.css.core/src/org/eclipse/e4/ui/tests/css/core/CssCoreTestSuite.java
@@ -41,6 +41,7 @@ import org.junit.platform.suite.api.Suite;
 	ValueTest.class,
 	SelectorTest.class,
 	CSSEngineTest.class,
+	CSS2FontHelperTest.class,
 	ImportTest.class,
 	InheritTest.class,
 	CSSEngineImplTest.class

--- a/tests/org.eclipse.e4.ui.tests.css.swt/src/org/eclipse/e4/ui/css/swt/helpers/CSSSWTFontHelperTest.java
+++ b/tests/org.eclipse.e4.ui.tests.css.swt/src/org/eclipse/e4/ui/css/swt/helpers/CSSSWTFontHelperTest.java
@@ -80,6 +80,34 @@ public class CSSSWTFontHelperTest extends CSSSWTHelperTestCase {
 	}
 
 	@Test
+	void testGetFontDataWithNumericWeight() {
+		FontData bold = getFontData(fontProperties("Times", 11, null, 600), new FontData("Courier", 11, SWT.NORMAL));
+		assertEquals(SWT.BOLD, bold.getStyle());
+
+		FontData regular = getFontData(fontProperties("Times", 11, null, 500), new FontData("Courier", 11, SWT.BOLD));
+		assertEquals(SWT.NORMAL, regular.getStyle());
+	}
+
+	@Test
+	void testGetFontDataWithRelativeWeight() {
+		FontData bolder = getFontData(fontProperties("Times", 11, null, "bolder"),
+				new FontData("Courier", 11, SWT.NORMAL));
+		assertEquals(SWT.BOLD, bolder.getStyle());
+
+		FontData lighter = getFontData(fontProperties("Times", 11, null, "lighter"),
+				new FontData("Courier", 11, SWT.BOLD));
+		assertEquals(SWT.NORMAL, lighter.getStyle());
+	}
+
+	@Test
+	void testGetFontDataWithUnknownWeightKeepsTheOldWeight() {
+		FontData result = getFontData(fontProperties("Times", 11, null, "semibold"),
+				new FontData("Courier", 11, SWT.BOLD));
+
+		assertEquals(SWT.BOLD, result.getStyle());
+	}
+
+	@Test
 	void testGetFontDataWhenMissingStyleInCss() {
 		FontData result = getFontData(fontProperties("Times", 11, null, CSS_BOLD),
 				new FontData("Courier", 5, SWT.ITALIC));

--- a/tests/org.eclipse.e4.ui.tests.css.swt/src/org/eclipse/e4/ui/css/swt/helpers/CSSSWTHelperTestCase.java
+++ b/tests/org.eclipse.e4.ui.tests.css.swt/src/org/eclipse/e4/ui/css/swt/helpers/CSSSWTHelperTestCase.java
@@ -73,7 +73,9 @@ public abstract class CSSSWTHelperTestCase {
 		if (style != null) {
 			result.setStyle(new CssText(CssText.Kind.IDENT, style.toString()));
 		}
-		if (weight != null) {
+		if (weight instanceof Number number) {
+			result.setWeight(new CssNumber(number.doubleValue(), true));
+		} else if (weight != null) {
 			result.setWeight(new CssText(CssText.Kind.IDENT, weight.toString()));
 		}
 		return result;

--- a/tests/org.eclipse.e4.ui.tests.css.swt/src/org/eclipse/e4/ui/tests/css/swt/LabelTest.java
+++ b/tests/org.eclipse.e4.ui.tests.css.swt/src/org/eclipse/e4/ui/tests/css/swt/LabelTest.java
@@ -61,6 +61,30 @@ public class LabelTest {
 	}
 
 	@Test
+	void testFontWeightNumeric() {
+		Label labelToTest = css.createTestLabel("Label { font-weight: 600 }");
+
+		assertEquals(SWT.BOLD, labelToTest.getFont().getFontData()[0].getStyle());
+	}
+
+	@Test
+	void testFontWeightBelowBoldStaysRegular() {
+		Label labelToTest = css.createTestLabel("Label { font-weight: 500 }");
+
+		assertEquals(SWT.NORMAL, labelToTest.getFont().getFontData()[0].getStyle());
+	}
+
+	@Test
+	void testFontWeightInShorthand() {
+		Label labelToTest = css.createTestLabel("Label { font: 700 12pt Arial }");
+		FontData fontData = labelToTest.getFont().getFontData()[0];
+
+		assertEquals("Arial", fontData.getName());
+		assertEquals(12, fontData.getHeight());
+		assertEquals(SWT.BOLD, fontData.getStyle());
+	}
+
+	@Test
 	void testFontItalic() {
 		Label labelToTest = css.createTestLabel("Label { font-style: italic }");
 		assertEquals(1, labelToTest.getFont().getFontData().length);


### PR DESCRIPTION
The CSS engine only understood the literal `bold` for `font-weight`; every other value, including `600` or `bolder`, cleared the bold bit. In the `font` shorthand a bare number was always read as a size and `lighter` as a family name, so both dropped the weight silently.

`font-weight` now accepts `1` to `1000` plus `normal`, `bold`, `bolder` and `lighter`, with the relative keywords resolved against the inherited weight. SWT fonts have no weight axis, so `600` and above select the bold face and everything below the regular one. In the shorthand a bare `100` to `900` is a weight. This makes stylesheets written against standard CSS behave as expected instead of ending up lighter than intended.