### PR TITLE
Count distinct files across the complete CompositeChange tree

### DIFF
--- a/bundles/org.eclipse.ltk.core.refactoring/src/org/eclipse/ltk/core/refactoring/CompositeChange.java
+++ b/bundles/org.eclipse.ltk.core.refactoring/src/org/eclipse/ltk/core/refactoring/CompositeChange.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2022 IBM Corporation and others.
+ * Copyright (c) 2000, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -16,9 +16,12 @@ package org.eclipse.ltk.core.refactoring;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Set;
 
+import org.eclipse.core.runtime.Adapters;
 import org.eclipse.core.runtime.Assert;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
@@ -26,6 +29,9 @@ import org.eclipse.core.runtime.ISafeRunnable;
 import org.eclipse.core.runtime.OperationCanceledException;
 import org.eclipse.core.runtime.SafeRunner;
 import org.eclipse.core.runtime.SubMonitor;
+
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IResource;
 
 import org.eclipse.ltk.internal.core.refactoring.RefactoringCoreMessages;
 import org.eclipse.ltk.internal.core.refactoring.RefactoringCorePlugin;
@@ -510,22 +516,51 @@ public class CompositeChange extends Change {
 	}
 
 	/**
-	 * @return Amount of changed files
+	 * Returns the number of distinct workspace files identified by this change tree.
+	 * Nested composite changes are traversed, and files affected by more than one
+	 * change are counted only once. For non-composite changes, files are obtained
+	 * from {@link Change#getAffectedObjects()}; when those objects are unknown,
+	 * {@link Change#getModifiedElement()} is used instead. Elements can be files or
+	 * adapt to {@link IFile} or {@link IResource}.
+	 * <p>
+	 * Elements that do not identify a file are not counted. This method does not
+	 * inspect workspace contents or expand folders. It counts all changes,
+	 * independently of their enablement state, without modifying the change tree.
+	 * </p>
+	 *
+	 * @return the number of distinct identified files
 	 * @since 3.13
 	 */
 	public int getFilenumber() {
-		if(fChanges.size()>0) {
-			if (fChanges.get(0) instanceof CompositeChange) {
-				CompositeChange obj= (CompositeChange) fChanges.get(0);
-				return obj.getAmount();
-			}
-			return 1;
-		}
-		return 0;
+		Set<IFile> files= new HashSet<>();
+		collectFiles(this, files);
+		return files.size();
 	}
 
-	private int getAmount() {
-		return fChanges.size();
+	private static void collectFiles(Change change, Set<IFile> files) {
+		if (change instanceof CompositeChange composite) {
+			for (Change child : composite.getChildren()) {
+				collectFiles(child, files);
+			}
+		} else {
+			Object[] affectedObjects= change.getAffectedObjects();
+			if (affectedObjects == null) {
+				addFile(change.getModifiedElement(), files);
+			} else {
+				for (Object affected : affectedObjects) {
+					addFile(affected, files);
+				}
+			}
+		}
+	}
+
+	private static void addFile(Object element, Set<IFile> files) {
+		IFile file= Adapters.adapt(element, IFile.class);
+		if (file != null) {
+			files.add(file);
+		} else if (Adapters.adapt(element, IResource.class) instanceof IFile resourceFile) {
+			files.add(resourceFile);
+		}
 	}
 
 }

--- a/tests/org.eclipse.ltk.core.refactoring.tests/src/org/eclipse/ltk/core/refactoring/tests/AllTests.java
+++ b/tests/org.eclipse.ltk.core.refactoring.tests/src/org/eclipse/ltk/core/refactoring/tests/AllTests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corporation and others.
+ * Copyright (c) 2000, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -24,6 +24,7 @@ import org.eclipse.ltk.core.refactoring.tests.scripting.RefactoringScriptingTest
 
 @Suite
 @SelectClasses({
+	CompositeChangeTest.class,
 	RefactoringContextTest.class,
 	ParticipantTests.class,
 	RefactoringHistoryTests.class,

--- a/tests/org.eclipse.ltk.core.refactoring.tests/src/org/eclipse/ltk/core/refactoring/tests/CompositeChangeTest.java
+++ b/tests/org.eclipse.ltk.core.refactoring.tests/src/org/eclipse/ltk/core/refactoring/tests/CompositeChangeTest.java
@@ -1,0 +1,198 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Carsten Hammer and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.ltk.core.refactoring.tests;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+import org.eclipse.core.runtime.IAdaptable;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.Path;
+
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IResource;
+import org.eclipse.core.resources.ResourcesPlugin;
+
+import org.eclipse.jface.text.Document;
+
+import org.eclipse.ltk.core.refactoring.Change;
+import org.eclipse.ltk.core.refactoring.CompositeChange;
+import org.eclipse.ltk.core.refactoring.NullChange;
+import org.eclipse.ltk.core.refactoring.RefactoringStatus;
+import org.eclipse.ltk.core.refactoring.TextFileChange;
+
+public class CompositeChangeTest {
+
+	@Test
+	public void testEmptyChanges() {
+		assertEquals(0, composite().getFilenumber());
+		assertEquals(0, composite(composite()).getFilenumber());
+	}
+
+	@Test
+	public void testDirectFileChanges() {
+		assertEquals(2, composite(textChange("/project/A.txt"), textChange("/project/B.txt")).getFilenumber());
+	}
+
+	@Test
+	public void testAllSiblingGroupsAreCounted() {
+		assertEquals(3, composite(
+				composite(textChange("/project/A.txt")),
+				composite(textChange("/project/B.txt"), textChange("/project/C.txt"))).getFilenumber());
+		assertEquals(3, composite(
+				composite(textChange("/project/B.txt"), textChange("/project/C.txt")),
+				composite(textChange("/project/A.txt"))).getFilenumber());
+	}
+
+	@Test
+	public void testMixedAndDeeplyNestedChanges() {
+		CompositeChange nested= composite(composite(composite(textChange("/project/B.txt"))));
+		nested.markAsSynthetic();
+		assertEquals(3, composite(textChange("/project/A.txt"), nested,
+				composite(), textChange("/project/C.txt")).getFilenumber());
+	}
+
+	@Test
+	public void testSeveralChangesToTheSameFileAreCountedOnce() {
+		assertEquals(1, composite(composite(textChange("/project/A.txt"), textChange("/project/A.txt")),
+				textChange("/project/A.txt")).getFilenumber());
+	}
+
+	@Test
+	public void testEqualNamesInDifferentProjectsAreDifferentFiles() {
+		assertEquals(2, composite(textChange("/one/A.txt"), textChange("/two/A.txt")).getFilenumber());
+	}
+
+	@Test
+	public void testOpaqueChangeCanAffectSeveralFiles() {
+		IFile first= file("/project/A.txt");
+		IFile second= file("/project/B.txt");
+		Change atomic= change(null, first, second, first);
+		TextFileChange duplicate= textChange("/project/B.txt");
+		CompositeChange root= composite(atomic, duplicate);
+		assertEquals(2, root.getFilenumber());
+		assertArrayEquals(new Change[] { atomic, duplicate }, root.getChildren());
+		assertSame(root, atomic.getParent());
+		assertTrue(atomic.isEnabled());
+	}
+
+	@Test
+	public void testUnknownAffectedObjectsDoNotHideSiblingFiles() {
+		assertEquals(2, composite(change(null, (Object[]) null), textChange("/project/A.txt"),
+				change(file("/project/B.txt"), (Object[]) null)).getFilenumber());
+	}
+
+	@Test
+	public void testResourceAdaptableElements() {
+		IFile first= file("/project/A.txt");
+		IAdaptable element= adaptable(first, IResource.class);
+		assertEquals(2, composite(change(element, (Object[]) null),
+				change(null, element, adaptable(file("/project/B.txt"), IResource.class))).getFilenumber());
+	}
+
+	@Test
+	public void testFileAdaptableElements() {
+		IAdaptable element= adaptable(file("/project/A.txt"), IFile.class);
+		assertEquals(1, composite(change(null, element), change(element, (Object[]) null)).getFilenumber());
+	}
+
+	@Test
+	public void testNonFileElementsAreNotCountedAsFiles() {
+		var project= ResourcesPlugin.getWorkspace().getRoot().getProject("project");
+		assertEquals(0, composite(new NullChange(), change(null, project, project.getFolder("folder"),
+				new Document("text"), null), change(null, (Object[]) null)).getFilenumber());
+	}
+
+	@Test
+	public void testExplicitlyEmptyAffectedObjects() {
+		assertEquals(0, composite(change(file("/project/A.txt"))).getFilenumber());
+	}
+
+	@Test
+	public void testCountDoesNotChangeSelectionOrTree() {
+		TextFileChange first= textChange("/project/A.txt");
+		TextFileChange second= textChange("/project/B.txt");
+		CompositeChange nested= composite(second);
+		nested.setEnabled(false);
+		CompositeChange root= composite(first, nested);
+		Change[] originalChildren= root.getChildren();
+		assertEquals(2, root.getFilenumber());
+		assertEquals(2, root.getFilenumber());
+		assertArrayEquals(originalChildren, root.getChildren());
+		assertSame(root, first.getParent());
+		assertSame(nested, second.getParent());
+		assertTrue(first.isEnabled());
+		assertFalse(nested.isEnabled());
+		assertFalse(second.isEnabled());
+	}
+
+	private static CompositeChange composite(Change... children) {
+		return new CompositeChange("changes", children);
+	}
+
+	private static IFile file(String path) {
+		// Handles suffice: counting must not read or change workspace contents.
+		return ResourcesPlugin.getWorkspace().getRoot().getFile(new Path(path));
+	}
+
+	private static TextFileChange textChange(String path) {
+		IFile file= file(path);
+		return new TextFileChange(file.getName(), file);
+	}
+
+	private static IAdaptable adaptable(IFile file, Class<? extends IResource> type) {
+		return new IAdaptable() {
+			@Override
+			public <T> T getAdapter(Class<T> adapter) {
+				return adapter == type ? adapter.cast(file) : null;
+			}
+		};
+	}
+
+	private static Change change(Object modified, Object... affected) {
+		return new Change() {
+			@Override
+			public String getName() {
+				return "test change";
+			}
+
+			@Override
+			public Object getModifiedElement() {
+				return modified;
+			}
+
+			@Override
+			public Object[] getAffectedObjects() {
+				return affected;
+			}
+
+			@Override
+			public void initializeValidationData(IProgressMonitor pm) {
+				throw new AssertionError("Counting must not initialize a change");
+			}
+
+			@Override
+			public RefactoringStatus isValid(IProgressMonitor pm) {
+				throw new AssertionError("Counting must not validate a change");
+			}
+
+			@Override
+			public Change perform(IProgressMonitor pm) {
+				throw new AssertionError("Counting must not perform a change");
+			}
+		};
+	}
+}


### PR DESCRIPTION
## What it does

Fixes the incorrect file count shown in the refactoring preview.

`CompositeChange.getFilenumber()` currently examines only the first child
of the change tree. Consequently, two direct `TextFileChange` objects for
different files report one file, nested groups can hide additional files,
and reordering groups can change the displayed count.

For example, a tree containing the groups `[A]` and `[B, C]` reports one
file. Reversing those groups reports two files, although both arrangements
affect the same three files.

The implementation now traverses nested composites and counts distinct
workspace files. For non-composite changes, it obtains file identities
from `getAffectedObjects()`, falling back to `getModifiedElement()` when
the affected objects are unknown. Elements adapting to `IFile` or
`IResource` are supported.

This also allows an opaque multi-file change to report its affected
files without exposing independently selectable child changes.
Selection, parent relationships and the change-tree structure are
preserved. Apply and Undo code is unchanged.

The count remains independent of selection, as before. Non-file objects
are ignored, folders are not expanded, and an explicitly empty
affected-object array is respected.

Feedback is requested on the treatment of changes with incomplete
resource metadata: this implementation counts only identifiable files
rather than inferring a file count from the number of change nodes.

## How to test

From the repository root, build the modified LTK-core bundle together
with its test bundle:

```sh
mvn -B -ntp clean verify \
  -pl :org.eclipse.ltk.core.refactoring,:org.eclipse.ltk.core.refactoring.tests \
  -Dtycho.surefire.useUIHarness=false \
  -Dtycho.surefire.useUIThread=false
```

To run only the new regression class, append:

```sh
-Dtest=org.eclipse.ltk.core.refactoring.tests.CompositeChangeTest
```

The 13 new JUnit Jupiter tests are registered in `AllTests`. They cover
direct and nested changes, sibling ordering, duplicate files, identical
filenames in different projects, opaque multi-file changes, resource
adaptation, unknown and empty metadata, and preservation of selection
and tree structure.

The tests use real Eclipse workspace file handles and `TextFileChange`
objects; counting does not require creating or modifying file contents.

[Verification run for commit `4def1218`](https://github.com/carstenartur/eclipse.platform.ui/actions/runs/34705105127)
used Java 21 on Linux:

- With the original implementation, the 13 new tests produced 11 expected
  assertion failures, with no test errors or skipped tests.
- With the corrected implementation, all 120 tests in the LTK-core
  `AllTests` suite passed, including all 13 new tests, with no failures,
  errors or skipped tests.

This verifies the LTK-core build and tests. The complete Platform UI
build and a live preview-wizard test are outside this verification.

## AI assistance

OpenAI ChatGPT assisted with investigating the defect, implementing the
change, developing the regression tests and drafting this description.

GitHub Copilot provided an additional
[automated code review in the fork](https://github.com/carstenartur/eclipse.platform.ui/pull/10#pullrequestreview-5187147906).
That review covered all three changed files and reported no blocking
findings. It is separate from the upstream maintainers' review.

## Author checklist

- [ ] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)