### PR TITLE
Draw squiggles and folding dots in points on scaled displays

### DIFF
--- a/bundles/org.eclipse.jface.text/projection/org/eclipse/jface/text/source/projection/ProjectionSupport.java
+++ b/bundles/org.eclipse.jface.text/projection/org/eclipse/jface/text/source/projection/ProjectionSupport.java
@@ -98,7 +98,9 @@ public class ProjectionSupport {
 						Point p= textWidget.getLocationAtOffset(lineEnd);
 
 						Color c= gc.getForeground();
+						Color bg= gc.getBackground();
 						gc.setForeground(color);
+						gc.setBackground(color);
 
 						FontMetrics metrics= gc.getFontMetrics();
 
@@ -117,10 +119,12 @@ public class ProjectionSupport {
 						gc.drawRectangle(p.x, p.y + leading, (int) width, height);
 						int third= (int) (width / 3);
 						int dotsVertical= p.y + baseline - 1;
-						gc.drawPoint(p.x + third, dotsVertical);
-						gc.drawPoint((int) (p.x + width - third), dotsVertical);
+						// drawPoint stays one device pixel on Windows
+						gc.fillRectangle(p.x + third, dotsVertical, 1, 1);
+						gc.fillRectangle((int) (p.x + width - third), dotsVertical, 1, 1);
 
 						gc.setForeground(c);
+						gc.setBackground(bg);
 
 					} else {
 						textWidget.redrawRange(offset, length, true);

--- a/bundles/org.eclipse.jface.text/src/org/eclipse/jface/text/source/AnnotationPainter.java
+++ b/bundles/org.eclipse.jface.text/src/org/eclipse/jface/text/source/AnnotationPainter.java
@@ -130,10 +130,14 @@ public class AnnotationPainter implements IPainter, PaintListener, IAnnotationMo
 
 				int[] polyline= computePolyline(left, right, textWidget.getBaseline(offset), textWidget.getLineHeight(offset));
 
-				gc.setLineWidth(0); // NOTE: 0 means width is 1 but with optimized performance
+				// width 0 stays one device pixel on Windows while the zigzag scales
+				gc.setLineWidth(1);
 				gc.setLineStyle(SWT.LINE_SOLID);
 				gc.setForeground(color);
+				int antialias= gc.getAntialias();
+				gc.setAntialias(SWT.ON);
 				gc.drawPolyline(polyline);
+				gc.setAntialias(antialias);
 
 			} else {
 				textWidget.redrawRange(offset, length, true);


### PR DESCRIPTION
`AnnotationPainter.SquigglesStrategy` draws its zigzag with line width 0 and the collapsed region marker of `ProjectionSupport` draws its two dots with `drawPoint`.
On Windows both stay one device pixel while the geometry around them scales, so they get thinner the higher the zoom.
This draws the squiggle as a 1 point antialiased line and the dots as 1 point squares, which is what GTK already renders.
On Linux GTK at 200 percent, before and after captures of the marker and of a `SquigglesStrategy` squiggle are pixel identical, as expected.
Note that the SDK editors draw squiggles through `UnderlineStrategy`, so that part mainly helps clients of the deprecated strategy.
Windows screenshots will be added in the next days.
