### PR TITLE
Use the new bundle name of the JSch library

### DIFF
--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/releng/PluginActivationTests.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/releng/PluginActivationTests.java
@@ -47,7 +47,7 @@ public class PluginActivationTests {
 
 	private static List<String> NOT_ACTIVE_BUNDLES = List.of(
 			"org.apache.xerces",
-			"com.jcraft.jsch",
+			"com.github.mwiede.jsch",
 			"javax.servlet",
 			"javax.servlet.jsp-api",
 			"org.apache.ant",


### PR DESCRIPTION
The Platform switched from com.jcraft.jsch to com.github.mwiede.jsch. An unknown name is silently skipped, so the assertion was lost.

https://github.com/eclipse-platform/eclipse.platform/issues/958

Assisted-by: Anthropic Claude Code (claude-opus-5[1m])