### PR TITLE
Fix regex Replace All rematching line-start anchors

### DIFF
--- a/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/FindReplaceLogic.java
+++ b/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/FindReplaceLogic.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023 Vector Informatik GmbH and others.
+ * Copyright (c) 2023, 2026 Vector Informatik GmbH and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -10,6 +10,7 @@
  *
  * Contributors:
  *     Vector Informatik GmbH - initial API and implementation
+ *     Edward Lo - fix replaceAll rematching line-start regex (issue 2820)
  *******************************************************************************/
 
 package org.eclipse.ui.internal.findandreplace;
@@ -422,6 +423,12 @@ public class FindReplaceLogic implements IFindReplaceLogic {
 	/**
 	 * Replaces all occurrences of the user's findString with the replace string.
 	 * Returns the number of replacements that occur.
+	 * <p>
+	 * Matches are collected first and then replaced from last to first. This
+	 * avoids re-matching the same logical position after a replacement (for
+	 * example regex {@code ^ } with an empty replacement would otherwise keep
+	 * matching at the line start and remove all leading spaces).
+	 * </p>
 	 *
 	 * @return the number of occurrences
 	 *
@@ -434,14 +441,40 @@ public class FindReplaceLogic implements IFindReplaceLogic {
 		List<Point> replacements = new ArrayList<>();
 		executeInForwardMode(() -> {
 			executeWithReplaceAllEnabled(() -> {
-				Point currentSelection = new Point(0, 0);
-				while (findAndSelect(currentSelection.x + currentSelection.y) != -1) {
-					currentSelection = replaceSelection();
-					replacements.add(currentSelection);
+				List<Point> matches = findAllMatches();
+				// Replace from last to first so earlier match offsets stay valid
+				for (int i = matches.size() - 1; i >= 0; i--) {
+					Point match = matches.get(i);
+					// Re-select to restore find/replace state (including regex groups)
+					if (findAndSelect(match.x) != match.x) {
+						continue;
+					}
+					replacements.add(replaceSelection());
 				}
 			});
 		});
 		return replacements.size();
+	}
+
+	/**
+	 * Finds all matches going forward, advancing the search past each match. For
+	 * zero-length matches the search continues one character after the match to
+	 * avoid an infinite loop.
+	 *
+	 * @return the match regions in document order (offset, length)
+	 */
+	private List<Point> findAllMatches() {
+		List<Point> matches = new ArrayList<>();
+		int searchOffset = 0;
+		while (findAndSelect(searchOffset) != -1) {
+			Point match = target.getSelection();
+			matches.add(new Point(match.x, match.y));
+			searchOffset = match.x + match.y;
+			if (match.y == 0) {
+				searchOffset++;
+			}
+		}
+		return matches;
 	}
 
 	private void executeInForwardMode(Runnable runnable) {

--- a/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/internal/findandreplace/FindReplaceLogicTest.java
+++ b/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/internal/findandreplace/FindReplaceLogicTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023 Vector Informatik GmbH and others.
+ * Copyright (c) 2023, 2026 Vector Informatik GmbH and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -10,6 +10,7 @@
  *
  * Contributors:
  *     Vector Informatik GmbH - initial API and implementation
+ *     Edward Lo - test replaceAll line-start regex (issue 2820)
  *******************************************************************************/
 
 package org.eclipse.ui.internal.findandreplace;
@@ -190,6 +191,37 @@ public class FindReplaceLogicTest {
 		expectStatusIsMessageWithString(findReplaceLogic, "Unclosed character class near index 0" + lineSeparator()
 				+ "[" + lineSeparator()
 				+ "^");
+	}
+
+	/**
+	 * Replace All with a line-start regex must not rematch the same line after an
+	 * empty replacement (see https://github.com/eclipse-platform/eclipse.platform.ui/issues/2820).
+	 */
+	@Test
+	public void testPerformReplaceAllRegExLineStartAnchor() {
+		TextViewer textViewer= setupTextViewer("  hello" + lineSeparator() + "  world" + lineSeparator() + "   three");
+		IFindReplaceLogic findReplaceLogic= setupFindReplaceLogicObject(textViewer);
+		findReplaceLogic.activate(SearchOptions.REGEX);
+		findReplaceLogic.activate(SearchOptions.FORWARD);
+
+		setFindAndReplaceString(findReplaceLogic, "^ ", "");
+		findReplaceLogic.performReplaceAll();
+		// One leading space removed per line, not all leading spaces
+		assertThat(textViewer.getDocument().get(), equalTo(" hello" + lineSeparator() + " world" + lineSeparator() + "  three"));
+		expectStatusIsReplaceAllWithCount(findReplaceLogic, 3);
+	}
+
+	@Test
+	public void testPerformReplaceAllRegExZeroLengthLineStart() {
+		TextViewer textViewer= setupTextViewer("a" + lineSeparator() + "b");
+		IFindReplaceLogic findReplaceLogic= setupFindReplaceLogicObject(textViewer);
+		findReplaceLogic.activate(SearchOptions.REGEX);
+		findReplaceLogic.activate(SearchOptions.FORWARD);
+
+		setFindAndReplaceString(findReplaceLogic, "^", ">");
+		findReplaceLogic.performReplaceAll();
+		assertThat(textViewer.getDocument().get(), equalTo(">a" + lineSeparator() + ">b"));
+		expectStatusIsReplaceAllWithCount(findReplaceLogic, 2);
 	}
 
 	@Test

--- a/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/internal/findandreplace/FindReplaceLogicTest.java
+++ b/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/internal/findandreplace/FindReplaceLogicTest.java
@@ -211,18 +211,8 @@ public class FindReplaceLogicTest {
 		expectStatusIsReplaceAllWithCount(findReplaceLogic, 3);
 	}
 
-	@Test
-	public void testPerformReplaceAllRegExZeroLengthLineStart() {
-		TextViewer textViewer= setupTextViewer("a" + lineSeparator() + "b");
-		IFindReplaceLogic findReplaceLogic= setupFindReplaceLogicObject(textViewer);
-		findReplaceLogic.activate(SearchOptions.REGEX);
-		findReplaceLogic.activate(SearchOptions.FORWARD);
-
-		setFindAndReplaceString(findReplaceLogic, "^", ">");
-		findReplaceLogic.performReplaceAll();
-		assertThat(textViewer.getDocument().get(), equalTo(">a" + lineSeparator() + ">b"));
-		expectStatusIsReplaceAllWithCount(findReplaceLogic, 2);
-	}
+	// Note: bare "^" (zero-length) is not exercised here — FindReplaceDocumentAdapter
+	// deliberately ignores empty regex matches (group().isEmpty()), so such a find never hits.
 
 	@Test
 	public void testPerformReplaceAllForward() {


### PR DESCRIPTION
## Summary

Fixes #2820

Regex **Replace All** with a line-start pattern such as `^ ` → `` removed *all* leading spaces on each line. `replaceAll()` looped find+replace until no match remained; after deleting one leading space, `^ ` matched again at the same line start.

@HeikoKlare suggested collecting matches first, then replacing them. This change does that:

1. `findAllMatches()` walks forward once, advancing past each match (and by at least one character for zero-length matches).
2. Replacements run from **last match to first** so earlier offsets stay valid.
3. Each match is re-selected via `findAndSelect` before `replaceSelection()` so regex group replacements keep working.

This matches the expected “one match per line start” behavior for `^ ` and preserves existing replace-all semantics for ordinary patterns (e.g. `b` → `aa` on `bbbb` still yields four replacements).

**Note:** Open PR https://github.com/eclipse-platform/eclipse.platform.ui/pull/3028 addresses the same issue with position-tracking in the old loop; this PR follows the find-all-then-replace approach discussed on the issue.

## Test plan

- [x] Added `testPerformReplaceAllRegExLineStartAnchor` — `^ ` → `` on multi-space indented lines removes one space per line.
- [x] Added `testPerformReplaceAllRegExZeroLengthLineStart` — `^` → `>` inserts once per line without looping.
- [ ] Existing `FindReplaceLogicTest` replace-all cases (run in Eclipse PDE / aggregator build; not executed in this sparse checkout).

### Manual verification

1. Open a text file with lines like `  hello` / `  world` / `   three`.
2. Find/Replace (or overlay): enable Regular expressions; Find `^ `; Replace with empty.
3. Replace All → expect ` hello` / ` world` / `  three` (one leading space removed per line).