### PR TITLE
Find/Replace overlay: derive its host control from the workbench part

### DIFF
--- a/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/overlay/FindReplaceOverlay.java
+++ b/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/overlay/FindReplaceOverlay.java
@@ -202,10 +202,10 @@ public class FindReplaceOverlay {
 		}
 	}
 
-	public FindReplaceOverlay(Shell parent, IWorkbenchPart part, IFindReplaceTarget target) {
+	public FindReplaceOverlay(IWorkbenchPart part, IFindReplaceTarget target) {
 		targetPart = part;
 		commandSupport = new FindReplaceOverlayCommandSupport(targetPart);
-		targetControl = getTargetControl(parent, part);
+		targetControl = getTargetControl(part);
 		findReplaceLogic = createFindReplaceLogic(target);
 		createContainerAndSearchControls(targetControl);
 		containerControl.addDisposeListener(__ -> commandSupport.dispose());
@@ -216,12 +216,15 @@ public class FindReplaceOverlay {
 				IAbstractTextEditorHelpContextIds.FIND_REPLACE_OVERLAY);
 	}
 
-	private static Composite getTargetControl(Shell targetShell, IWorkbenchPart targetPart) {
-		if (targetPart instanceof StatusTextEditor textEditor) {
-			return textEditor.getAdapter(ITextViewer.class).getTextWidget();
-		} else {
-			return targetShell;
+	private static Composite getTargetControl(IWorkbenchPart targetPart) {
+		if (targetPart == null) {
+			return null;
 		}
+		ITextViewer viewer = targetPart.getAdapter(ITextViewer.class);
+		if (viewer != null) {
+			return viewer.getTextWidget();
+		}
+		return null;
 	}
 
 	private boolean insertedInTargetParent() {

--- a/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/texteditor/FindReplaceAction.java
+++ b/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/texteditor/FindReplaceAction.java
@@ -418,14 +418,7 @@ public class FindReplaceAction extends ResourceAction implements IUpdate {
 
 	private void showOverlayInEditor() {
 		if (overlay == null) {
-			Shell shellToUse = null;
-
-			if (fShell == null) {
-				shellToUse = fWorkbenchPart.getSite().getShell();
-			} else {
-				shellToUse = fShell;
-			}
-			overlay = new FindReplaceOverlay(shellToUse, fWorkbenchPart, fTarget);
+			overlay = new FindReplaceOverlay(fWorkbenchPart, fTarget);
 		}
 
 		overlay.open();

--- a/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/internal/findandreplace/FindReplaceUITest.java
+++ b/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/internal/findandreplace/FindReplaceUITest.java
@@ -17,8 +17,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import java.util.ResourceBundle;
-
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -64,9 +62,10 @@ public abstract class FindReplaceUITest<AccessType extends IFindReplaceUIAccess>
 		fTextViewer= new TextViewer(PlatformUI.getWorkbench().getActiveWorkbenchWindow().getShell(), SWT.BORDER | SWT.V_SCROLL | SWT.H_SCROLL);
 		fTextViewer.setDocument(new Document(content));
 		fTextViewer.getControl().setFocus();
-		findReplaceAction= new FindReplaceAction(ResourceBundle.getBundle("org.eclipse.ui.texteditor.ConstructedEditorMessages"), "Editor.FindReplace.", fTextViewer.getControl().getShell(),
-				fTextViewer.getFindReplaceTarget());
+		findReplaceAction= initializeFindReplaceAction();
 	}
+
+	protected abstract FindReplaceAction initializeFindReplaceAction();
 
 	protected void initializeFindReplaceUIForTextViewer() {
 		dialog= openUIFromTextViewer(fTextViewer);

--- a/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/internal/findandreplace/overlay/FindReplaceOverlayTest.java
+++ b/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/internal/findandreplace/overlay/FindReplaceOverlayTest.java
@@ -20,11 +20,16 @@ import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
+
+import java.util.ResourceBundle;
 
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.graphics.Point;
+import org.eclipse.swt.graphics.Rectangle;
 
 import org.eclipse.core.runtime.preferences.IEclipsePreferences;
 import org.eclipse.core.runtime.preferences.InstanceScope;
@@ -36,8 +41,12 @@ import org.eclipse.jface.viewers.ISelection;
 
 import org.eclipse.jface.text.IFindReplaceTarget;
 import org.eclipse.jface.text.IMultiTextSelection;
+import org.eclipse.jface.text.ITextViewer;
 import org.eclipse.jface.text.TextViewer;
 
+import org.eclipse.ui.IWorkbenchPart;
+import org.eclipse.ui.IWorkbenchPartSite;
+import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.internal.findandreplace.FindReplaceUITest;
 import org.eclipse.ui.internal.findandreplace.SearchOptions;
 
@@ -49,6 +58,8 @@ public class FindReplaceOverlayTest extends FindReplaceUITest<OverlayAccess> {
 
 	private static final String USE_FIND_REPLACE_OVERLAY= "useFindReplaceOverlay"; //$NON-NLS-1$
 
+	private static final Rectangle VIEWER_BOUNDS= new Rectangle(0, 0, 800, 400);
+
 	@Override
 	public OverlayAccess openUIFromTextViewer(TextViewer viewer) {
 		Accessor actionAccessor= new Accessor(getFindReplaceAction(), FindReplaceAction.class);
@@ -57,6 +68,27 @@ public class FindReplaceOverlayTest extends FindReplaceUITest<OverlayAccess> {
 		OverlayAccess uiAccess= new OverlayAccess(getFindReplaceTarget(), overlay);
 		waitForFocus(uiAccess::hasFocus, testInfo.getTestMethod().get().getName());
 		return uiAccess;
+	}
+
+	@Override
+	protected FindReplaceAction initializeFindReplaceAction() {
+		return new FindReplaceAction(
+				ResourceBundle.getBundle("org.eclipse.ui.texteditor.ConstructedEditorMessages"),
+				"Editor.FindReplace.", createHostPart(getTextViewer()));
+	}
+
+	private static IWorkbenchPart createHostPart(TextViewer viewer) {
+		// Nothing lays the viewer out in the workbench window's shell, where the test
+		// creates it, whereas the overlay needs a host control of a reasonable size.
+		viewer.getTextWidget().setBounds(VIEWER_BOUNDS);
+
+		IWorkbenchPartSite site= Mockito.mock(IWorkbenchPartSite.class);
+		when(site.getWorkbenchWindow()).thenReturn(PlatformUI.getWorkbench().getActiveWorkbenchWindow());
+		IWorkbenchPart part= Mockito.mock(IWorkbenchPart.class);
+		when(part.getSite()).thenReturn(site);
+		when(part.getAdapter(ITextViewer.class)).thenReturn(viewer);
+		when(part.getAdapter(IFindReplaceTarget.class)).thenReturn(viewer.getFindReplaceTarget());
+		return part;
 	}
 
 	@Test

--- a/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/workbench/texteditor/tests/FindReplaceDialogTest.java
+++ b/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/workbench/texteditor/tests/FindReplaceDialogTest.java
@@ -21,6 +21,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assumptions.assumeFalse;
 
+import java.util.ResourceBundle;
+
 import org.junit.jupiter.api.Test;
 
 import org.eclipse.swt.SWT;
@@ -56,6 +58,13 @@ public class FindReplaceDialogTest extends FindReplaceUITest<DialogAccess> {
 		DialogAccess uiAccess= new DialogAccess(getFindReplaceTarget(), dialog);
 		waitForFocus(uiAccess::hasFocus, testInfo.getTestMethod().get().getName());
 		return uiAccess;
+	}
+
+	@Override
+	protected FindReplaceAction initializeFindReplaceAction() {
+		return new FindReplaceAction(ResourceBundle.getBundle("org.eclipse.ui.texteditor.ConstructedEditorMessages"), "Editor.FindReplace.",
+				getTextViewer().getControl().getShell(),
+				getTextViewer().getFindReplaceTarget());
 	}
 
 	@Test


### PR DESCRIPTION
The overlay used to be constructed with a shell beside the part it is opened on, and it placed itself into that shell whenever that part was not a text editor. Nothing in the product ever took that path: the shell was there so that the find/replace UI tests, which run on a bare text viewer, had somewhere to put the overlay. Production API thus carried a parameter that only the tests needed.

The overlay now always takes its host control from the text viewer of the part it is opened on, which removes the shell parameter from `FindReplaceOverlay` and from the overlay path of `FindReplaceAction`. The tests provide a part wrapping their viewer instead, for which a mocked one is enough: the overlay asks a part for no more than the viewer to place itself on, the target to search in and the window its commands belong to. Exercising the overlay on a real editor remains the subject of `FindReplaceOverlayInEditorTest`.

This is not meant to change behavior. The overlay is still used for `StatusTextEditor`s only, and for those the host control is the same widget as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)