### PR TITLE
Define shared syntax coloring colors in the platform

### DIFF
--- a/bundles/org.eclipse.ui.editors/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.ui.editors/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.ui.editors; singleton:=true
-Bundle-Version: 3.22.200.qualifier
+Bundle-Version: 3.23.0.qualifier
 Bundle-Activator: org.eclipse.ui.internal.editors.text.EditorsPlugin
 Bundle-ActivationPolicy: lazy
 Bundle-Vendor: %providerName

--- a/bundles/org.eclipse.ui.editors/css/e4-dark_preferencestyle.css
+++ b/bundles/org.eclipse.ui.editors/css/e4-dark_preferencestyle.css
@@ -1,5 +1,9 @@
-
 IEclipsePreferences#org-eclipse-ui-workbench:org-eclipse-ui-editors { 
 	preferences:
 		'org.eclipse.ui.editors.inlineAnnotationColor=155,155,155'
+		'org.eclipse.editors.syntax.tagColor=86,156,214'
+		'org.eclipse.editors.syntax.attributeNameColor=196,138,114'
+		'org.eclipse.editors.syntax.stringColor=118,200,244'
+		'org.eclipse.editors.syntax.commentColor=96,139,78'
+		'org.eclipse.editors.syntax.directiveColor=128,128,128'
 }

--- a/bundles/org.eclipse.ui.editors/plugin.properties
+++ b/bundles/org.eclipse.ui.editors/plugin.properties
@@ -156,3 +156,11 @@ dummy=
 #--- color definition for code mining annotations
 TEXT_EDITOR_CODE_MINING_COLOR= Text editor code mining color
 TEXT_EDITOR_CODE_MINING_COLOR_DESCRIPTION= The default color used for text editor code mining annotations.
+
+SYNTAX_COLORS_CATEGORY= Syntax coloring
+SYNTAX_COLORS_CATEGORY_DESCRIPTION= Colors shared by editors for syntax coloring, for example the XML, target definition and Ant editors.
+SYNTAX_TAG_COLOR= Tag
+SYNTAX_ATTRIBUTE_NAME_COLOR= Attribute name
+SYNTAX_STRING_COLOR= Attribute value and string
+SYNTAX_COMMENT_COLOR= Comment
+SYNTAX_DIRECTIVE_COLOR= Directive

--- a/bundles/org.eclipse.ui.editors/plugin.xml
+++ b/bundles/org.eclipse.ui.editors/plugin.xml
@@ -1126,6 +1126,49 @@
          </description>
       </colorDefinition>
 
+      <themeElementCategory
+            id="org.eclipse.editors.syntaxColors"
+            label="%SYNTAX_COLORS_CATEGORY">
+         <description>
+            %SYNTAX_COLORS_CATEGORY_DESCRIPTION
+         </description>
+      </themeElementCategory>
+      <colorDefinition
+            categoryId="org.eclipse.editors.syntaxColors"
+            id="org.eclipse.editors.syntax.tagColor"
+            isEditable="true"
+            label="%SYNTAX_TAG_COLOR"
+            value="0,0,128">
+      </colorDefinition>
+      <colorDefinition
+            categoryId="org.eclipse.editors.syntaxColors"
+            id="org.eclipse.editors.syntax.attributeNameColor"
+            isEditable="true"
+            label="%SYNTAX_ATTRIBUTE_NAME_COLOR"
+            value="128,0,0">
+      </colorDefinition>
+      <colorDefinition
+            categoryId="org.eclipse.editors.syntaxColors"
+            id="org.eclipse.editors.syntax.stringColor"
+            isEditable="true"
+            label="%SYNTAX_STRING_COLOR"
+            value="0,128,0">
+      </colorDefinition>
+      <colorDefinition
+            categoryId="org.eclipse.editors.syntaxColors"
+            id="org.eclipse.editors.syntax.commentColor"
+            isEditable="true"
+            label="%SYNTAX_COMMENT_COLOR"
+            value="128,0,0">
+      </colorDefinition>
+      <colorDefinition
+            categoryId="org.eclipse.editors.syntaxColors"
+            id="org.eclipse.editors.syntax.directiveColor"
+            isEditable="true"
+            label="%SYNTAX_DIRECTIVE_COLOR"
+            value="128,128,128">
+      </colorDefinition>
+
       <theme
 		  id="org.eclipse.ui.ide.systemDefault">
          <colorOverride

--- a/bundles/org.eclipse.ui.editors/src/org/eclipse/ui/editors/text/SyntaxThemeConstants.java
+++ b/bundles/org.eclipse.ui.editors/src/org/eclipse/ui/editors/text/SyntaxThemeConstants.java
@@ -1,0 +1,48 @@
+/*******************************************************************************
+ * Copyright (c) 2026 vogella GmbH and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Lars Vogel (vogella GmbH) - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.ui.editors.text;
+
+/**
+ * Theme color ids for syntax coloring. Editors should resolve them against the
+ * workbench {@code ColorRegistry} instead of defining colors of their own, so
+ * that editors follow the active theme consistently.
+ * <p>
+ * For the color of unstyled text use the editor foreground color instead.
+ * </p>
+ *
+ * @since 3.23
+ */
+public final class SyntaxThemeConstants {
+
+	/** Color of element and tag names. */
+	public static final String TAG_COLOR= "org.eclipse.editors.syntax.tagColor"; //$NON-NLS-1$
+
+	/** Color of attribute names. */
+	public static final String ATTRIBUTE_NAME_COLOR= "org.eclipse.editors.syntax.attributeNameColor"; //$NON-NLS-1$
+
+	/** Color of quoted values, for example attribute values and string literals. */
+	public static final String STRING_COLOR= "org.eclipse.editors.syntax.stringColor"; //$NON-NLS-1$
+
+	/** Color of comments. */
+	public static final String COMMENT_COLOR= "org.eclipse.editors.syntax.commentColor"; //$NON-NLS-1$
+
+	/**
+	 * Color of directives, for example an XML declaration, a document type
+	 * declaration, a preprocessor statement or a shebang line.
+	 */
+	public static final String DIRECTIVE_COLOR= "org.eclipse.editors.syntax.directiveColor"; //$NON-NLS-1$
+
+	private SyntaxThemeConstants() {
+	}
+}


### PR DESCRIPTION
PDE, Ant and the e4 model tooling each define their own colors for syntax coloring of the same XML-ish content (issue #4291). This adds one shared set to `org.eclipse.ui.editors`: theme color definitions for tag, attribute name, attribute value/string, comment and directive, with dark theme values, a "Syntax coloring" category in Colors and Fonts and the public `SyntaxThemeConstants` class.

An editor reusing these no longer needs its own color definitions, its own dark stylesheet or its own entry in the Colors and Fonts tree. The ids are `org.eclipse.editors.syntax.*` rather than tied to the contributing bundle, and the token names avoid XML wording, so `directiveColor` covers an XML declaration, a doctype, a preprocessor statement or a shebang alike and tokens like `keywordColor` can be added later. There is no constant for unstyled text on purpose, the existing editor foreground color covers it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qe7ZCgDF7UAGXk8VvqiPLz