### PR TITLE
Find/Replace tests: drop the Hamcrest dependency

### DIFF
--- a/tests/org.eclipse.ui.workbench.texteditor.tests/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.ui.workbench.texteditor.tests/META-INF/MANIFEST.MF
@@ -21,8 +21,7 @@ Require-Bundle:
 Bundle-RequiredExecutionEnvironment: JavaSE-21
 Eclipse-BundleShape: dir
 Automatic-Module-Name: org.eclipse.ui.workbench.texteditor.tests
-Import-Package: org.hamcrest;version="[3.0.0,4.0.0)",
- org.junit.jupiter.api;version="[5.14.0,6.0.0)",
+Import-Package: org.junit.jupiter.api;version="[5.14.0,6.0.0)",
  org.junit.jupiter.api.function;version="[5.14.0,6.0.0)",
  org.junit.platform.suite.api;version="[1.14.0,2.0.0)",
  org.mockito,

--- a/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/internal/findandreplace/FindReplaceLogicTest.java
+++ b/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/internal/findandreplace/FindReplaceLogicTest.java
@@ -15,13 +15,10 @@
 package org.eclipse.ui.internal.findandreplace;
 
 import static java.lang.System.lineSeparator;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.instanceOf;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.not;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyInt;
@@ -129,33 +126,33 @@ public class FindReplaceLogicTest {
 
 		setFindAndReplaceString(findReplaceLogic, "a", "b");
 		findReplaceLogic.performReplaceAll();
-		assertThat(textViewer.getDocument().get(), equalTo("bbbb"));
+		assertEquals("bbbb", textViewer.getDocument().get());
 		expectStatusIsReplaceAllWithCount(findReplaceLogic, 4);
 
 		setFindAndReplaceString(findReplaceLogic, "b", "aa");
 		findReplaceLogic.performReplaceAll();
-		assertThat(textViewer.getDocument().get(), equalTo("aaaaaaaa"));
+		assertEquals("aaaaaaaa", textViewer.getDocument().get());
 		expectStatusIsReplaceAllWithCount(findReplaceLogic, 4);
 
 		setFindAndReplaceString(findReplaceLogic, "b", "c");
 		findReplaceLogic.performReplaceAll();
-		assertThat(textViewer.getDocument().get(), equalTo("aaaaaaaa"));
+		assertEquals("aaaaaaaa", textViewer.getDocument().get());
 		expectStatusIsCode(findReplaceLogic, FindStatus.StatusCode.NO_MATCH);
 
 		setFindAndReplaceString(findReplaceLogic, "aaaaaaaa", "d");
 		findReplaceLogic.performReplaceAll(); // https://github.com/eclipse-platform/eclipse.platform.ui/issues/1203
-		assertThat(textViewer.getDocument().get(), equalTo("d"));
+		assertEquals("d", textViewer.getDocument().get());
 		expectStatusIsReplaceAllWithCount(findReplaceLogic, 1);
 
 		setFindAndReplaceString(findReplaceLogic, "d", "");
 		findReplaceLogic.performReplaceAll();
-		assertThat(textViewer.getDocument().get(), equalTo(""));
+		assertEquals("", textViewer.getDocument().get());
 		expectStatusIsReplaceAllWithCount(findReplaceLogic, 1);
 
 		textViewer.getDocument().set("f");
 		setFindAndReplaceString(findReplaceLogic, "f", "");
 		findReplaceLogic.performReplaceAll();
-		assertThat(textViewer.getDocument().get(), equalTo(""));
+		assertEquals("", textViewer.getDocument().get());
 		expectStatusIsReplaceAllWithCount(findReplaceLogic, 1);
 
 		IFindReplaceTarget mockFindReplaceTarget= Mockito.mock(IFindReplaceTarget.class);
@@ -176,17 +173,17 @@ public class FindReplaceLogicTest {
 
 		setFindAndReplaceString(findReplaceLogic, ".+\\@.+\\.com", "");
 		findReplaceLogic.performReplaceAll();
-		assertThat(textViewer.getDocument().get(), equalTo(" looks.almost@like_an_email"));
+		assertEquals(" looks.almost@like_an_email", textViewer.getDocument().get());
 		expectStatusIsReplaceAllWithCount(findReplaceLogic, 1);
 
 		setFindAndReplaceString(findReplaceLogic, "( looks.)|(like_)", "");
 		findReplaceLogic.performReplaceAll();
-		assertThat(textViewer.getDocument().get(), equalTo("almost@an_email"));
+		assertEquals("almost@an_email", textViewer.getDocument().get());
 		expectStatusIsReplaceAllWithCount(findReplaceLogic, 2);
 
 		setFindAndReplaceString(findReplaceLogic, "[", "");
 		findReplaceLogic.performReplaceAll();
-		assertThat(textViewer.getDocument().get(), equalTo("almost@an_email"));
+		assertEquals("almost@an_email", textViewer.getDocument().get());
 		expectStatusIsMessageWithString(findReplaceLogic, "Unclosed character class near index 0" + lineSeparator()
 				+ "[" + lineSeparator()
 				+ "^");
@@ -201,17 +198,17 @@ public class FindReplaceLogicTest {
 
 		setFindAndReplaceString(findReplaceLogic, ".+\\@.+\\.com", "");
 		findReplaceLogic.performReplaceAll();
-		assertThat(textViewer.getDocument().get(), equalTo(" looks.almost@like_an_email"));
+		assertEquals(" looks.almost@like_an_email", textViewer.getDocument().get());
 		expectStatusIsReplaceAllWithCount(findReplaceLogic, 1);
 
 		setFindAndReplaceString(findReplaceLogic, "( looks.)|(like_)", "");
 		findReplaceLogic.performReplaceAll();
-		assertThat(textViewer.getDocument().get(), equalTo("almost@an_email"));
+		assertEquals("almost@an_email", textViewer.getDocument().get());
 		expectStatusIsReplaceAllWithCount(findReplaceLogic, 2);
 
 		setFindAndReplaceString(findReplaceLogic, "[", "");
 		findReplaceLogic.performReplaceAll();
-		assertThat(textViewer.getDocument().get(), equalTo("almost@an_email"));
+		assertEquals("almost@an_email", textViewer.getDocument().get());
 		expectStatusIsMessageWithString(findReplaceLogic, "Unclosed character class near index 0" + lineSeparator()
 				+ "[" + lineSeparator()
 				+ "^");
@@ -226,11 +223,11 @@ public class FindReplaceLogicTest {
 
 		findReplaceLogic.performSearch(); // select first, then replace. We don't need to perform a second search
 		findReplaceLogic.performSelectAndReplace();
-		assertThat(textViewer.getDocument().get(), equalTo("Hello World<replace>!"));
+		assertEquals("Hello World<replace>!", textViewer.getDocument().get());
 		expectStatusEmpty(findReplaceLogic);
 
 		findReplaceLogic.performSelectAndReplace(); // perform the search yourself and replace that automatically
-		assertThat(textViewer.getDocument().get(), equalTo("Hello World !"));
+		assertEquals("Hello World !", textViewer.getDocument().get());
 		expectStatusEmpty(findReplaceLogic);
 	}
 
@@ -245,12 +242,12 @@ public class FindReplaceLogicTest {
 		findReplaceLogic.performSearch();
 		boolean status= findReplaceLogic.performSelectAndReplace();
 		assertTrue(status);
-		assertThat(textViewer.getDocument().get(), equalTo("Hello World<replace>!"));
+		assertEquals("Hello World<replace>!", textViewer.getDocument().get());
 		expectStatusEmpty(findReplaceLogic);
 
 		status= findReplaceLogic.performSelectAndReplace();
 		assertTrue(status);
-		assertThat(textViewer.getDocument().get(), equalTo("Hello World !"));
+		assertEquals("Hello World !", textViewer.getDocument().get());
 		expectStatusEmpty(findReplaceLogic);
 
 		status= findReplaceLogic.performSelectAndReplace();
@@ -273,10 +270,10 @@ public class FindReplaceLogicTest {
 		setFindAndReplaceString(findReplaceLogic, "o$", "o!");
 		boolean status= findReplaceLogic.performSelectAndReplace();
 		assertTrue(status);
-		assertThat(textViewer.getDocument().get(), equalTo("""
+		assertEquals("""
 				Hello!
 				World
-				!"""));
+				!""", textViewer.getDocument().get());
 		expectStatusEmpty(findReplaceLogic);
 
 		setFindAndReplaceString(findReplaceLogic, """
@@ -284,9 +281,9 @@ public class FindReplaceLogicTest {
 				!""", "d!");
 		status= findReplaceLogic.performSelectAndReplace();
 		assertTrue(status);
-		assertThat(textViewer.getDocument().get(), equalTo("""
+		assertEquals("""
 				Hello!
-				World!"""));
+				World!""", textViewer.getDocument().get());
 		expectStatusEmpty(findReplaceLogic);
 
 		setFindAndReplaceString(findReplaceLogic, """
@@ -308,21 +305,21 @@ public class FindReplaceLogicTest {
 		setFindAndReplaceString(findReplaceLogic, "<(\\w*)>", " ");
 		boolean status= findReplaceLogic.performSelectAndReplace();
 		assertTrue(status);
-		assertThat(textViewer.getDocument().get(), equalTo("Hello World<replace>!<replace>!"));
+		assertEquals("Hello World<replace>!<replace>!", textViewer.getDocument().get());
 		expectStatusEmpty(findReplaceLogic);
 
 		setFindAndReplaceString(findReplaceLogic, "<replace>", " ");
 		findReplaceLogic.deactivate(SearchOptions.REGEX);
 		status= findReplaceLogic.performSelectAndReplace();
 		assertTrue(status);
-		assertThat(textViewer.getDocument().get(), equalTo("Hello World !<replace>!"));
+		assertEquals("Hello World !<replace>!", textViewer.getDocument().get());
 		expectStatusEmpty(findReplaceLogic);
 
 		setFindAndReplaceString(findReplaceLogic, "<(\\w*)>", " ");
 		findReplaceLogic.activate(SearchOptions.REGEX);
 		status= findReplaceLogic.performSelectAndReplace();
 		assertTrue(status);
-		assertThat(textViewer.getDocument().get(), equalTo("Hello World ! !"));
+		assertEquals("Hello World ! !", textViewer.getDocument().get());
 		expectStatusEmpty(findReplaceLogic);
 
 		status= findReplaceLogic.performSelectAndReplace();
@@ -342,10 +339,10 @@ public class FindReplaceLogicTest {
 		findReplaceLogic.performSearch(); // select first, then replace. We don't need to perform a second search
 		expectStatusIsCode(findReplaceLogic, FindStatus.StatusCode.WRAPPED);
 		findReplaceLogic.performSelectAndReplace();
-		assertThat(textViewer.getDocument().get(), equalTo("Hello<replace>World !"));
+		assertEquals("Hello<replace>World !", textViewer.getDocument().get());
 
 		findReplaceLogic.performSelectAndReplace(); // perform the search yourself and replace that automatically
-		assertThat(textViewer.getDocument().get(), equalTo("Hello World !"));
+		assertEquals("Hello World !", textViewer.getDocument().get());
 		expectStatusEmpty(findReplaceLogic);
 	}
 
@@ -358,14 +355,14 @@ public class FindReplaceLogicTest {
 
 		boolean status= findReplaceLogic.performReplaceAndFind();
 		assertTrue(status, "replace should have been performed");
-		assertThat(textViewer.getDocument().get(), equalTo("Hello World<replace>!"));
-		assertThat(findReplaceLogic.getTarget().getSelectionText(), equalTo("<replace>"));
+		assertEquals("Hello World<replace>!", textViewer.getDocument().get());
+		assertEquals("<replace>", findReplaceLogic.getTarget().getSelectionText());
 		expectStatusEmpty(findReplaceLogic);
 
 		setFindAndReplaceString(findReplaceLogic, "<replace>", " ");
 		status= findReplaceLogic.performReplaceAndFind();
 		assertTrue(status, "replace should have been performed");
-		assertThat(textViewer.getDocument().get(), equalTo("Hello World !"));
+		assertEquals("Hello World !", textViewer.getDocument().get());
 		expectStatusIsCode(findReplaceLogic, FindStatus.StatusCode.NO_MATCH);
 
 		status= findReplaceLogic.performReplaceAndFind();
@@ -384,13 +381,13 @@ public class FindReplaceLogicTest {
 
 		boolean status= findReplaceLogic.performReplaceAndFind();
 		assertTrue(status, "replace should have been performed");
-		assertThat(textViewer.getDocument().get(), equalTo("Hello<Replace>World !"));
-		assertThat(findReplaceLogic.getTarget().getSelectionText(), equalTo(" "));
+		assertEquals("Hello<Replace>World !", textViewer.getDocument().get());
+		assertEquals(" ", findReplaceLogic.getTarget().getSelectionText());
 
 		status= findReplaceLogic.performReplaceAndFind();
 		assertFalse(status, "replace should not have been performed");
-		assertThat(textViewer.getDocument().get(), equalTo("Hello<Replace>World !"));
-		assertThat(findReplaceLogic.getTarget().getSelectionText(), equalTo(" "));
+		assertEquals("Hello<Replace>World !", textViewer.getDocument().get());
+		assertEquals(" ", findReplaceLogic.getTarget().getSelectionText());
 	}
 
 	@Test
@@ -403,14 +400,14 @@ public class FindReplaceLogicTest {
 
 		boolean status= findReplaceLogic.performReplaceAndFind();
 		assertTrue(status, "replace should have been performed");
-		assertThat(textViewer.getDocument().get(), equalTo("Hello World<replace>!"));
-		assertThat(findReplaceLogic.getTarget().getSelectionText(), equalTo("<replace>"));
+		assertEquals("Hello World<replace>!", textViewer.getDocument().get());
+		assertEquals("<replace>", findReplaceLogic.getTarget().getSelectionText());
 		expectStatusEmpty(findReplaceLogic);
 
 		setFindAndReplaceString(findReplaceLogic, "<replace>", " ");
 		status= findReplaceLogic.performReplaceAndFind();
 		assertTrue(status, "replace should have been performed");
-		assertThat(textViewer.getDocument().get(), equalTo("Hello World !"));
+		assertEquals("Hello World !", textViewer.getDocument().get());
 		expectStatusIsCode(findReplaceLogic, FindStatus.StatusCode.NO_MATCH);
 
 		status= findReplaceLogic.performReplaceAndFind();
@@ -450,16 +447,16 @@ public class FindReplaceLogicTest {
 		setFindAndReplaceString(findReplaceLogic, "Hello", "Hello\\");
 		boolean status= findReplaceLogic.performReplaceAndFind();
 		assertFalse(status);
-		assertThat(textViewer.getDocument().get(), equalTo("Hello"));
-		assertThat(findReplaceLogic.getTarget().getSelectionText(), equalTo("Hello"));
-		assertThat(findReplaceLogic.getStatus(), instanceOf(InvalidRegExStatus.class));
+		assertEquals("Hello", textViewer.getDocument().get());
+		assertEquals("Hello", findReplaceLogic.getTarget().getSelectionText());
+		assertInstanceOf(InvalidRegExStatus.class, findReplaceLogic.getStatus());
 
 		setFindAndReplaceString(findReplaceLogic, "Hello", "Hello" + System.lineSeparator());
 
 		status= findReplaceLogic.performReplaceAndFind();
 		assertTrue(status);
-		assertThat(textViewer.getDocument().get(), equalTo("Hello" + System.lineSeparator()));
-		assertThat(findReplaceLogic.getTarget().getSelectionText(), equalTo("Hello" + System.lineSeparator()));
+		assertEquals("Hello" + System.lineSeparator(), textViewer.getDocument().get());
+		assertEquals("Hello" + System.lineSeparator(), findReplaceLogic.getTarget().getSelectionText());
 		expectStatusIsCode(findReplaceLogic, FindStatus.StatusCode.NO_MATCH);
 	}
 
@@ -468,20 +465,20 @@ public class FindReplaceLogicTest {
 
 		boolean status= findReplaceLogic.performReplaceAndFind();
 		assertTrue(status);
-		assertThat(textViewer.getDocument().get(), equalTo("Hello World<replace>!<r>!"));
-		assertThat(findReplaceLogic.getTarget().getSelectionText(), equalTo("<replace>"));
+		assertEquals("Hello World<replace>!<r>!", textViewer.getDocument().get());
+		assertEquals("<replace>", findReplaceLogic.getTarget().getSelectionText());
 		expectStatusEmpty(findReplaceLogic);
 
 		status= findReplaceLogic.performReplaceAndFind();
 		assertTrue(status);
-		assertThat(textViewer.getDocument().get(), equalTo("Hello World !<r>!"));
-		assertThat(findReplaceLogic.getTarget().getSelectionText(), equalTo("<r>"));
+		assertEquals("Hello World !<r>!", textViewer.getDocument().get());
+		assertEquals("<r>", findReplaceLogic.getTarget().getSelectionText());
 		expectStatusEmpty(findReplaceLogic);
 
 		setFindAndReplaceString(findReplaceLogic, "<(\\w)>", " ");
 		status= findReplaceLogic.performReplaceAndFind();
 		assertTrue(status);
-		assertThat(textViewer.getDocument().get(), equalTo("Hello World ! !"));
+		assertEquals("Hello World ! !", textViewer.getDocument().get());
 		expectStatusIsCode(findReplaceLogic, FindStatus.StatusCode.NO_MATCH);
 
 		setFindAndReplaceString(findReplaceLogic, "<(\\w*)>", " ");
@@ -604,7 +601,7 @@ public class FindReplaceLogicTest {
 		findReplaceLogic.performReplaceAll();
 
 		expectStatusIsReplaceAllWithCount(findReplaceLogic, 1);
-		assertThat(textViewer.getTextWidget().getText(), is("line1" + lineSeparator() + "ine2" + lineSeparator() + "line3"));
+		assertEquals("line1" + lineSeparator() + "ine2" + lineSeparator() + "line3", textViewer.getTextWidget().getText());
 	}
 
 	@Test
@@ -620,7 +617,7 @@ public class FindReplaceLogicTest {
 		findReplaceLogic.performReplaceAll();
 
 		expectStatusIsReplaceAllWithCount(findReplaceLogic, 1);
-		assertThat(textViewer.getTextWidget().getText(), is("line1" + lineSeparator() + "ine2" + lineSeparator() + "line3"));
+		assertEquals("line1" + lineSeparator() + "ine2" + lineSeparator() + "line3", textViewer.getTextWidget().getText());
 	}
 
 	@Test
@@ -636,7 +633,7 @@ public class FindReplaceLogicTest {
 		findReplaceLogic.performReplaceAll();
 
 		expectStatusIsReplaceAllWithCount(findReplaceLogic, 1);
-		assertThat(textViewer.getTextWidget().getText(), is("line1" + lineSeparator() + "ine2" + lineSeparator() + "line3"));
+		assertEquals("line1" + lineSeparator() + "ine2" + lineSeparator() + "line3", textViewer.getTextWidget().getText());
 	}
 
 	@Test
@@ -652,7 +649,7 @@ public class FindReplaceLogicTest {
 		findReplaceLogic.performReplaceAll();
 
 		expectStatusIsReplaceAllWithCount(findReplaceLogic, 2);
-		assertThat(textViewer.getTextWidget().getText(), is("line1" + lineSeparator() + "ine2" + lineSeparator() + "ine3"));
+		assertEquals("line1" + lineSeparator() + "ine2" + lineSeparator() + "ine3", textViewer.getTextWidget().getText());
 	}
 
 	@Test
@@ -670,7 +667,7 @@ public class FindReplaceLogicTest {
 
 		// Selection ending at beginning of new line should not include that line in search scope
 		expectStatusIsReplaceAllWithCount(findReplaceLogic, 1);
-		assertThat(textViewer.getTextWidget().getText(), is("line1" + lineSeparator() + "ine2" + lineSeparator() + "line3"));
+		assertEquals("line1" + lineSeparator() + "ine2" + lineSeparator() + "line3", textViewer.getTextWidget().getText());
 	}
 
 	@Test
@@ -688,7 +685,7 @@ public class FindReplaceLogicTest {
 		findReplaceLogic.performReplaceAll();
 
 		expectStatusIsReplaceAllWithCount(findReplaceLogic, 1);
-		assertThat(textViewer.getTextWidget().getText(), is("ine1" + lineSeparator() + "line2" + lineSeparator() + "line3"));
+		assertEquals("ine1" + lineSeparator() + "line2" + lineSeparator() + "line3", textViewer.getTextWidget().getText());
 	}
 
 	@Test
@@ -743,15 +740,15 @@ public class FindReplaceLogicTest {
 		findReplaceLogic.activate(SearchOptions.WRAP);
 		setFindAndReplaceString(findReplaceLogic, LINE_STRING, "");
 		findReplaceLogic.performSelectAndReplace();
-		assertThat(textViewer.getTextWidget().getText(), is(LINE_STRING + lineSeparator() + lineSeparator() + LINE_STRING));
+		assertEquals(LINE_STRING + lineSeparator() + lineSeparator() + LINE_STRING, textViewer.getTextWidget().getText());
 		expectStatusEmpty(findReplaceLogic);
 
 		findReplaceLogic.performSelectAndReplace();
-		assertThat(textViewer.getTextWidget().getText(), is(LINE_STRING + lineSeparator() + lineSeparator()));
+		assertEquals(LINE_STRING + lineSeparator() + lineSeparator(), textViewer.getTextWidget().getText());
 		expectStatusEmpty(findReplaceLogic);
 
 		findReplaceLogic.performSelectAndReplace();
-		assertThat(textViewer.getTextWidget().getText(), is(LINE_STRING + lineSeparator() + lineSeparator()));
+		assertEquals(LINE_STRING + lineSeparator() + lineSeparator(), textViewer.getTextWidget().getText());
 		expectStatusIsCode(findReplaceLogic, StatusCode.NO_MATCH);
 	}
 
@@ -766,8 +763,8 @@ public class FindReplaceLogicTest {
 		findReplaceLogic.setFindString(LINE_STRING);
 		findReplaceLogic.performSearch();
 		expectStatusEmpty(findReplaceLogic);
-		assertThat(findReplaceLogic.getTarget().getSelection().x, not(is(0)));
-		assertThat(findReplaceLogic.getTarget().getSelection().x, not(is(textViewer.getDocument().get().length() - LINE_STRING_LENGTH)));
+		assertNotEquals(0, findReplaceLogic.getTarget().getSelection().x);
+		assertNotEquals(textViewer.getDocument().get().length() - LINE_STRING_LENGTH, findReplaceLogic.getTarget().getSelection().x);
 	}
 
 	/**
@@ -810,9 +807,9 @@ public class FindReplaceLogicTest {
 		setFindAndReplaceString(findReplaceLogic, LINE_STRING, "");
 
 		findReplaceLogic.performSelectAndReplace();
-		assertThat(textViewer.getTextWidget().getText(), is(LINE_STRING + lineSeparator()));
+		assertEquals(LINE_STRING + lineSeparator(), textViewer.getTextWidget().getText());
 		findReplaceLogic.performSelectAndReplace();
-		assertThat(textViewer.getTextWidget().getText(), is(lineSeparator()));
+		assertEquals(lineSeparator(), textViewer.getTextWidget().getText());
 	}
 
 	@Test
@@ -826,10 +823,10 @@ public class FindReplaceLogicTest {
 		setFindAndReplaceString(findReplaceLogic, "NOTFOUND", "");
 		findReplaceLogic.performSelectAndReplace();
 		// ensure nothing was replaced
-		assertThat(textViewer.getTextWidget().getText(), is(setupString));
+		assertEquals(setupString, textViewer.getTextWidget().getText());
 		// ensure the selection was not overridden
-		assertThat(findReplaceLogic.getTarget().getSelection().x, is(0));
-		assertThat(findReplaceLogic.getTarget().getSelection().y, is(4));
+		assertEquals(0, findReplaceLogic.getTarget().getSelection().x);
+		assertEquals(4, findReplaceLogic.getTarget().getSelection().y);
 	}
 
 	@Test
@@ -843,23 +840,23 @@ public class FindReplaceLogicTest {
 		findReplaceLogic.activate(SearchOptions.INCREMENTAL);
 
 		findReplaceLogic.setFindString("test");
-		assertThat(textViewer.getSelectedRange(), is(new Point(0, 4)));
+		assertEquals(new Point(0, 4), textViewer.getSelectedRange());
 		textViewer.setSelectedRange(5, 0);
 		findReplaceLogic.resetIncrementalBaseLocation();
 		findReplaceLogic.performSearch();
-		assertThat(textViewer.getSelectedRange(), is(new Point(5, 4)));
+		assertEquals(new Point(5, 4), textViewer.getSelectedRange());
 		textViewer.setSelectedRange(7, 0);
 		findReplaceLogic.resetIncrementalBaseLocation();
 		findReplaceLogic.performSearch();
-		assertThat(textViewer.getSelectedRange(), is(new Point(10, 4)));
+		assertEquals(new Point(10, 4), textViewer.getSelectedRange());
 		textViewer.setSelectedRange(10, 0);
 		findReplaceLogic.resetIncrementalBaseLocation();
 		findReplaceLogic.performSearch();
-		assertThat(textViewer.getSelectedRange(), is(new Point(10, 4)));
+		assertEquals(new Point(10, 4), textViewer.getSelectedRange());
 		// Verify that after clearing the search, caret goes back to last active location
 		findReplaceLogic.setFindString("");
 		findReplaceLogic.performSearch();
-		assertThat(textViewer.getSelectedRange(), is(new Point(10, 4)));
+		assertEquals(new Point(10, 4), textViewer.getSelectedRange());
 	}
 
 	@Test
@@ -874,9 +871,9 @@ public class FindReplaceLogicTest {
 
 		findReplaceLogic.resetIncrementalBaseLocation(); // Set base location
 		findReplaceLogic.setFindString("test");
-		assertThat(textViewer.getSelectedRange(), is(new Point(5, 4)));
+		assertEquals(new Point(5, 4), textViewer.getSelectedRange());
 		findReplaceLogic.setFindString(""); // Clear the find string
-		assertThat(textViewer.getSelectedRange(), is(new Point(5, 0))); // Restored to base location
+		assertEquals(new Point(5, 0), textViewer.getSelectedRange()); // Restored to base location
 	}
 
 	@Test
@@ -891,10 +888,10 @@ public class FindReplaceLogicTest {
 
 		findReplaceLogic.resetIncrementalBaseLocation();
 		findReplaceLogic.setFindString("test");
-		assertThat(textViewer.getSelectedRange(), is(new Point(5, 0)));
+		assertEquals(new Point(5, 0), textViewer.getSelectedRange());
 		findReplaceLogic.setFindString(""); // Clear the find string
 		// Will not restore selection since incremental mode is not active
-		assertThat(textViewer.getSelectedRange(), is(new Point(5, 0))); // Remains unchanged
+		assertEquals(new Point(5, 0), textViewer.getSelectedRange()); // Remains unchanged
 	}
 
 	@Test
@@ -940,23 +937,23 @@ public class FindReplaceLogicTest {
 		findReplaceLogic.activate(SearchOptions.FORWARD);
 
 		findReplaceLogic.setFindString("Test");
-		assertThat(findReplaceLogic.getTarget().getSelection(), is(new Point(0, 4)));
+		assertEquals(new Point(0, 4), findReplaceLogic.getTarget().getSelection());
 
 		findReplaceLogic.activate(SearchOptions.REGEX);
 		findReplaceLogic.deactivate(SearchOptions.INCREMENTAL);
 		findReplaceLogic.performSearch();
 		findReplaceLogic.activate(SearchOptions.INCREMENTAL);
-		assertThat(findReplaceLogic.getTarget().getSelection(), is(new Point(5, 4)));
+		assertEquals(new Point(5, 4), findReplaceLogic.getTarget().getSelection());
 		findReplaceLogic.deactivate(SearchOptions.INCREMENTAL);
 		findReplaceLogic.performSearch();
 		findReplaceLogic.activate(SearchOptions.INCREMENTAL);
-		assertThat(findReplaceLogic.getTarget().getSelection(), is(new Point(10, 4)));
+		assertEquals(new Point(10, 4), findReplaceLogic.getTarget().getSelection());
 		findReplaceLogic.deactivate(SearchOptions.REGEX);
 
 		findReplaceLogic.setFindString("Test");
-		assertThat(findReplaceLogic.getTarget().getSelection(), is(new Point(10, 4)));
+		assertEquals(new Point(10, 4), findReplaceLogic.getTarget().getSelection());
 		findReplaceLogic.performSearch();
-		assertThat(findReplaceLogic.getTarget().getSelection(), is(new Point(15, 4)));
+		assertEquals(new Point(15, 4), findReplaceLogic.getTarget().getSelection());
 	}
 
 	@Test
@@ -968,7 +965,7 @@ public class FindReplaceLogicTest {
 		findReplaceLogic.activate(SearchOptions.INCREMENTAL);
 		textViewer.setSelectedRange(0, 0);
 		findReplaceLogic.setFindString("hello");
-		assertThat(findReplaceLogic.getTarget().getSelection(), is(new Point(0, 5)));
+		assertEquals(new Point(0, 5), findReplaceLogic.getTarget().getSelection());
 	}
 
 	@Test
@@ -980,7 +977,7 @@ public class FindReplaceLogicTest {
 		findReplaceLogic.activate(SearchOptions.INCREMENTAL);
 		textViewer.setSelectedRange(5, 0);
 		findReplaceLogic.setFindString("hello");
-		assertThat(findReplaceLogic.getTarget().getSelection(), is(new Point(5, 5)));
+		assertEquals(new Point(5, 5), findReplaceLogic.getTarget().getSelection());
 	}
 
 	@Test
@@ -991,7 +988,7 @@ public class FindReplaceLogicTest {
 
 		findReplaceLogic.activate(SearchOptions.CASE_SENSITIVE);
 
-		assertThat(receivedValues, is(List.of(true)));
+		assertEquals(List.of(true), receivedValues);
 	}
 
 	@Test
@@ -1003,7 +1000,7 @@ public class FindReplaceLogicTest {
 
 		findReplaceLogic.deactivate(SearchOptions.CASE_SENSITIVE);
 
-		assertThat(receivedValues, is(List.of(false)));
+		assertEquals(List.of(false), receivedValues);
 	}
 
 	@Test
@@ -1040,8 +1037,8 @@ public class FindReplaceLogicTest {
 
 		findReplaceLogic.activate(SearchOptions.CASE_SENSITIVE);
 
-		assertThat(received1, is(List.of(true)));
-		assertThat(received2, is(List.of(true)));
+		assertEquals(List.of(true), received1);
+		assertEquals(List.of(true), received2);
 	}
 
 	@Test
@@ -1054,7 +1051,7 @@ public class FindReplaceLogicTest {
 
 		findReplaceLogic.activate(SearchOptions.REGEX);
 
-		assertThat(receivedValues, is(List.of(false)));
+		assertEquals(List.of(false), receivedValues);
 	}
 
 	@Test
@@ -1068,7 +1065,7 @@ public class FindReplaceLogicTest {
 
 		findReplaceLogic.deactivate(SearchOptions.REGEX);
 
-		assertThat(receivedValues, is(List.of(true)));
+		assertEquals(List.of(true), receivedValues);
 	}
 
 	@Test
@@ -1080,7 +1077,7 @@ public class FindReplaceLogicTest {
 
 		findReplaceLogic.setFindString("hello world");
 
-		assertThat(receivedValues, is(List.of(false)));
+		assertEquals(List.of(false), receivedValues);
 	}
 
 	@Test
@@ -1092,7 +1089,7 @@ public class FindReplaceLogicTest {
 
 		findReplaceLogic.setFindString("word");
 
-		assertThat(receivedValues, is(List.of(true)));
+		assertEquals(List.of(true), receivedValues);
 	}
 
 	@Test
@@ -1111,27 +1108,27 @@ public class FindReplaceLogicTest {
 	}
 
 	private void expectStatusEmpty(IFindReplaceLogic findReplaceLogic) {
-		assertThat(findReplaceLogic.getStatus(), instanceOf(NoStatus.class));
+		assertInstanceOf(NoStatus.class, findReplaceLogic.getStatus());
 	}
 
 	private void expectStatusIsCode(IFindReplaceLogic findReplaceLogic, FindStatus.StatusCode code) {
-		assertThat(findReplaceLogic.getStatus(), instanceOf(FindStatus.class));
-		assertThat(((FindStatus) findReplaceLogic.getStatus()).getMessageCode(), equalTo(code));
+		assertInstanceOf(FindStatus.class, findReplaceLogic.getStatus());
+		assertEquals(code, ((FindStatus) findReplaceLogic.getStatus()).getMessageCode());
 	}
 
 	private void expectStatusIsReplaceAllWithCount(IFindReplaceLogic findReplaceLogic, int count) {
-		assertThat(findReplaceLogic.getStatus(), instanceOf(ReplaceAllStatus.class));
-		assertThat(((ReplaceAllStatus) findReplaceLogic.getStatus()).getReplaceCount(), equalTo(count));
+		assertInstanceOf(ReplaceAllStatus.class, findReplaceLogic.getStatus());
+		assertEquals(count, ((ReplaceAllStatus) findReplaceLogic.getStatus()).getReplaceCount());
 	}
 
 	private void expectStatusIsFindAllWithCount(IFindReplaceLogic findReplaceLogic, int count) {
-		assertThat(findReplaceLogic.getStatus(), instanceOf(FindAllStatus.class));
-		assertThat(((FindAllStatus) findReplaceLogic.getStatus()).getSelectCount(), equalTo(count));
+		assertInstanceOf(FindAllStatus.class, findReplaceLogic.getStatus());
+		assertEquals(count, ((FindAllStatus) findReplaceLogic.getStatus()).getSelectCount());
 	}
 
 	private void expectStatusIsMessageWithString(IFindReplaceLogic findReplaceLogic, String message) {
-		assertThat(findReplaceLogic.getStatus(), instanceOf(InvalidRegExStatus.class));
-		assertThat(((InvalidRegExStatus) findReplaceLogic.getStatus()).getMessage(), equalTo(message));
+		assertInstanceOf(InvalidRegExStatus.class, findReplaceLogic.getStatus());
+		assertEquals(message, ((InvalidRegExStatus) findReplaceLogic.getStatus()).getMessage());
 	}
 
 }

--- a/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/internal/findandreplace/FindReplaceUITest.java
+++ b/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/internal/findandreplace/FindReplaceUITest.java
@@ -13,8 +13,6 @@
  ******************************************************************************/
 package org.eclipse.ui.internal.findandreplace;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.junit.jupiter.api.AfterEach;
@@ -202,7 +200,7 @@ public abstract class FindReplaceUITest<AccessType extends IFindReplaceUIAccess>
 		dialog.assertSelected(SearchOptions.WHOLE_WORD);
 
 		dialog.simulateKeyboardInteractionInFindInputField(SWT.CR, false);
-		assertThat(target.getSelectionText(), is(dialog.getFindText()));
+		assertEquals(dialog.getFindText(), target.getSelectionText());
 
 		assertEquals(0, (target.getSelection()).x);
 		assertEquals(dialog.getFindText().length(), (target.getSelection()).y);
@@ -240,16 +238,16 @@ public abstract class FindReplaceUITest<AccessType extends IFindReplaceUIAccess>
 		dialog.setFindText("ABCD");
 		dialog.setReplaceText("abcd");
 		dialog.performReplace();
-		assertThat(fTextViewer.getDocument().get(), is("abcd ABCD ABCD"));
+		assertEquals("abcd ABCD ABCD", fTextViewer.getDocument().get());
 
 		dialog.performReplaceAll();
-		assertThat(fTextViewer.getDocument().get(), is("abcd abcd abcd"));
+		assertEquals("abcd abcd abcd", fTextViewer.getDocument().get());
 
 		dialog.select(SearchOptions.REGEX);
 		dialog.setFindText("(ab|cd)");
 		dialog.setReplaceText("o");
 		dialog.performReplaceAll();
-		assertThat(fTextViewer.getDocument().get(), is("oo oo oo"));
+		assertEquals("oo oo oo", fTextViewer.getDocument().get());
 	}
 
 	@Test
@@ -266,7 +264,7 @@ public abstract class FindReplaceUITest<AccessType extends IFindReplaceUIAccess>
 		dialog.setReplaceText("");
 		dialog.performReplaceAll();
 
-		assertThat(fTextViewer.getDocument().get(), is("line" + System.lineSeparator() + System.lineSeparator()));
+		assertEquals("line" + System.lineSeparator() + System.lineSeparator(), fTextViewer.getDocument().get());
 	}
 
 	@Test
@@ -297,7 +295,7 @@ public abstract class FindReplaceUITest<AccessType extends IFindReplaceUIAccess>
 		dialog.setFindText("text");
 		dialog.performReplaceAll();
 
-		assertThat(fTextViewer.getDocument().get(), is("text" + System.lineSeparator() + System.lineSeparator()));
+		assertEquals("text" + System.lineSeparator() + System.lineSeparator(), fTextViewer.getDocument().get());
 	}
 
 	@Test
@@ -360,7 +358,7 @@ public abstract class FindReplaceUITest<AccessType extends IFindReplaceUIAccess>
 		assertEquals("text\\.\\*", dialog.getFindText());
 
 		dialog.performReplaceAll();
-		assertThat(fTextViewer.getDocument().get(), is("test ;"));
+		assertEquals("test ;", fTextViewer.getDocument().get());
 	}
 
 	@Test
@@ -372,7 +370,7 @@ public abstract class FindReplaceUITest<AccessType extends IFindReplaceUIAccess>
 		dialog.setReplaceText("aa");
 		dialog.performReplace();
 
-		assertThat(fTextViewer.getDocument().get(), is("abaaefg"));
+		assertEquals("abaaefg", fTextViewer.getDocument().get());
 	}
 
 	@Test

--- a/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/internal/findandreplace/overlay/FindReplaceOverlayTest.java
+++ b/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/internal/findandreplace/overlay/FindReplaceOverlayTest.java
@@ -14,11 +14,9 @@
 package org.eclipse.ui.internal.findandreplace.overlay;
 
 import static org.eclipse.ui.internal.findandreplace.FindReplaceTestUtil.waitForFocus;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.instanceOf;
-import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.when;
 
@@ -154,11 +152,11 @@ public class FindReplaceOverlayTest extends FindReplaceUITest<OverlayAccess> {
 		OverlayAccess dialog= getDialog();
 		IFindReplaceTarget target= getFindReplaceTarget();
 		dialog.setFindText("Line");
-		assertThat(target.getSelectionText(), is("line"));
+		assertEquals("line", target.getSelectionText());
 		assertEquals(new Point(1, 4), target.getSelection());
 
 		dialog.select(SearchOptions.CASE_SENSITIVE);
-		assertThat(target.getSelectionText(), is("Line"));
+		assertEquals("Line", target.getSelectionText());
 		assertEquals(new Point(8, 4), target.getSelection());
 
 		dialog.unselect(SearchOptions.CASE_SENSITIVE);
@@ -173,7 +171,7 @@ public class FindReplaceOverlayTest extends FindReplaceUITest<OverlayAccess> {
 		dialog.unselect(SearchOptions.WHOLE_WORD);
 		assertEquals(1, (target.getSelection()).x);
 		assertEquals(4, (target.getSelection()).y);
-		assertThat(target.getSelectionText(), is("line"));
+		assertEquals("line", target.getSelectionText());
 	}
 
 	@Test
@@ -184,10 +182,10 @@ public class FindReplaceOverlayTest extends FindReplaceUITest<OverlayAccess> {
 		OverlayAccess dialog= getDialog();
 
 		dialog.openReplaceDialog();
-		assertThat(dialog.isReplaceDialogOpen(), is(false));
+		assertFalse(dialog.isReplaceDialogOpen());
 		reopenFindReplaceUIForTextViewer();
 		dialog= getDialog();
-		assertThat(dialog.isReplaceDialogOpen(), is(false));
+		assertFalse(dialog.isReplaceDialogOpen());
 	}
 
 	@Test
@@ -196,21 +194,21 @@ public class FindReplaceOverlayTest extends FindReplaceUITest<OverlayAccess> {
 		OverlayAccess dialog= getDialog();
 
 		dialog.openReplaceDialog();
-		assertThat(dialog.isReplaceDialogOpen(), is(true));
+		assertTrue(dialog.isReplaceDialogOpen());
 		reopenFindReplaceUIForTextViewer();
 		dialog= getDialog();
-		assertThat(dialog.isReplaceDialogOpen(), is(true));
+		assertTrue(dialog.isReplaceDialogOpen());
 
 		dialog.closeReplaceDialog();
 		reopenFindReplaceUIForTextViewer();
 		dialog= getDialog();
-		assertThat(dialog.isReplaceDialogOpen(), is(false));
+		assertFalse(dialog.isReplaceDialogOpen());
 
 		dialog.openReplaceDialog();
 		getTextViewer().setEditable(false);
 		reopenFindReplaceUIForTextViewer();
 		dialog= getDialog();
-		assertThat(dialog.isReplaceDialogOpen(), is(false));
+		assertFalse(dialog.isReplaceDialogOpen());
 	}
 
 	@Test
@@ -221,13 +219,13 @@ public class FindReplaceOverlayTest extends FindReplaceUITest<OverlayAccess> {
 		OverlayAccess dialog= getDialog();
 		dialog.select(SearchOptions.REGEX);
 		dialog.setFindText("text");
-		assertThat(target.getSelection().y, is(4));
+		assertEquals(4, target.getSelection().y);
 		dialog.pressSearch(true);
-		assertThat(target.getSelection().x, is("text ".length()));
+		assertEquals("text ".length(), target.getSelection().x);
 		dialog.pressSearch(true);
-		assertThat(target.getSelection().x, is("text text ".length()));
+		assertEquals("text text ".length(), target.getSelection().x);
 		dialog.pressSearch(false);
-		assertThat(target.getSelection().x, is("text ".length()));
+		assertEquals("text ".length(), target.getSelection().x);
 	}
 
 	@Test
@@ -295,10 +293,10 @@ public class FindReplaceOverlayTest extends FindReplaceUITest<OverlayAccess> {
 		dialog.setReplaceText("replacement");
 
 		dialog.performReplace();
-		assertThat(getTextViewer().getDocument().get(), is("text text"));
+		assertEquals("text text", getTextViewer().getDocument().get());
 
 		dialog.performReplaceAll();
-		assertThat(getTextViewer().getDocument().get(), is("text text"));
+		assertEquals("text text", getTextViewer().getDocument().get());
 	}
 
 	@Test
@@ -310,7 +308,7 @@ public class FindReplaceOverlayTest extends FindReplaceUITest<OverlayAccess> {
 		dialog.pressSelectAll();
 
 		ISelection selection= getTextViewer().getSelection();
-		assertThat(selection, is(instanceOf(IMultiTextSelection.class)));
+		assertInstanceOf(IMultiTextSelection.class, selection);
 		assertEquals(3, ((IMultiTextSelection) selection).getRegions().length);
 	}
 

--- a/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/workbench/texteditor/tests/DialogAccess.java
+++ b/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/workbench/texteditor/tests/DialogAccess.java
@@ -11,10 +11,8 @@
 package org.eclipse.ui.workbench.texteditor.tests;
 
 import static org.eclipse.ui.internal.findandreplace.FindReplaceTestUtil.runEventQueue;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.hasItems;
-import static org.hamcrest.Matchers.not;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Arrays;
 import java.util.Set;
@@ -287,26 +285,22 @@ class DialogAccess implements IFindReplaceUIAccess {
 
 	@Override
 	public void assertEnabled(SearchOptions option) {
-		Set<SearchOptions> enabled= getEnabledOptions();
-		assertThat(enabled, hasItems(option));
+		assertTrue(getEnabledOptions().contains(option));
 	}
 
 	@Override
 	public void assertDisabled(SearchOptions option) {
-		Set<SearchOptions> enabled= getEnabledOptions();
-		assertThat(enabled, not(hasItems(option)));
+		assertFalse(getEnabledOptions().contains(option));
 	}
 
 	@Override
 	public void assertSelected(SearchOptions option) {
-		Set<SearchOptions> enabled= getSelectedOptions();
-		assertThat(enabled, hasItems(option));
+		assertTrue(getSelectedOptions().contains(option));
 	}
 
 	@Override
 	public void assertUnselected(SearchOptions option) {
-		Set<SearchOptions> enabled= getSelectedOptions();
-		assertThat(enabled, not(hasItems(option)));
+		assertFalse(getSelectedOptions().contains(option));
 	}
 
 	private Set<SearchOptions> getEnabledOptions() {

--- a/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/workbench/texteditor/tests/FindReplaceDialogTest.java
+++ b/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/workbench/texteditor/tests/FindReplaceDialogTest.java
@@ -15,8 +15,6 @@ package org.eclipse.ui.workbench.texteditor.tests;
 
 import static org.eclipse.ui.internal.findandreplace.FindReplaceTestUtil.runEventQueue;
 import static org.eclipse.ui.internal.findandreplace.FindReplaceTestUtil.waitForFocus;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assumptions.assumeFalse;
@@ -156,7 +154,7 @@ public class FindReplaceDialogTest extends FindReplaceUITest<DialogAccess> {
 		initializeFindReplaceUIForTextViewer();
 		DialogAccess dialog= getDialog();
 
-		assertThat(dialog.getFindText(), is("text"));
+		assertEquals("text", dialog.getFindText());
 
 		IFindReplaceTarget target= getFindReplaceTarget();
 		assertEquals(0, (target.getSelection()).x);
@@ -205,7 +203,7 @@ public class FindReplaceDialogTest extends FindReplaceUITest<DialogAccess> {
 		dialog.assertSelected(SearchOptions.WHOLE_WORD);
 
 		dialog.simulateKeyboardInteractionInFindInputField(SWT.CR, false);
-		assertThat(target.getSelectionText(), is(dialog.getFindText()));
+		assertEquals(dialog.getFindText(), target.getSelectionText());
 
 		assertEquals(0, (target.getSelection()).x);
 		assertEquals(dialog.getFindText().length(), (target.getSelection()).y);


### PR DESCRIPTION
The find/replace tests mixed Hamcrest matchers with JUnit 5 assertions, so readers had to switch between two assertion vocabularies and the test bundle carried an additional library dependency for no benefit.

Every matcher in use (`is`, `equalTo`, `instanceOf`, `not`, `hasItems`) had a direct JUnit 5 counterpart, so the assertions are now expressed with the JUnit API alone and the Hamcrest package import is removed from the bundle manifest.

The change is behavior-preserving for the tests themselves.