### PR TITLE
Version bumps for new stream

### DIFF
--- a/tests/org.eclipse.core.filebuffers.tests/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.core.filebuffers.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Plugin.name
 Bundle-SymbolicName: org.eclipse.core.filebuffers.tests;singleton:=true
-Bundle-Version: 3.14.100.qualifier
+Bundle-Version: 3.14.200.qualifier
 Bundle-Activator: org.eclipse.core.filebuffers.tests.FileBuffersTestPlugin
 Bundle-ActivationPolicy: lazy
 Bundle-Vendor: %Plugin.providerName

--- a/tests/org.eclipse.text.tests/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.text.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Plugin.name
 Bundle-SymbolicName: org.eclipse.text.tests
-Bundle-Version: 3.15.0.qualifier
+Bundle-Version: 3.15.100.qualifier
 Bundle-Vendor: %Plugin.providerName
 Bundle-Localization: plugin
 Export-Package: 


### PR DESCRIPTION
Reported in
https://download.eclipse.org/eclipse/downloads/drops4/I20260911-2300/buildlogs/reporeports/reports/versionChecks.html .